### PR TITLE
11 - Resolved Null Crash and Improved Hint Behavior in TextInputLayout

### DIFF
--- a/maui/src/TextInputLayout/SfTextInputLayout.Methods.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.Methods.cs
@@ -160,6 +160,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
                 {
                     if (!IsHintAlwaysFloated)
                     {
+                        IsHintFloated = false;
                         IsHintDownToUp = true;
                         InvalidateDrawable();
                     }
@@ -173,7 +174,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 
                 // Clear icon can't draw when isClearIconVisible property updated based on text.
                 // So here call the InvalidateDrawable to draw the clear icon.
-                if (Text.Length == 1 || Text.Length == 0)
+                if (Text != null && (Text.Length == 1 || Text.Length == 0))
                 {
                     InvalidateDrawable();
                 }

--- a/maui/src/TextInputLayout/SfTextInputLayout.Methods.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.Methods.cs
@@ -174,7 +174,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 
                 // Clear icon can't draw when isClearIconVisible property updated based on text.
                 // So here call the InvalidateDrawable to draw the clear icon.
-                if (Text != null && (Text.Length == 1 || Text.Length == 0))
+                if (Text != null && Text.Length <= 1)
                 {
                     InvalidateDrawable();
                 }


### PR DESCRIPTION
### Root Cause of the Issue

The issue occurs due to a lack of null checks in the InputView's TextChanged event.

### Description of Change

- Added null checks for the Text property to prevent crashes when the text is set to null.
- Ensure that when the text is set to null or empty, the hint state is updated correctly by setting IsHintFloated to false. 

### Issues Fixed

Fixes #[11](https://github.com/syncfusion/maui-toolkit/issues/11)



### Ouput

#### Before:


https://github.com/user-attachments/assets/7d2c816d-9174-401a-ac8f-5c2b78a4d099




#### After:


https://github.com/user-attachments/assets/21aa81fe-6741-44bb-8fe1-e236f7696e91



