### PR TITLE
Resolved Null Crash and Improved Hint Behavior in SfTextInputLayout

### DIFF
--- a/maui/src/TextInputLayout/SfTextInputLayout.Methods.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.Methods.cs
@@ -160,6 +160,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
                 {
                     if (!IsHintAlwaysFloated)
                     {
+                        IsHintFloated = false;
                         IsHintDownToUp = true;
                         InvalidateDrawable();
                     }
@@ -173,7 +174,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 
                 // Clear icon can't draw when isClearIconVisible property updated based on text.
                 // So here call the InvalidateDrawable to draw the clear icon.
-                if (Text.Length == 1 || Text.Length == 0)
+                if (Text?.Length <= 1)
                 {
                     InvalidateDrawable();
                 }


### PR DESCRIPTION
### Root Cause of the Issue

The issue occurs due to a lack of null checks in the InputView's TextChanged event.

### Description of Change

- Added null checks for the Text property using the null conditional operator to prevent crashes when the text is set to null.
- Ensure that when the text is set to null or empty, the hint state is updated correctly by setting IsHintFloated to false. 
- 
### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #11 
<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

### Screenshots

#### Before:

https://github.com/user-attachments/assets/f8b905e2-3253-45ff-b6b4-7615b9a9ef8f

#### After:

https://github.com/user-attachments/assets/ea1a92ef-54cf-49e5-b63d-836e5dd1e3eb

