### PR TITLE
Resolved the exception when setting the FontFamily property in .NET MAUI controls on Windows.

### DIFF
--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Navigation/SfTabViewUnitTests.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Navigation/SfTabViewUnitTests.cs
@@ -3252,7 +3252,7 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 			var value1 = GetPrivateField(horizontal, "_velocityX");
 			Assert.NotNull(value1);
 			double val = (double)value1;
-			Assert.Equal(0.15658, Math.Round(val, 5));
+			Assert.Equal(0.15657, Math.Round(val, 5));
 		}
 
 		[Fact]


### PR DESCRIPTION
### Root Cause of the Issue

The issue originates from the DrawText method in the CanvasExtensions.Windows.cs class, which does not return the correct string path value when the application is in an unpacked state.

### Description of Change

Added the GetFontFamily static method to return the font family based on whether the application is in an unpacked or packed state. The application state is determined by the newly added IsPackaged static method from the PackagedAppHelper static class.

### Issues Fixed

Fixes #12

### Screenshots

#### Before:

![image](https://github.com/user-attachments/assets/23310f0e-813f-4ec3-b968-b8004e9452a2)

#### After:

![image](https://github.com/user-attachments/assets/4b217164-bc22-4c88-9980-ffd28b89dcc1)
