### PR TITLE
Resolved the Content Resize Issue in MAUI TabView When Output Window is Resized.

### DIFF
--- a/maui/src/TabView/Control/HorizontalContent/SfHorizontalContent.cs
+++ b/maui/src/TabView/Control/HorizontalContent/SfHorizontalContent.cs
@@ -35,6 +35,7 @@ namespace Syncfusion.Maui.Toolkit.TabView
 		bool _isPreviousItemVisible;
 		bool _isNextItemVisible;
 		SelectionChangingEventArgs? _selectionChangingEventArgs;
+		bool _isSelectionProcessed;
 #if WINDOWS
 		bool _isItemRemoved;
 #endif
@@ -246,16 +247,14 @@ namespace Syncfusion.Maui.Toolkit.TabView
 		/// <returns>It returns the size</returns>
 		protected override Size MeasureContent(double widthConstraint, double heightConstraint)
 		{
-			if (widthConstraint > 0 && widthConstraint != double.PositiveInfinity && MinimumWidthRequest != widthConstraint)
+			if (widthConstraint > 0 && widthConstraint != double.PositiveInfinity)
 			{
-				MinimumWidthRequest = widthConstraint;
 				ContentWidth = widthConstraint;
 				UpdateTabItemContentSize();
 				UpdateTabItemContentPosition();
 			}
-			if (heightConstraint > 0 && heightConstraint != double.PositiveInfinity && MinimumHeightRequest != heightConstraint)
+			if (heightConstraint > 0 && heightConstraint != double.PositiveInfinity)
 			{
-				MinimumHeightRequest = heightConstraint;
 				UpdateTabItemContentSize();
 				UpdateTabItemContentPosition();
 			}
@@ -373,6 +372,7 @@ namespace Syncfusion.Maui.Toolkit.TabView
 
 		void UpdateSelectedIndex()
 		{
+			_isSelectionProcessed = true;
 			UpdateTabItemContentPosition();
 		}
 
@@ -576,12 +576,30 @@ namespace Syncfusion.Maui.Toolkit.TabView
 				{
 					xPosition = ContentWidth * SelectedIndex;
 #if WINDOWS
-					_horizontalStackLayout?.TranslateTo(-xPosition, 0, (uint)ContentTransitionDuration, Easing.Linear);
-#else
-					if (((this as IVisualElementController).EffectiveFlowDirection & EffectiveFlowDirection.RightToLeft) != EffectiveFlowDirection.RightToLeft)
+					if (_isSelectionProcessed)
+					{
 						_horizontalStackLayout?.TranslateTo(-xPosition, 0, (uint)ContentTransitionDuration, Easing.Linear);
+						_isSelectionProcessed = false;
+					}
 					else
-						_horizontalStackLayout?.TranslateTo(xPosition, 0, (uint)ContentTransitionDuration, Easing.Linear);
+					{
+						if (_horizontalStackLayout is not null)
+						{
+							_horizontalStackLayout.TranslationX = -xPosition;
+						}
+					}
+#else
+					double targetX = ((this as IVisualElementController).EffectiveFlowDirection & EffectiveFlowDirection.RightToLeft) is not EffectiveFlowDirection.RightToLeft ? -xPosition : xPosition;
+					if (_isSelectionProcessed)
+					{
+						_horizontalStackLayout?.TranslateTo(targetX, 0, (uint)ContentTransitionDuration, Easing.Linear);
+						_isSelectionProcessed = false;
+					}
+					else
+					{
+						if (_horizontalStackLayout is not null)
+							_horizontalStackLayout.TranslationX = targetX;
+					}
 #endif
 				}
 			}
@@ -601,13 +619,31 @@ namespace Syncfusion.Maui.Toolkit.TabView
 				}
 				else
 				{
-					_horizontalStackLayout?.TranslateTo(-xPosition, 0, (uint)ContentTransitionDuration, Easing.Linear);
+					if (_isSelectionProcessed)
+					{
+						_horizontalStackLayout?.TranslateTo(-xPosition, 0, (uint)ContentTransitionDuration, Easing.Linear);
+						_isSelectionProcessed = false;
+					}
+					else
+					{
+						if (_horizontalStackLayout is not null)
+						{
+							_horizontalStackLayout.TranslationX = -xPosition;
+						}
+					}				
 				}
 #else
-				if (((this as IVisualElementController).EffectiveFlowDirection & EffectiveFlowDirection.RightToLeft) != EffectiveFlowDirection.RightToLeft)
-					_horizontalStackLayout?.TranslateTo(-xPosition, 0, (uint)ContentTransitionDuration, Easing.Linear);
+				double targetX = ((this as IVisualElementController).EffectiveFlowDirection & EffectiveFlowDirection.RightToLeft) is not EffectiveFlowDirection.RightToLeft ? -xPosition : xPosition;
+				if (_isSelectionProcessed)
+				{
+					_horizontalStackLayout?.TranslateTo(targetX, 0, (uint)ContentTransitionDuration, Easing.Linear);
+					_isSelectionProcessed = false;
+				}
 				else
-					_horizontalStackLayout?.TranslateTo(xPosition, 0, (uint)ContentTransitionDuration, Easing.Linear);
+				{
+					if (_horizontalStackLayout is not null)
+						_horizontalStackLayout.TranslationX = targetX;
+				}
 #endif
 			}
 

--- a/maui/src/TabView/Control/SfTabBar.cs
+++ b/maui/src/TabView/Control/SfTabBar.cs
@@ -39,6 +39,7 @@ namespace Syncfusion.Maui.Toolkit.TabView
         readonly double _arrowButtonSize = 32;
 		double _removedItemWidth = 0;
 		bool _itemRemoved = false;
+        bool _isSelectionProcessed;
 
         // State-tracking fields
 
@@ -719,6 +720,7 @@ namespace Syncfusion.Maui.Toolkit.TabView
         {
             if (newIndex != -1)
             {
+                _isSelectionProcessed = true;
                 UpdateSelectedTabItemIsSelected(newIndex, oldIndex);
                 UpdateTabIndicatorWidth();
                 if (_tabSelectionChangedEventArgs != null)
@@ -2308,6 +2310,7 @@ namespace Syncfusion.Maui.Toolkit.TabView
 
                         _previousIndicatorWidth = _currentIndicatorWidth;
                     });
+                    _isSelectionProcessed = false;
                 }
                 else
                 {
@@ -2326,7 +2329,18 @@ namespace Syncfusion.Maui.Toolkit.TabView
 						}
 						else
 						{
-							_tabSelectionIndicator.TranslateTo(targetX, 0, animationDuration, Easing.Linear);
+							if (_isSelectionProcessed)
+							{
+								_tabSelectionIndicator.TranslateTo(targetX, 0, animationDuration, Easing.Linear);
+								_isSelectionProcessed = false;
+							}
+							else
+							{
+								if (_tabSelectionIndicator is not null)
+								{
+									_tabSelectionIndicator.TranslationX = targetX;
+								}
+							}
 						}
 						UpdateFillSelectedTabItem();
                         UpdateScrollViewPosition(SelectedIndex);


### PR DESCRIPTION
### Root Cause of the Issue

This issue occurred because the content's width and height were not updated when resizing the output window.

### Description of Change

Removed the dynamic width and height changes when the measure content method was triggered. To address the continuous repositioning issue, we’ve optimized the handling of translation during window resizing:

Improved Animation Control: When the selection is being processed, we now update the TranslationX property directly without triggering unnecessary animations, ensuring smoother performance.

This update ensures that the TabView behaves more efficiently during resizing, improving performance and stability, particularly when the final tab is selected.

### Issues Fixed

Fixes https://github.com/syncfusion/maui-toolkit/issues/34

### Screenshots

#### Before:

https://github.com/user-attachments/assets/eeb643b8-1226-40f9-a19c-f1b59300ebc1


#### After:

https://github.com/user-attachments/assets/25eea7d3-b52a-4920-b2ff-7896aa532084

