### PR TITLE
Provide the EnableVirtualization property to the TabView control.

### DIFF
--- a/maui/src/TabView/Control/SfTabBar.cs
+++ b/maui/src/TabView/Control/SfTabBar.cs
@@ -720,7 +720,11 @@ namespace Syncfusion.Maui.Toolkit.TabView
         {
             if (newIndex != -1)
             {
-                _isSelectionProcessed = true;
+				if (IsLoaded)
+				{
+					_isSelectionProcessed = true;
+				}
+
                 UpdateSelectedTabItemIsSelected(newIndex, oldIndex);
                 UpdateTabIndicatorWidth();
                 if (_tabSelectionChangedEventArgs != null)

--- a/maui/src/TabView/Control/SfTabView.cs
+++ b/maui/src/TabView/Control/SfTabView.cs
@@ -306,6 +306,17 @@ namespace Syncfusion.Maui.Toolkit.TabView
                 BindingMode.Default,
                 null);
 
+		/// <summary>
+		/// Identifies the <see cref="EnableVirtualization"/> bindable property.
+		/// </summary>
+		public static readonly BindableProperty EnableVirtualizationProperty =
+			BindableProperty.Create(
+				nameof(EnableVirtualization),
+				typeof(bool),
+				typeof(SfTabView),
+				false,
+				propertyChanged: OnEnableVirtualizationChanged);
+
         static readonly BindableProperty IsContentTransitionEnabledProperty =
             BindableProperty.Create(
                 nameof(IsContentTransitionEnabled),
@@ -1257,6 +1268,32 @@ namespace Syncfusion.Maui.Toolkit.TabView
             set => SetValue(ContentTransitionDurationProperty, value);
         }
 
+		/// <summary>
+		/// Gets or sets a value indicating whether lazy loading is enabled during the initial load.
+		/// </summary>
+		/// <value>
+		/// A boolean value indicating whether lazy loading is enabled. The default value is false.
+		/// </value>
+		/// <example>
+		/// Here is an example of how to set the <see cref="EnableVirtualization"/> property.
+		/// 
+		/// # [XAML](#tab/tabid-1)
+		/// <code><![CDATA[
+		/// <tabView:SfTabView EnableVirtualization="True" />
+		/// ]]></code>
+		/// 
+		/// # [C#](#tab/tabid-2)
+		/// <code><![CDATA[
+		/// SfTabView tabView = new SfTabView();
+		/// tabView.EnableVirtualization = true;
+		/// ]]></code>
+		/// </example>
+		public bool EnableVirtualization
+		{
+			get => (bool)GetValue(EnableVirtualizationProperty);
+			set => SetValue(EnableVirtualizationProperty, value);
+		}
+
         ///  <summary>
         /// Gets or sets a value that can be used to customize the scroll button’s background color in the <see cref="SfTabView"/>.
         /// </summary>
@@ -1556,6 +1593,11 @@ namespace Syncfusion.Maui.Toolkit.TabView
         /// Handles changes to the <see cref="FontAutoScalingEnabled"/> property.
         /// </summary>
         static void OnFontAutoScalingEnabledChanged(BindableObject bindable, object oldValue, object newValue) => (bindable as SfTabView)?.UpdateFontAutoScalingEnabled((Boolean)newValue);
+
+		/// <summary>
+		/// Handles changes to the <see cref="EnableVirtualization"/> property.
+		/// </summary>
+		static void OnEnableVirtualizationChanged(BindableObject bindable, object oldValue, object newValue) => (bindable as SfTabView)?.UpdateEnableVirtualization();
 
         #endregion
 
@@ -1954,6 +1996,15 @@ namespace Syncfusion.Maui.Toolkit.TabView
                 _tabHeaderContainer.FontAutoScalingEnabled = newValue;
             }
         }
+
+		/// <summary>
+		/// Updates the enable virtualization.
+		/// </summary>
+		void UpdateEnableVirtualization()
+		{
+			if (_tabContentContainer != null)
+				_tabContentContainer.EnableVirtualization = EnableVirtualization;
+		}
 
         /// <summary>
         /// Gets the theme dictionary for the tab view.


### PR DESCRIPTION
### Root Cause of the Issue

The TabView control takes more time to load initially because all tab items are loaded upfront. Customers require a feature to support the lazy loading of tab items and enhance performance.

### Description of Change

Introduced a new public property, EnableVirtualization, in the TabView control. When enabled, only the selected tab item is loaded during the initial rendering. Placeholder views (BoxView) are used for non-selected tab items, reducing the initial load time. After the initial load, the content of a tab item will load when you either navigate to the next tab by selecting it from the TabBar or swipe to the next item.

### Issues Fixed

- Addressed the performance issue with the TabView control's initial loading.
- Improved load times by introducing lazy loading through the EnableVirtualization feature.
- Ensured that only the selected tab item was rendered initially, while non-selected tab items used lightweight placeholder views.
