### PR TITLE
Carousel linear mode dynamic image changes committed

### DIFF
--- a/maui/src/Carousel/Platform/Android/PlatformCarousel.Android.cs
+++ b/maui/src/Carousel/Platform/Android/PlatformCarousel.Android.cs
@@ -12,6 +12,7 @@ using View = Android.Views.View;
 using IList = System.Collections.IList;
 using Syncfusion.Maui.Toolkit.Carousel.Platform;
 using Rect = Android.Graphics.Rect;
+using Microsoft.Maui.Platform;
 
 namespace Syncfusion.Maui.Toolkit.Carousel
 {
@@ -631,6 +632,11 @@ namespace Syncfusion.Maui.Toolkit.Carousel
             {
                 Refresh();
             }
+
+            if (viewMode == ViewMode.Linear && linearLayout is not null && virtualView is not null)
+			{
+				linearLayout.InvalidateMeasure(virtualView);
+			}
         }
 
         /// <summary>
@@ -662,6 +668,11 @@ namespace Syncfusion.Maui.Toolkit.Carousel
             {
                 Refresh();
             }
+
+            if (viewMode == ViewMode.Linear && linearLayout is not null && virtualView is not null)
+			{
+				linearLayout.InvalidateMeasure(virtualView);
+			}
         }
 
         /// <summary>


### PR DESCRIPTION
### Root Cause of the Issue

- The issue occurs because the ItemHeight and ItemWidth properties are not recalculated after the carousel is created, particularly during the SizeChanged event, causing images not to display on Android

### Description of Change

- Adjusted the SfCarousel to reallocate and recalculate its layout whenever ItemHeight or ItemWidth is updated for linear mode.
- Ensured proper virtual view measurements for the carousel.

### Issues Fixed

Fixes #36 

### Screenshots

#### Before:

![image](https://github.com/user-attachments/assets/a003ff4f-d02f-46fe-b6ed-ac8a8f8e836d)


#### After:

![image](https://github.com/user-attachments/assets/bf973897-8f40-46ff-b697-11f21c438978)
