### PR TITLE
Remove the unwanted namespace

### DIFF
--- a/maui/src/BottomSheet/SfBottomSheet.cs
+++ b/maui/src/BottomSheet/SfBottomSheet.cs
@@ -2,7 +2,6 @@
 using Syncfusion.Maui.Toolkit.Internals;
 using Syncfusion.Maui.Toolkit.Themes;
 using Syncfusion.Maui.Toolkit.Helper;
-using Syncfusion.Maui.ToolKit.BottomSheet;
 
 namespace Syncfusion.Maui.Toolkit.BottomSheet
 {

--- a/maui/src/Themes/SfBottomSheetStyle.xaml
+++ b/maui/src/Themes/SfBottomSheetStyle.xaml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Syncfusion.Maui.ToolKit.BottomSheet.SfBottomSheetStyle"
+             x:Class="Syncfusion.Maui.Toolkit.BottomSheet.SfBottomSheetStyle"
              xmlns:bottomsheet="clr-namespace:Syncfusion.Maui.Toolkit.BottomSheet">
 
     <Style TargetType="bottomsheet:SfBottomSheet">

--- a/maui/src/Themes/SfBottomSheetStyle.xaml.cs
+++ b/maui/src/Themes/SfBottomSheetStyle.xaml.cs
@@ -1,6 +1,6 @@
 using Microsoft.Maui.Controls;
 
-namespace Syncfusion.Maui.ToolKit.BottomSheet;
+namespace Syncfusion.Maui.Toolkit.BottomSheet;
 
 /// <summary>
 /// SfBottomSheetStyle provides a set of predefined styles for SfBottomSheet control.


### PR DESCRIPTION
### Root Cause of the Issue

An unwanted namespace was exposed in the MAUI Toolkit, leading to potential conflicts.

### Description of Change

Removed the unwanted namespace from the MAUI Toolkit. Ensured that the affected functionality (e.g., BottomSheet control) is not impacted by this change.

### Issues Fixed

 This change resolves the namespace conflict for the BottomSheet control.

### Screenshots

#### Before:

- Not applicable

#### After:

- Not applicable