### PR TITLE
Resolved Entry ReturnType = "NEXT" Not Working with SfTextInputLayout Issue

### DIFF
--- a/maui/src/TextInputLayout/SfTextInputLayout.Methods.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.Methods.cs
@@ -489,6 +489,27 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 			}
 		}
 
+#if ANDROID
+
+		private void ApplyNativeProperties(Entry entry)
+		{
+			if (entry.Handler?.PlatformView is AndroidX.AppCompat.Widget.AppCompatEditText androidEntry)
+			{
+				androidEntry.ImeOptions = entry.ReturnType switch
+				{
+					ReturnType.Default => Android.Views.InputMethods.ImeAction.Unspecified,
+					ReturnType.Next => Android.Views.InputMethods.ImeAction.Next,
+					ReturnType.Done => Android.Views.InputMethods.ImeAction.Done,
+					ReturnType.Go => Android.Views.InputMethods.ImeAction.Go,
+					ReturnType.Search => Android.Views.InputMethods.ImeAction.Search,
+					ReturnType.Send => Android.Views.InputMethods.ImeAction.Send,
+					_ => Android.Views.InputMethods.ImeAction.Unspecified
+				};
+			}
+		}
+
+#endif
+
 		void SetupAndroidView(object? sender)
 		{
 #if ANDROID
@@ -496,6 +517,10 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 			{
 				androidView.SetBackgroundColor(Android.Graphics.Color.Transparent);
 				androidView.SetPadding(0, 0, 0, 0);
+			}
+			if (sender is Entry entry)
+			{
+				ApplyNativeProperties(entry);
 			}
 #endif
 		}

--- a/maui/src/TextInputLayout/SfTextInputLayout.Methods.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.Methods.cs
@@ -520,6 +520,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 			}
 			if (sender is Entry entry)
 			{
+				//Explicitly reset ReturnType to handle native restrictions.
 				ApplyNativeProperties(entry);
 			}
 #endif

--- a/maui/src/TextInputLayout/SfTextInputLayout.Properties.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.Properties.cs
@@ -2144,13 +2144,13 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 			{
 				if (inputLayout.Content is InputView || inputLayout.Content is Picker)
 				{
-					inputLayout.Content.Opacity = value ? 1 : 0;
+					inputLayout.Content.Opacity = value ? 1 : (DeviceInfo.Platform == DevicePlatform.iOS ? 0.00001 : 0);
 				}
 				else if (inputLayout != null && inputLayout.Content is SfView numericEntry && numericEntry.Children.Count > 0)
 				{
 					if (numericEntry.Children[0] is Entry numericInputView)
 					{
-						numericInputView.Opacity = value ? 1 : 0;
+						numericInputView.Opacity = value ? 1 : (DeviceInfo.Platform == DevicePlatform.iOS ? 0.00001 : 0);
 					}
 				}
 			}

--- a/maui/src/TextInputLayout/SfTextInputLayout.Properties.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.Properties.cs
@@ -2142,6 +2142,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 		{
 			if (bindable is SfTextInputLayout inputLayout && newValue is bool value)
 			{
+				//Adjusted Opacity from 0 to 0.00001 to ensure the content remains functionally active while enabling the ReturnType property.
 				if (inputLayout.Content is InputView || inputLayout.Content is Picker)
 				{
 					inputLayout.Content.Opacity = value ? 1 : (DeviceInfo.Platform == DevicePlatform.iOS ? 0.00001 : 0);

--- a/maui/src/TextInputLayout/SfTextInputLayout.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.cs
@@ -665,6 +665,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
             }
 
             //For placeholder overlap issue here handled the opacity value for controls.
+            //Adjusted Opacity from 0 to 0.00001 to ensure the content remains functionally active while enabling the ReturnType property.
             if (newValue is InputView entryEditorContent)
             {
 				entryEditorContent.Opacity = IsHintFloated ? 1 : (DeviceInfo.Platform == DevicePlatform.iOS ? 0.00001 : 0);

--- a/maui/src/TextInputLayout/SfTextInputLayout.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.cs
@@ -667,20 +667,20 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
             //For placeholder overlap issue here handled the opacity value for controls.
             if (newValue is InputView entryEditorContent)
             {
-                entryEditorContent.Opacity = IsHintFloated ? 1 : 0;
+				entryEditorContent.Opacity = IsHintFloated ? 1 : (DeviceInfo.Platform == DevicePlatform.iOS ? 0.00001 : 0);
             }
             else if (newValue is SfView numericEntryContent && numericEntryContent.Children.Count > 0)
             {
                 if (numericEntryContent.Children[0] is Entry numericInputView)
                 {
-                    numericInputView.Opacity = IsHintFloated ? 1 : 0;
+					numericInputView.Opacity = IsHintFloated ? 1 : (DeviceInfo.Platform == DevicePlatform.iOS ? 0.00001 : 0);
                 }
             }
             else if (newValue is Picker picker)
             {
                 if (DeviceInfo.Platform != DevicePlatform.WinUI)
                 {
-                    picker.Opacity = IsHintFloated ? 1 : 0;
+					picker.Opacity = IsHintFloated ? 1 : (DeviceInfo.Platform == DevicePlatform.iOS ? 0.00001 : 0);
                 }
             }
 


### PR DESCRIPTION
### Root Cause of the Issue

**iOS:** The ReturnType = "NEXT" of Entry not working, because the Opacity of the Entry was set to 0.
**Android:** The ReturnType property was not being set at all, possibly due to a native restriction.

### Description of Change

**iOS:** Adjusted the Opacity value from 0 to a minimal value (0.00001), ensuring the ReturnType property works as expected.
**Android:** Added a condition to explicitly reset the native property value (ReturnType) to handle native restrictions.

### Issues Fixed

Fixes [#51](https://github.com/syncfusion/maui-toolkit/issues/51)

### Screenshots

#### Before:


https://github.com/user-attachments/assets/9b2aef95-9ecb-4b31-a213-a21cd96389d1



#### After:

iOS


https://github.com/user-attachments/assets/b0a6263e-3ec6-4dfa-a849-786cd2f68bbf


Android


https://github.com/user-attachments/assets/17016eb8-8ae4-4720-bb2e-e06cdbd47fa8


