### PR TITLE
Enhancements and Bug Fixes: Long Press, AutoReverse, Toolbar Item, and Accessibility Improvements

### DIFF
--- a/maui/src/NumericEntry/Event/ValueChangedEventArgs.cs
+++ b/maui/src/NumericEntry/Event/ValueChangedEventArgs.cs
@@ -3,7 +3,7 @@
 	/// <summary>
 	/// Provides event data for the <see cref="SfNumericEntry.ValueChanged"/> event.
 	/// </summary>
-	public class NumericEntryValueChangedEventArgs
+	public class NumericEntryValueChangedEventArgs : EventArgs
 	{
 		/// <summary>
 		/// Initializes a new instance of the <see cref="NumericEntryValueChangedEventArgs"/> class.

--- a/maui/src/NumericEntry/SfNumericEntry.Methods.cs
+++ b/maui/src/NumericEntry/SfNumericEntry.Methods.cs
@@ -344,6 +344,13 @@ namespace Syncfusion.Maui.Toolkit.NumericEntry
 				_textBox.SetBinding(SfEntryView.IsVisibleProperty, "IsVisible");
 				_textBox.SetBinding(SfEntryView.CursorPositionProperty, "CursorPosition", BindingMode.TwoWay);
 				_textBox.SetBinding(SfEntryView.SelectionLengthProperty, "SelectionLength", BindingMode.TwoWay);
+
+#if WINDOWS
+				if(_textBox.Text != null)
+				{
+					_textBox.CursorPosition = _textBox.Text.Length;
+				}
+#endif
 			}
 		}
 
@@ -2360,6 +2367,13 @@ namespace Syncfusion.Maui.Toolkit.NumericEntry
 			}
 
 			_textBox.Text = displayText;
+			if (ValueChangeMode == ValueChangeMode.OnKeyFocus && _textBox.Text != null && _textBox.Text != displayText)
+			{
+				if (Parse(_textBox.Text) == Maximum)
+				{
+					caretPosition = _textBox.Text.Length;
+				}
+			}
 			if (_textBox.Text != null)
 			{
 				_textBox.CursorPosition = caretPosition >= 0 ? (caretPosition <= _textBox.Text.Length) ? caretPosition : _textBox.Text.Length : 0;
@@ -2541,7 +2555,11 @@ namespace Syncfusion.Maui.Toolkit.NumericEntry
 					}
 				}
 
+#if WINDOWS
+				if ((resetCursor || _isFirst) && _textBox.Text != null)
+#else
 				if (resetCursor && _textBox.Text != null)
+#endif
 				{
 					_textBox.CursorPosition = _textBox.Text.Length;
 				}

--- a/maui/src/NumericEntry/SfNumericEntry.Methods.cs
+++ b/maui/src/NumericEntry/SfNumericEntry.Methods.cs
@@ -707,12 +707,12 @@ namespace Syncfusion.Maui.Toolkit.NumericEntry
             string decimalSeparator = GetNumberDecimalSeparator(GetNumberFormat());
             if (entry != null && (entry.Text == "-" || entry.Text == decimalSeparator))
             {
-                if (!IsSamsungDevice() && _textBox != null)
+                if (!_isSamsungWithSamsungKeyboard && _textBox != null)
                 {
                     _textBox.Text = AllowNull ? string.Empty : "0";
                 }
             }
-            if (IsSamsungDevice() && _textBox != null && _textBox.Text.Length > 1)
+            if (_isSamsungWithSamsungKeyboard && _textBox != null && _textBox.Text.Length > 1)
             {
                 if (_textBox.Text[0] == decimalSeparator[0] && _textBox.Text.LastIndexOf(decimalSeparator) == 0)
                 {
@@ -732,13 +732,21 @@ namespace Syncfusion.Maui.Toolkit.NumericEntry
         }
 
 		/// <summary>
-		/// Validate the device is Samsung.
+		/// Validate the device is Samsung and which keyboard is used.
 		/// </summary>
-		/// <returns>It returns <c>True</c> if the device is Samsung</returns>
-        bool IsSamsungDevice()
-        {
-            return string.Equals(global::Android.OS.Build.Manufacturer, "samsung", StringComparison.OrdinalIgnoreCase);
-        }
+		void CheckDeviceAndKeyboard()
+		{
+			if (string.Equals(global::Android.OS.Build.Manufacturer, "samsung", StringComparison.OrdinalIgnoreCase))
+			{
+				var context = Android.App.Application.Context;
+				string currentKeyboard = KeyboardChecker.GetCurrentKeyboard(context);
+				_isSamsungWithSamsungKeyboard = currentKeyboard == "Samsung Keyboard";
+			}
+			else
+			{
+				_isSamsungWithSamsungKeyboard = false;
+			}
+		}
 
 #endif
 
@@ -1597,6 +1605,9 @@ namespace Syncfusion.Maui.Toolkit.NumericEntry
 			{
 				SetFlowDirection();
 			}
+
+#elif ANDROID
+			CheckDeviceAndKeyboard();
 #endif
 
 		}
@@ -1879,7 +1890,7 @@ namespace Syncfusion.Maui.Toolkit.NumericEntry
 
 		#if ANDROID
 			// Prefix zero if needed, except on Samsung devices
-			if (!IsSamsungDevice())
+			if (!_isSamsungWithSamsungKeyboard)
 			{
 				PrefixZeroIfNeeded(ref displayText, IsNegative(displayText, GetNumberFormat()), GetNumberFormat());
 			}
@@ -1992,7 +2003,7 @@ namespace Syncfusion.Maui.Toolkit.NumericEntry
 				return;
 			}
 #if ANDROID
-            if (!IsSamsungDevice())
+            if (!_isSamsungWithSamsungKeyboard)
             {
                 _cursorPosition = decimalIndex + 1;
             }
@@ -2081,7 +2092,7 @@ namespace Syncfusion.Maui.Toolkit.NumericEntry
 #endif
 				}
 #if ANDROID
-                else if (displayText.StartsWith('.') && IsSamsungDevice())
+                else if (displayText.StartsWith('.') && _isSamsungWithSamsungKeyboard)
                 {
                     string decimalSeparator = GetNumberDecimalSeparator(GetNumberFormat());
                     displayText = string.Concat("", displayText.AsSpan(1));

--- a/maui/src/NumericEntry/SfNumericEntry.Methods.cs
+++ b/maui/src/NumericEntry/SfNumericEntry.Methods.cs
@@ -2393,6 +2393,9 @@ namespace Syncfusion.Maui.Toolkit.NumericEntry
 		/// <param name="caretPosition">The position of the caret where input should be inserted.</param>
 		void InsertNumbers(string displayText, string selectedText, string input, int caretPosition)
 		{
+#if WINDOWS
+            displayText ??= "";
+#endif
 			displayText = displayText.Remove(caretPosition, Math.Min(selectedText.Length, displayText.Length - caretPosition));
 			string negativeSign = GetNegativeSign(GetNumberFormat());
 			bool isNegative = IsNegative(displayText, GetNumberFormat());

--- a/maui/src/NumericEntry/SfNumericEntry.cs
+++ b/maui/src/NumericEntry/SfNumericEntry.cs
@@ -172,6 +172,72 @@ namespace Syncfusion.Maui.Toolkit.NumericEntry
 		/// Another separator string for UI layout.
 		/// </summary>
 		string? _anotherSeparator;
+
+		/// <summary>
+		/// Height of the toolbar in points.
+		/// </summary>
+		const float ToolbarHeight = 50.0f;
+
+		/// <summary>
+		/// Thickness of separator lines in points.
+		/// </summary>
+		const float LineThickness = 0.5f;
+
+		/// <summary>
+		/// Width threshold for small screens in points.
+		/// </summary>
+		const float SmallScreenWidth = 320.0f;
+
+		/// <summary>
+		/// Width threshold for medium screens in points.
+		/// </summary>
+		const float LargeScreenWidth = 667.0f;
+
+		/// <summary>
+		/// Divisor used to calculate button width.
+		/// </summary>
+		const int ButtonDivider = 3;
+
+		/// <summary>
+		/// Button spacing for small landscape screens.
+		/// </summary>
+		const float SmallLandscapeButtonSpacing = 2.5f;
+
+		/// <summary>
+		/// Separator spacing for small landscape screens.
+		/// </summary>
+		const float SmallLandscapeSeparatorSpacing = 5.0f;
+
+		/// <summary>
+		/// Button spacing for large landscape screens.
+		/// </summary>
+		const float LargeLandscapeButtonSpacing = 3.1f;
+
+		/// <summary>
+		/// Separator spacing for large landscape screens.
+		/// </summary>
+		const float LargeLandscapeSeparatorSpacing = 6.1f;
+
+		/// <summary>
+		/// Button spacing for medium portrait screens.
+		/// </summary>
+		const float MediumPortraitButtonSpacing = 2.0f;
+
+		/// <summary>
+		/// Separator spacing for medium portrait screens.
+		/// </summary>
+		const float MediumPortraitSeparatorSpacing = 4.0f;
+
+		/// <summary>
+		/// Button spacing for small portrait screens.
+		/// </summary>
+		const float SmallPortraitButtonSpacing = 1.5f;
+
+		/// <summary>
+		/// Separator spacing for small portrait screens.
+		/// </summary>
+		const float SmallPortraitSeparatorSpacing = 3.0f;
+
 #endif
 #elif WINDOWS
         /// <summary>
@@ -403,7 +469,7 @@ namespace Syncfusion.Maui.Toolkit.NumericEntry
 		{
             // Ensure any necessary size updates are performed
 			UpdateSemanticsSizes();
-			if (SemanticsDataIsCurrent())
+			if (SemanticsDataIsCurrent() && IsTextInputLayout)
 			{
 				return _numericEntrySemanticsNodes;
 			}
@@ -849,11 +915,11 @@ namespace Syncfusion.Maui.Toolkit.NumericEntry
         /// Determines whether the current device orientation is portrait or not.
         /// </summary>
         /// <returns>True if the orientation is portrait or face up/down; otherwise, false.</returns>
-        static bool IsPortraitOrientation()
+        static bool IsLandscapeOrientation()
         {
-            return 	UIDevice.CurrentDevice.Orientation == UIDeviceOrientation.Portrait || UIDevice.CurrentDevice.Orientation == UIDeviceOrientation.PortraitUpsideDown ||
-                UIDevice.CurrentDevice.Orientation == UIDeviceOrientation.FaceUp || UIDevice.CurrentDevice.Orientation == UIDeviceOrientation.FaceDown;
-        }
+			return UIDevice.CurrentDevice.Orientation == UIDeviceOrientation.PortraitUpsideDown || UIDevice.CurrentDevice.Orientation == UIDeviceOrientation.LandscapeLeft || UIDevice.CurrentDevice.Orientation == UIDeviceOrientation.LandscapeRight;
+
+		}
 
         /// <summary>
         /// Configures the frames for minus, separator, and return buttons based on the screen width and provided adjustments.
@@ -878,56 +944,54 @@ namespace Syncfusion.Maui.Toolkit.NumericEntry
 			}
         }
 
-        /// <summary>
-        /// Updates the frames and layout of toolbar buttons, adjusting based on screen orientation and size.
-        /// Ensures the components maintain appropriate spacing and sizing for touch interactions.
-        /// </summary>
-        void UpdateFrames()
+		/// <summary>
+		/// Updates the frames and layout of toolbar buttons, adjusting based on screen orientation and size.
+		/// Ensures the components maintain appropriate spacing and sizing for touch interactions.
+		/// </summary>
+		void UpdateFrames()
         {
-            if (UIDevice.CurrentDevice.Orientation != UIDeviceOrientation.Unknown)
-            {
-				if (_toolbarView == null || _minusButton == null || _separatorButton == null || _returnButton == null
-					|| _lineView1 == null || _lineView2 == null || _lineView3 == null || _lineView4 == null)
-				{
-					return;
-				}
 
-                nfloat width = UIScreen.MainScreen.Bounds.Width;
-                _buttonWidth = width / 3;
-                _toolbarView.Frame = new CGRect(0.0f, 0.0f, (float)width, 50.0f);
-                if (IsPortraitOrientation())
-                {
-                    if (width <= 375 && width > 320)
-                    {
-                        SetButtonFrames(2, 4);
-                    }
-                    else if (width <= 320)
-                    {
-                        SetButtonFrames((nfloat)1.5, 3);
-                        
-                    }
-                    else if (width > 375)
-                    {
-                        SetButtonFrames(2, 4);
-                    }
-                }
-                else if (UIDevice.CurrentDevice.Orientation == UIDeviceOrientation.LandscapeLeft || UIDevice.CurrentDevice.Orientation == UIDeviceOrientation.LandscapeRight)
-                {
-                    if (width <= 667)
-                    {
-                        SetButtonFrames((nfloat)2.5, 5);
-                    }
-                    else if (width > 667)
-                    {
-                        SetButtonFrames((nfloat)3.1, (nfloat)6.1);
-                    }
-                }
-                _lineView1.Frame = new CGRect(0, 0, _toolbarView.Frame.Size.Width, 0.5f);
-                _lineView2.Frame = new CGRect(0, _toolbarView.Frame.Size.Height - 0.5f, _toolbarView.Frame.Size.Width, 0.5f);
-                _lineView3.Frame = new CGRect(_minusButton.Frame.Right - 0.5f, 0, 0.5, _minusButton.Frame.Size.Height);
-                _lineView4.Frame = new CGRect(_returnButton.Frame.Left, 0, 0.5, _minusButton.Frame.Size.Height);
-            }
-        }
+			if (_toolbarView == null || _minusButton == null || _separatorButton == null || _returnButton == null
+					|| _lineView1 == null || _lineView2 == null || _lineView3 == null || _lineView4 == null)
+			{
+				return;
+			}
+
+
+			if (IsLandscapeOrientation())
+			{
+				nfloat width = (nfloat)Math.Max((double)UIScreen.MainScreen.Bounds.Height, (double)UIScreen.MainScreen.Bounds.Width);
+				_buttonWidth = width / ButtonDivider;
+				_toolbarView.Frame = new CGRect(0.0f, 0.0f, (float)width, ToolbarHeight);
+				if (width <= LargeScreenWidth)
+				{
+					SetButtonFrames(SmallLandscapeButtonSpacing, SmallLandscapeSeparatorSpacing);
+				}
+				else if (width > LargeScreenWidth)
+				{
+					SetButtonFrames(LargeLandscapeButtonSpacing, LargeLandscapeSeparatorSpacing);
+				}
+			}
+			else
+			{
+				nfloat width = (nfloat)Math.Min((double)UIScreen.MainScreen.Bounds.Height, (double)UIScreen.MainScreen.Bounds.Width);
+				_buttonWidth = width / ButtonDivider;
+				_toolbarView.Frame = new CGRect(0.0f, 0.0f, (float)width, ToolbarHeight);
+				if (width > SmallScreenWidth)
+				{
+					SetButtonFrames(MediumPortraitButtonSpacing, MediumPortraitSeparatorSpacing);
+				}
+				else if (width <= SmallScreenWidth)
+				{
+					SetButtonFrames(SmallPortraitButtonSpacing, SmallPortraitSeparatorSpacing);
+
+				}
+			}
+			_lineView1.Frame = new CGRect(0, 0, _toolbarView.Frame.Size.Width, LineThickness);
+			_lineView2.Frame = new CGRect(0, _toolbarView.Frame.Size.Height - LineThickness, _toolbarView.Frame.Size.Width, LineThickness);
+			_lineView3.Frame = new CGRect(_minusButton.Frame.Right - LineThickness, 0, LineThickness, _minusButton.Frame.Size.Height);
+			_lineView4.Frame = new CGRect(_returnButton.Frame.Left, 0, LineThickness, _minusButton.Frame.Size.Height);
+		}
 #endif
 		#endregion
 	}

--- a/maui/src/TextInputLayout/SfTextInputLayout.Properties.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.Properties.cs
@@ -636,7 +636,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 		/// Gets or sets a value that indicates whether to show the up down button.
 		/// </summary>
 		/// <value><c>false</c> if disable up down button; otherwise, <c>true</c>.</value>
-		/// <remarks>This property supports for SfNumericEntry control only.</remarks>
+		/// <remarks>This property supports for SfNumericUpDown control only.</remarks>
 		internal static readonly BindableProperty ShowUpDownButtonProperty =
 			BindableProperty.Create(
 				nameof(ShowUpDownButton),
@@ -650,7 +650,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 		/// Gets or sets a value that indicates whether to show the clear button.
 		/// </summary>
 		/// <value><c>false</c> if disable clear button; otherwise, <c>true</c>.</value>
-		/// <remarks>This property supports for SfComboBox only.</remarks>
+		/// <remarks>This property supports for SfNumericEntry only.</remarks>
 		internal static readonly BindableProperty ShowClearButtonProperty =
 			BindableProperty.Create(
 				nameof(ShowClearButton),
@@ -1525,6 +1525,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 		/// <summary>
 		/// Gets or sets the color of the clear button.
 		/// </summary>
+		/// <remarks>This property supports for SfNumericEntry only.</remarks>
 		internal Color ClearButtonColor
 		{
 			get => (Color)GetValue(ClearButtonColorProperty);
@@ -1684,6 +1685,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 		/// Gets or sets the color of the up button.
 		/// </summary>
 		/// <value>Specifies the value for up button. The default value is Colors.Black.</value>
+		/// <remarks>This property supports for SfNumericUpDown only.</remarks>
 		internal Color UpButtonColor
 		{
 			get => (Color)this.GetValue(UpButtonColorProperty);
@@ -1694,6 +1696,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 		/// Gets or sets the color of the down button.
 		/// </summary>
 		/// <value>Specifies the value for down button. The default value is Colors.Black.</value>
+		/// <remarks>This property supports for SfNumericUpDown only.</remarks>
 		internal Color DownButtonColor
 		{
 			get => (Color)this.GetValue(DownButtonColorProperty);

--- a/maui/src/TextInputLayout/SfTextInputLayout.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.cs
@@ -37,10 +37,20 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 		/// </summary>
 		bool _isPressOccurring = false;
 
-        /// <summary>
-        /// Gets or sets a value updown button alignment is vertical or not.
-        /// </summary>
-        bool _isUpDownVerticalAlignment = false;
+		/// <summary>
+		/// The initial delay in milliseconds before activating a long press.
+		/// </summary>
+		const int StartDelay = 500;
+
+		/// <summary>
+		/// The interval in milliseconds between repeated actions during a continuous long press.
+		/// </summary>
+		const int ContinueDelay = 200;
+
+		/// <summary>
+		/// Gets or sets a value updown button alignment is vertical or not.
+		/// </summary>
+		bool _isUpDownVerticalAlignment = false;
 
         /// <summary>
         /// Gets the padding value of the helper text, error text, counter text.
@@ -171,6 +181,12 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
         /// Gets or sets a value of trailing view width.
         /// </summary>
         double _trailViewWidth = 0;
+
+        /// <summary>
+        /// Provides a cancellation token source for managing long press operations.
+        /// This allows for cancellation of ongoing long press tasks when needed.
+        /// </summary>
+        CancellationTokenSource? _cancellationTokenSource;
 
         /// <summary>
         /// Gets or sets the left and right padding value for password visibility toggle icon.
@@ -405,8 +421,11 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
         {
             if (e.Action == PointerActions.Cancelled || e.Action == PointerActions.Exited)
             {
-                _isPressOccurring = false;
                 IsLayoutTapped = false;
+				if (ShowUpDownButton)
+				{
+					StopLongPressTimer();
+				}
             }
 #if WINDOWS
             IsIconPressed = false;
@@ -448,6 +467,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 #if WINDOWS
                     IsIconPressed = true;
 #endif
+					StopLongPressTimer();
                     return;
                 }
 


### PR DESCRIPTION
### Description
**Improve Long Press Behavior:** Updated the logic for long press code using CancellationTokenSource to restrict unintended increments.

**Resolve AutoReverse Color Issue:** Fixed the issue where the up or down button color appeared disabled when the minimum or maximum value was reached, and AutoReverse was set to true.

**Toolbar Item Issue:** Resolved the issue where the toolbar item was not visible on the latest devices and did not change its size while rotating.

**Improve Inaccessibility:** Enhanced the accessibility for NumericUpDown when the button is disabled.


### Root Cause of the Issue
**Long Press:** The increment behavior was not properly managed due to missing cancellation logic.

**AutoReverse Color:** The disabled color was not correctly restricted when AutoReverse was enabled.

**Toolbar Item:** Device-specific visibility and resizing issues were not handled.

**Inaccessibility:** Accessibility for disabled buttons was overlooked.

### Description of Change

1. Implemented CancellationTokenSource to improve long press behavior.
2. Properly restricted the button colors for AutoReverse mode.
3. Ensured toolbar items are visible and resize correctly on device rotation.
4. Improved accessibility for NumericUpDown control when updown button in a disabled state.

### Screenshots
**AutoReverse:**
#### Before:
![image](https://github.com/user-attachments/assets/73099e60-90c8-4640-8743-50c9a9f95b74)

#### After:
![image](https://github.com/user-attachments/assets/489202fb-b7ae-4800-bcdb-77e52fb41f54)

**ToolBarItem Not Visible:**
#### Before:
![image](https://github.com/user-attachments/assets/821a32ed-eee7-4bb8-b6b7-8d2879868f17)

#### After:
![image](https://github.com/user-attachments/assets/a40e6935-4c10-42bc-8c0d-a81be48575dd)

**ToolBarItem Not Visible:**
#### Before:
https://github.com/user-attachments/assets/857616a3-c016-43df-99d0-45941257bed9

#### After:

https://github.com/user-attachments/assets/a27716e5-c18a-4514-afee-5b66e6a97397

