### PR TITLE
SegmentedControl does not receive Focus when pressing the Tab key on Windows

### DIFF
--- a/maui/src/SegmentedControl/Interface/ISegmentInfo.cs
+++ b/maui/src/SegmentedControl/Interface/ISegmentInfo.cs
@@ -130,6 +130,13 @@ namespace Syncfusion.Maui.Toolkit.SegmentedControl
 		/// </summary>
 		void ClearFocusedView();
 
+#if WINDOWS
+		/// <summary>
+		/// Update the keyboard focused view for the segmentedControl.
+		/// </summary>
+		void UpdateFocusState(bool state);
+#endif
+
 		/// <summary>
 		/// Updates the scroll view position to focused index for the segment item.
 		/// </summary>

--- a/maui/src/SegmentedControl/Interface/ISegmentInfo.cs
+++ b/maui/src/SegmentedControl/Interface/ISegmentInfo.cs
@@ -134,7 +134,7 @@ namespace Syncfusion.Maui.Toolkit.SegmentedControl
 		/// <summary>
 		/// Update the keyboard focused view for the segmentedControl.
 		/// </summary>
-		void UpdateFocusState(bool state);
+		void SetFocusVisualState(bool state);
 #endif
 
 		/// <summary>

--- a/maui/src/SegmentedControl/SfSegmentedControl.cs
+++ b/maui/src/SegmentedControl/SfSegmentedControl.cs
@@ -1190,7 +1190,7 @@ namespace Syncfusion.Maui.Toolkit.SegmentedControl
 		}
 
 #if WINDOWS
-		void ISegmentItemInfo.UpdateFocusState(bool state)
+		void ISegmentItemInfo.SetFocusVisualState(bool state)
 		{
 			if (this.Handler != null && this.Handler.PlatformView != null && this.Handler.PlatformView is Microsoft.UI.Xaml.UIElement nativeView)
 			{

--- a/maui/src/SegmentedControl/SfSegmentedControl.cs
+++ b/maui/src/SegmentedControl/SfSegmentedControl.cs
@@ -1067,6 +1067,21 @@ namespace Syncfusion.Maui.Toolkit.SegmentedControl
 			return base.ArrangeContent(bounds);
 		}
 
+#if WINDOWS
+		/// <summary>
+		/// Raises when <see cref="SfSegmentedControl"/>'s handler gets changed.
+		/// <exclude/>
+		/// </summary>
+		protected override void OnHandlerChanged()
+		{
+			base.OnHandlerChanged();
+			if (this.Handler != null && this.Handler.PlatformView != null && this.Handler.PlatformView is Microsoft.UI.Xaml.UIElement nativeView)
+			{
+				nativeView.IsTabStop = true;
+			}
+		}
+#endif
+
 		/// <summary>
 		/// Invokes on the binding context of the view changed.
 		/// </summary>
@@ -1173,6 +1188,16 @@ namespace Syncfusion.Maui.Toolkit.SegmentedControl
 		{
 			_keyNavigationView?.ClearFocusedView();
 		}
+
+#if WINDOWS
+		void ISegmentItemInfo.UpdateFocusState(bool state)
+		{
+			if (this.Handler != null && this.Handler.PlatformView != null && this.Handler.PlatformView is Microsoft.UI.Xaml.UIElement nativeView)
+			{
+				nativeView.UseSystemFocusVisuals = state;
+			}
+		}
+#endif
 
 		/// <summary>
 		/// Updates the scroll view position to focused index for the segment item.

--- a/maui/src/SegmentedControl/Views/Keyboard/KeyNavigationView.cs
+++ b/maui/src/SegmentedControl/Views/Keyboard/KeyNavigationView.cs
@@ -199,6 +199,21 @@ namespace Syncfusion.Maui.Toolkit.SegmentedControl
 			canvas.CanvasRestoreState();
 		}
 
-		#endregion
+#if WINDOWS
+		/// <summary>
+		/// Raises when <see cref="KeyNavigationView"/>'s handler gets changed.
+		/// <exclude/>
+		/// </summary>
+		protected override void OnHandlerChanged()
+		{
+			base.OnHandlerChanged();
+			if (this.Handler != null && this.Handler.PlatformView != null && this.Handler.PlatformView is Microsoft.UI.Xaml.UIElement platformView)
+			{
+				platformView.IsTabStop = false;
+			}
+		}
+#endif
+
+#endregion
 	}
 }

--- a/maui/src/SegmentedControl/Views/OutlinedBorderView.cs
+++ b/maui/src/SegmentedControl/Views/OutlinedBorderView.cs
@@ -83,6 +83,21 @@ namespace Syncfusion.Maui.Toolkit.SegmentedControl
 			base.OnDraw(canvas, dirtyRect);
 		}
 
+#if WINDOWS
+		/// <summary>
+		/// Raises when <see cref="OutlinedBorderView"/>'s handler gets changed.
+		/// <exclude/>
+		/// </summary>
+		protected override void OnHandlerChanged()
+		{
+			base.OnHandlerChanged();
+			if (this.Handler != null && this.Handler.PlatformView != null && this.Handler.PlatformView is Microsoft.UI.Xaml.UIElement platformView)
+			{
+				platformView.IsTabStop = false;
+			}
+		}
+#endif
+
 		#endregion
 	}
 }

--- a/maui/src/SegmentedControl/Views/SegmentLayout.cs
+++ b/maui/src/SegmentedControl/Views/SegmentLayout.cs
@@ -196,6 +196,24 @@ namespace Syncfusion.Maui.Toolkit.SegmentedControl
 				_focusedIndex = -1;
 			}
 
+#if WINDOWS
+			if (e.Key == KeyboardKey.Left || e.Key == KeyboardKey.Right)
+			{
+				_itemInfo?.UpdateFocusState(false);
+			}
+#endif
+
+			if (e.Key == KeyboardKey.Tab || (e.Key == KeyboardKey.Tab && e.IsShiftKeyPressed) || e.Key == KeyboardKey.Down || e.Key == KeyboardKey.Up)
+			{
+				e.Handled = false;
+				_focusedIndex = -1;
+				_itemInfo?.ClearFocusedView();
+#if WINDOWS
+				_itemInfo?.UpdateFocusState(true);
+#endif
+				return;
+			}
+
 			e.Handled = true;
 		}
 

--- a/maui/src/SegmentedControl/Views/SegmentLayout.cs
+++ b/maui/src/SegmentedControl/Views/SegmentLayout.cs
@@ -199,7 +199,7 @@ namespace Syncfusion.Maui.Toolkit.SegmentedControl
 #if WINDOWS
 			if (e.Key == KeyboardKey.Left || e.Key == KeyboardKey.Right)
 			{
-				_itemInfo?.UpdateFocusState(false);
+				_itemInfo?.SetFocusVisualState(false);
 			}
 #endif
 
@@ -209,7 +209,7 @@ namespace Syncfusion.Maui.Toolkit.SegmentedControl
 				_focusedIndex = -1;
 				_itemInfo?.ClearFocusedView();
 #if WINDOWS
-				_itemInfo?.UpdateFocusState(true);
+				_itemInfo?.SetFocusVisualState(true);
 #endif
 				return;
 			}

--- a/maui/src/SegmentedControl/Views/Selection/SelectionView.cs
+++ b/maui/src/SegmentedControl/Views/Selection/SelectionView.cs
@@ -298,6 +298,17 @@ namespace Syncfusion.Maui.Toolkit.SegmentedControl
 			base.OnDraw(canvas, dirtyRect);
 		}
 
+#if WINDOWS
+		protected override void OnHandlerChanged()
+		{
+			base.OnHandlerChanged();
+			if (this.Handler != null && this.Handler.PlatformView != null && this.Handler.PlatformView is Microsoft.UI.Xaml.UIElement platformView)
+			{
+				platformView.IsTabStop = false;
+			}
+		}
+#endif
+
 		#endregion
 	}
 }


### PR DESCRIPTION
### Root Cause of the Issue

The keyboard navigation for the SegmentedControl view is not handled properly when navigating between controls using the Tab key.

### Description of Change

Segment control is not  focusable when navigating using the Tab key. Setting **IsTabStop = true to MAUI native platform view** ensures that the control is recognized as part of the tab navigation flow.

### Unit test  cases
This change is related to UI interaction, hence not applicable

### Issues Fixed

Fixes [67](https://github.com/syncfusion/maui-toolkit/issues/67)

### Screenshots

#### Before:

https://github.com/user-attachments/assets/8fddbbee-5900-4f90-9135-76c948640416

#### After:

https://github.com/user-attachments/assets/4be776a4-90c2-41e6-a003-960756887722
