### PR TITLE
Fixed the segmentedcontrol keyboard navigation and accessibility issue in windows

### DIFF
--- a/maui/src/SegmentedControl/Interface/ISegmentInfo.cs
+++ b/maui/src/SegmentedControl/Interface/ISegmentInfo.cs
@@ -130,13 +130,6 @@ namespace Syncfusion.Maui.Toolkit.SegmentedControl
 		/// </summary>
 		void ClearFocusedView();
 
-#if WINDOWS
-		/// <summary>
-		/// Update the keyboard focused view for the segmentedControl.
-		/// </summary>
-		void SetFocusVisualState(bool state);
-#endif
-
 		/// <summary>
 		/// Updates the scroll view position to focused index for the segment item.
 		/// </summary>

--- a/maui/src/SegmentedControl/SfSegmentedControl.cs
+++ b/maui/src/SegmentedControl/SfSegmentedControl.cs
@@ -92,7 +92,9 @@ namespace Syncfusion.Maui.Toolkit.SegmentedControl
 			MinimumHeightRequest = 40;
 			SelectionIndicatorSettings.Parent = this;
 			TextStyle.Parent = this;
+#if !WINDOWS
 			this.AddKeyboardListener(this);
+#endif
 		}
 
 		#endregion
@@ -1188,16 +1190,6 @@ namespace Syncfusion.Maui.Toolkit.SegmentedControl
 		{
 			_keyNavigationView?.ClearFocusedView();
 		}
-
-#if WINDOWS
-		void ISegmentItemInfo.SetFocusVisualState(bool state)
-		{
-			if (this.Handler != null && this.Handler.PlatformView != null && this.Handler.PlatformView is Microsoft.UI.Xaml.UIElement nativeView)
-			{
-				nativeView.UseSystemFocusVisuals = state;
-			}
-		}
-#endif
 
 		/// <summary>
 		/// Updates the scroll view position to focused index for the segment item.

--- a/maui/src/SegmentedControl/Views/SegmentLayout.cs
+++ b/maui/src/SegmentedControl/Views/SegmentLayout.cs
@@ -6,11 +6,7 @@ namespace Syncfusion.Maui.Toolkit.SegmentedControl
 	/// <summary>
 	/// Represents a layout for arranging and displaying a collection of segment items.
 	/// </summary>
-#if WINDOWS
-	internal partial class SegmentLayout : SfView, IKeyboardListener
-#else
 	internal class SegmentLayout : SfView
-#endif
 	{
 		#region Fields
 
@@ -50,9 +46,6 @@ namespace Syncfusion.Maui.Toolkit.SegmentedControl
 			_itemInfo = itemInfo;
 			DrawingOrder = DrawingOrder.AboveContent;
 			InitializeSegmentItemsView();
-#if WINDOWS
-			this.AddKeyboardListener(this);
-#endif
 		}
 
 		#endregion
@@ -196,21 +189,11 @@ namespace Syncfusion.Maui.Toolkit.SegmentedControl
 				_focusedIndex = -1;
 			}
 
-#if WINDOWS
-			if (e.Key == KeyboardKey.Left || e.Key == KeyboardKey.Right)
-			{
-				_itemInfo?.SetFocusVisualState(false);
-			}
-#endif
-
 			if (e.Key == KeyboardKey.Tab || (e.Key == KeyboardKey.Tab && e.IsShiftKeyPressed) || e.Key == KeyboardKey.Down || e.Key == KeyboardKey.Up)
 			{
 				e.Handled = false;
 				_focusedIndex = -1;
 				_itemInfo?.ClearFocusedView();
-#if WINDOWS
-				_itemInfo?.SetFocusVisualState(true);
-#endif
 				return;
 			}
 
@@ -848,31 +831,6 @@ namespace Syncfusion.Maui.Toolkit.SegmentedControl
 			return bounds.Size;
 		}
 
-		#endregion
-
-		#region Interface implementation
-#if WINDOWS
-		/// <summary>
-		/// Gets a value indicating whether the view can become the first responder to listen the keyboard actions.
-		/// </summary>
-		/// <remarks>This property will be considered only in iOS Platform.</remarks>
-		bool IKeyboardListener.CanBecomeFirstResponder
-		{
-			get { return true; }
-		}
-
-		/// <inheritdoc/>
-		void IKeyboardListener.OnKeyDown(KeyEventArgs e)
-		{
-			ProcessOnKeyDown(e);
-		}
-
-		/// <inheritdoc/>
-		void IKeyboardListener.OnKeyUp(KeyEventArgs e)
-		{
-
-		}
-#endif
 		#endregion
 	}
 }


### PR DESCRIPTION
### Root Cause of the Issue

Segmented control does not support the default keyboard navigation for the segmented item in the windows platform.
Customer given semantics description is not set to the SegmentedItemView in the windows platform.

### Description of Change

When using keyboard navigation with the narrator enabled, the segmented item will read the customer-provided semantics description in the view.

### Issues Fixed

Removed the custom keyboard navigation for the segmented control and used the default framework navigation. Fixed the narrator accessibility issue to ensure it reads the customer-provided semantics description.

Fixes #

[77](https://github.com/syncfusion/maui-toolkit/issues/77)

### Screenshots

#### Before

https://github.com/user-attachments/assets/5587284e-0ea8-4ac5-92d8-e84e05bf0795

#### After:

https://github.com/user-attachments/assets/7d81f0e9-f74b-431f-aab0-80610a026238
