### PR TITLE
938933-Shimmer effect does not display when added inside the PullToRefresh.

### DIFF
--- a/maui/src/PullToRefresh/SfPullToRefresh.cs
+++ b/maui/src/PullToRefresh/SfPullToRefresh.cs
@@ -1861,7 +1861,7 @@ namespace Syncfusion.Maui.Toolkit.PullToRefresh
 		/// <exclude/>
 		protected override Size MeasureContent(double widthConstraint, double heightConstraint)
 		{
-			if ((!IsPulling && !ActualIsRefreshing) || _previousMeasuredSize != new Size(widthConstraint, heightConstraint))
+			if (!IsPulling || _previousMeasuredSize != new Size(widthConstraint, heightConstraint))
 			{
 				if (PullableContent is not null)
 				{
@@ -1883,7 +1883,7 @@ namespace Syncfusion.Maui.Toolkit.PullToRefresh
 		/// <exclude/>
 		protected override Size ArrangeContent(Rect bounds)
 		{
-			if ((!IsPulling && !ActualIsRefreshing) || !bounds.Equals(_previousBounds))
+			if (!IsPulling || !bounds.Equals(_previousBounds))
 			{
 				ManualArrangeContent(false, bounds);
 				_previousBounds = bounds;


### PR DESCRIPTION
### Root Cause of the Issue

**Android:** The main issue was the inclusion of the IsActualRefreshing condition in the Measure and Arrange content. This condition is unnecessary, and as a result, the pullable content measure and arrange was not being called when it was placed shimmer as a pullable content of PullToRefresh..

### Description of Change

**Android:**
- Since IsActualRefreshing is not necessary, we removed the condition from both the Measure and Arrange content.
- As a result, the measure content for the shimmer is now called properly.

### Issues Fixed

Fixes [#72](https://github.com/syncfusion/maui-toolkit/issues/72)

### Screenshots

#### Before:


https://github.com/user-attachments/assets/a49231eb-3a0d-4d42-b760-3685cf909352


#### After:


https://github.com/user-attachments/assets/deebedc0-5852-463f-890d-05bd3d16bfe2



