### PR TITLE
Shimmer not adjusting for increased font size

### DIFF
--- a/maui/src/Shimmer/SfShimmer.cs
+++ b/maui/src/Shimmer/SfShimmer.cs
@@ -484,7 +484,10 @@ namespace Syncfusion.Maui.Toolkit.Shimmer
 			{
 				if (child == Content)
 				{
-					Size contentSize = child.Measure(measuredSize.Width, measuredSize.Height);
+					// When the height constraint or width constraint is not valid(infinite), we use double.PositiveInfinity to allow
+					// the content to determine its own natural height or width without any restrictions.
+					// This ensures that the content can lay out properly even when no specific height is provided by the parent.
+					Size contentSize = child.Measure(isValidWidth ?  measuredSize.Width : double.PositiveInfinity, isValidHeight ? measuredSize.Height : double.PositiveInfinity);
 
 					// If the returned content size is zero, the custom view or the shimmer drawable may not get rendered.
 					// Because we are measuring the custom view or the shimmer drawable with the content size.


### PR DESCRIPTION
### Root Cause of the Issue

Previously, check and set the height and width to 300, If the height and width are infinite. As a result, the content is not updated above the height.

### Description of Change

If height and width as infinite, then restrict the default height and width and update the height and width based on parent. As a result, the content updated based on children size.

Issue: https://github.com/syncfusion/maui-toolkit/issues/87
Task: https://dev.azure.com/EssentialStudio/Mobile%20and%20Desktop/_workitems/edit/941662

### Screenshots

#### Before:

## Android:
| ![Android without Shimmer](https://github.com/user-attachments/assets/4c552e15-bc56-478b-90f0-8dfe9856ccd4) | ![Android with Shimmer](https://github.com/user-attachments/assets/b8f13ee8-b186-42c7-9043-92c780ce3040) |
|---|---|
| **Android without Shimmer** | **Android with Shimmer** |

## iOS:
| ![iOS without Shimmer](https://github.com/user-attachments/assets/9b777f57-c66d-4ae1-9af8-7614e18c2029) | ![iOS with Shimmer](https://github.com/user-attachments/assets/98639728-7ef0-4420-8df6-b0107704c4df) |
|---|---|
| **iOS without Shimmer** | **iOS with Shimmer** |

#### After:

## Android:

| ![WithoutShimmer](https://github.com/user-attachments/assets/2c4a4619-c1c6-4810-8227-7371d545c2f6) | ![ShimmerFix](https://github.com/user-attachments/assets/61edf31b-ad86-4263-a336-ead5c80981db) |
|---|---|
| **Android without Shimmer** | **Android with Shimmer** |

## ios:

| ![WithoutShimmer](https://github.com/user-attachments/assets/b34dbb63-688f-48f7-9159-680eb40e4355) | ![ShimmerFix](https://github.com/user-attachments/assets/87d7a9e0-2fc8-4048-8b79-d17cc84bdbbe) | 
|---|---|
| **ios without Shimmer** | **ios with Shimmer** |