### PR TITLE
Remove Ripple Effect applied when segment item template added

### DIFF
--- a/maui/src/SegmentedControl/Views/SegmentItemView.cs
+++ b/maui/src/SegmentedControl/Views/SegmentItemView.cs
@@ -875,7 +875,10 @@ namespace Syncfusion.Maui.Toolkit.SegmentedControl
 		{
 			if (e.Action == PointerActions.Pressed)
 			{
-				_effectsView?.ApplyEffects();
+				if (itemInfo?.SegmentTemplate is null)
+				{
+                    _effectsView?.ApplyEffects();
+                }
 			}
 #if __MACCATALYST__ || WINDOWS
 			else if (e.Action == PointerActions.Entered && e.PointerDeviceType == PointerDeviceType.Mouse)


### PR DESCRIPTION
### Root Cause of the Issue

The segmented control was applying touch effects to all segments by default, even when a custom template was used. This led to an unintended visual effect while pressing on a segment when templates were used.

### Description of Change

- Updated the `OnTouch` event in the `SegmentItemView` to check if a `SegmentTemplate` is set before applying touch effects.  
- The effects are now only applied if no custom template is used.  

### Issues Fixed


Fixes : https://github.com/syncfusion/maui-toolkit/issues/88



### Screenshots

#### Before:

https://github.com/user-attachments/assets/abe2e472-e6c4-4dd0-a771-8541e97a0ec5

#### After:

https://github.com/user-attachments/assets/6e5a0c3c-7d20-49c4-8af6-1babc0cc89e9
