### PR TITLE
Provide AOT trimming support for Maui toolkit

### DIFF
--- a/maui/samples/Gallery/Samples/Calendar/AppearanceCustomization/ViewModel/AppearanceViewModel.cs
+++ b/maui/samples/Gallery/Samples/Calendar/AppearanceCustomization/ViewModel/AppearanceViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Maui.Controls.Shapes;
+using Syncfusion.Maui.Toolkit.Calendar;
 using System.ComponentModel;
 using System.Globalization;
 using System.Xml;
@@ -50,7 +51,10 @@ public class AppearanceViewModel : INotifyPropertyChanged
             border.Stroke = _isLightTheme ? Color.FromRgba("#6750A4") : Color.FromRgba("#D0BCFF");
 
             Label label = new Label();
-            label.SetBinding(Label.TextProperty, "Date.Day");
+            label.SetBinding(Label.TextProperty, BindingHelper.CreateBinding(
+   propertyName: "Date.Day",
+   getter: static (CalendarCellDetails context) => context.Date.Day));
+
             label.HorizontalOptions = LayoutOptions.Center;
             label.VerticalOptions = LayoutOptions.Center;
             label.Padding = new Thickness(2);
@@ -77,7 +81,10 @@ public class AppearanceViewModel : INotifyPropertyChanged
             border.Stroke = _isLightTheme ? Color.FromRgba("#6750A4") : Color.FromRgba("#D0BCFF");
 
             Label label = new Label();
-            label.SetBinding(Label.TextProperty, "Date.Day");
+            label.SetBinding(Label.TextProperty, BindingHelper.CreateBinding(
+propertyName: "Date.Day",
+getter: static (CalendarCellDetails context) => context.Date.Day));
+
             label.HorizontalOptions = LayoutOptions.Center;
             label.VerticalOptions = LayoutOptions.Center;
             border.Content = label;

--- a/maui/src/BindingHelper/BindingHelper.cs
+++ b/maui/src/BindingHelper/BindingHelper.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.Maui.Controls.Internals;
+
+/// <summary>
+/// Helper class for creating bindings in .NET MAUI applications.
+/// </summary>
+public static class BindingHelper
+    {
+		/// <summary>
+		/// Creates a typed binding for a given source and its properties.
+		/// </summary>
+		/// <typeparam name="TSource">The type of the binding source.</typeparam>
+		/// <typeparam name="TProperty">The type of the property to bind.</typeparam>
+		/// <param name="propertyName">The name of the property to bind to.</param>
+		/// <param name="getter">A function to get the value of the property from the source.</param>
+		/// <param name="setter">An optional action to set the value of the property on the source.</param>
+		/// <param name="mode">The binding mode that determines the data flow direction.</param>
+		/// <param name="converter">An optional value converter for the binding.</param>
+		/// <param name="converterParameter">An optional parameter used by the converter.</param>
+		/// <param name="source">The source object for binding.</param>
+		/// <returns>A <see cref="BindingBase"/> representing the created binding.</returns>
+		public static BindingBase CreateBinding<TSource, TProperty>(
+                string propertyName,
+                Func<TSource, TProperty> getter,
+                Action<TSource, TProperty>? setter = null,
+                BindingMode mode = BindingMode.Default,
+                IValueConverter? converter = null,
+                object? converterParameter = null,
+                object? source = null)
+        {
+            return new TypedBinding<TSource, TProperty>(
+                getter: source => (getter(source), true),
+                setter,
+                handlers:
+                [
+                        new(static source => source, propertyName),
+                ])
+            {
+                Converter = converter,
+                ConverterParameter = converterParameter,
+                Mode = mode,
+                Source = source,
+            };
+        }
+    }

--- a/maui/src/Calendar/Helper/CalendarViewHelper.cs
+++ b/maui/src/Calendar/Helper/CalendarViewHelper.cs
@@ -1619,27 +1619,44 @@ namespace Syncfusion.Maui.Toolkit.Calendar
         /// <returns>A calendar instance.</returns>
         internal static Globalization.Calendar GetCalendar(string calendarIdentifier)
         {
-            var calendarTypes = new Dictionary<string, Type>
+            switch (calendarIdentifier)
             {
-                { "Gregorian", typeof(GregorianCalendar) },
-                { "Hijri", typeof(HijriCalendar) },
-                { "Persian", typeof(PersianCalendar) },
-                { "ThaiBuddhist", typeof(ThaiBuddhistCalendar) },
-                { "Taiwan", typeof(TaiwanCalendar) },
-                { "UmAlQura", typeof(UmAlQuraCalendar) },
-                { "Korean", typeof(KoreanCalendar) }
-            };
 
-            if (calendarTypes.TryGetValue(calendarIdentifier, out var type))
-            {
-                if (Activator.CreateInstance(type) is Globalization.Calendar calendar)
-                {
-                    return calendar;
-                }
+                case "Gregorian":
+
+                    return new GregorianCalendar();
+
+                case "Hijri":
+
+                    return new HijriCalendar();
+
+                case "Persian":
+
+                    return new PersianCalendar();
+
+                case "ThaiBuddhist":
+
+                    return new ThaiBuddhistCalendar();
+
+                case "Taiwan":
+
+                    return new TaiwanCalendar();
+
+                case "UmAlQura":
+
+                    return new UmAlQuraCalendar();
+
+                case "Korean":
+
+                    return new KoreanCalendar();
+
+                default:
+
+                    // If calendar identifier is specified wrongly, then default calendar will be used.
+
+                    return CultureInfo.CurrentUICulture.DateTimeFormat.Calendar;
+
             }
-
-            // If calendar identifier is specified wrongly, then default calendar will be used.
-            return CultureInfo.CurrentUICulture.DateTimeFormat.Calendar;
         }
 
         /// <summary>

--- a/maui/src/Calendar/Helper/CalendarViewHelper.cs
+++ b/maui/src/Calendar/Helper/CalendarViewHelper.cs
@@ -1619,24 +1619,27 @@ namespace Syncfusion.Maui.Toolkit.Calendar
         /// <returns>A calendar instance.</returns>
         internal static Globalization.Calendar GetCalendar(string calendarIdentifier)
         {
-            var type = Type.GetType("System.Globalization." + calendarIdentifier + "Calendar");
-            if (type != null)
+            var calendarTypes = new Dictionary<string, Type>
             {
-                var calendar = Activator.CreateInstance(type) as Globalization.Calendar;
-                if (calendar != null)
+                { "Gregorian", typeof(GregorianCalendar) },
+                { "Hijri", typeof(HijriCalendar) },
+                { "Persian", typeof(PersianCalendar) },
+                { "ThaiBuddhist", typeof(ThaiBuddhistCalendar) },
+                { "Taiwan", typeof(TaiwanCalendar) },
+                { "UmAlQura", typeof(UmAlQuraCalendar) },
+                { "Korean", typeof(KoreanCalendar) }
+            };
+
+            if (calendarTypes.TryGetValue(calendarIdentifier, out var type))
+            {
+                if (Activator.CreateInstance(type) is Globalization.Calendar calendar)
                 {
                     return calendar;
                 }
-                else
-                {
-                    return CultureInfo.CurrentUICulture.DateTimeFormat.Calendar;
-                }
             }
-            else
-            {
-                // If calendar identifier is specified wrongly, then default calendar will be used.
-                return CultureInfo.CurrentUICulture.DateTimeFormat.Calendar;
-            }
+
+            // If calendar identifier is specified wrongly, then default calendar will be used.
+            return CultureInfo.CurrentUICulture.DateTimeFormat.Calendar;
         }
 
         /// <summary>

--- a/maui/src/Calendar/Resources/SfCalendar.en-US.resx
+++ b/maui/src/Calendar/Resources/SfCalendar.en-US.resx
@@ -1,0 +1,155 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="OK" xml:space="preserve">
+    <value>OK</value>
+    <comment>Text for disabled item</comment>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Cancel</value>
+    <comment>Text for selected item</comment>
+  </data>
+  <data name="Today" xml:space="preserve">
+    <value>Today</value>
+  </data>
+  <data name="Special Date" xml:space="preserve">
+    <value>Special Date</value>
+  </data>
+  <data name="Blackout Date" xml:space="preserve">
+    <value>Blackout Date</value>
+  </data>
+  <data name="Disabled Date" xml:space="preserve">
+    <value>Disabled Date</value>
+  </data>
+  <data name="Week" xml:space="preserve">
+    <value>Week</value>
+  </data>
+  <data name="Disabled Cell" xml:space="preserve">
+    <value>Disabled Cell</value>
+  </data>
+  <data name="To" xml:space="preserve">
+    <value>To</value>
+  </data>
+  <data name="Forward" xml:space="preserve">
+    <value>Forward</value>
+  </data>
+  <data name="Backward" xml:space="preserve">
+    <value>Backward</value>
+  </data>
+</root>

--- a/maui/src/Calendar/SfCalendar.cs
+++ b/maui/src/Calendar/SfCalendar.cs
@@ -106,6 +106,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
         /// </summary>
         public SfCalendar()
         {
+            SfCalendarResources.InitializeDefaultResource("Syncfusion.Maui.Toolkit.Calendar.Resources.SfCalendar", typeof(SfCalendar));
             ThemeElement.InitializeThemeResources(this, "SfCalendarTheme");
             _proxy = new(this);
             DrawingOrder = DrawingOrder.AboveContent;

--- a/maui/src/Charts/Axis/CategoryAxis.cs
+++ b/maui/src/Charts/Axis/CategoryAxis.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Syncfusion.Maui.Toolkit.Charts
 {
@@ -84,6 +85,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 			}
 		}
 
+		[UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "<Pending>")]
 		internal override void GenerateVisibleLabels()
 		{
 			if (VisibleRange.IsEmpty)

--- a/maui/src/Charts/Axis/DateTimeAxis.cs
+++ b/maui/src/Charts/Axis/DateTimeAxis.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Maui.Graphics;
 
 namespace Syncfusion.Maui.Toolkit.Charts
@@ -182,6 +183,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 			}
 		}
 
+		[UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "<Pending>")]
 		internal override void GenerateVisibleLabels()
 		{
 			SmallTickPoints.Clear();

--- a/maui/src/Charts/Axis/LogarithmicAxis.cs
+++ b/maui/src/Charts/Axis/LogarithmicAxis.cs
@@ -1,4 +1,6 @@
-﻿namespace Syncfusion.Maui.Toolkit.Charts
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Syncfusion.Maui.Toolkit.Charts
 {
 	public partial class LogarithmicAxis : RangeAxisBase
 	{
@@ -125,6 +127,7 @@
 			return new DoubleRange(start, start + 1);
 		}
 
+		[UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "<Pending>")]
 		internal override void GenerateVisibleLabels()
 		{
 			if (VisibleRange.IsEmpty)

--- a/maui/src/Charts/Axis/NumericalAxis.cs
+++ b/maui/src/Charts/Axis/NumericalAxis.cs
@@ -1,4 +1,6 @@
-﻿namespace Syncfusion.Maui.Toolkit.Charts
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Syncfusion.Maui.Toolkit.Charts
 {
 	public partial class NumericalAxis : RangeAxisBase
 	{
@@ -110,6 +112,7 @@
 		#endregion
 
 		#region Internal Methods
+		[UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "<Pending>")]
 		internal override void GenerateVisibleLabels()
 		{
 			var actualLabels = VisibleLabels;

--- a/maui/src/Charts/Behaviors/ChartTooltipBehavior.cs
+++ b/maui/src/Charts/Behaviors/ChartTooltipBehavior.cs
@@ -694,7 +694,8 @@ namespace Syncfusion.Maui.Toolkit.Charts
                         tooltip.BindingContext = tooltipInfo;
                         tooltip.Duration = Duration;
                         tooltip.Position = tooltipInfo.Position;
-                        tooltip.SetBinding(SfTooltip.BackgroundProperty, nameof(TooltipInfo.Background));
+                        tooltip.SetBinding(SfTooltip.BackgroundProperty, 
+							BindingHelper.CreateBinding(nameof(TooltipInfo.Background), getter: static(TooltipInfo tooltipInfo1) => tooltipInfo1.Background));
                         tooltip.Content = GetTooltipTemplate(tooltipInfo);
                         tooltip.Show(seriesBounds, tooltipInfo.TargetRect, canAnimate);
                     }

--- a/maui/src/Charts/Behaviors/ChartTrackballBehavior.cs
+++ b/maui/src/Charts/Behaviors/ChartTrackballBehavior.cs
@@ -1119,18 +1119,25 @@ namespace Syncfusion.Maui.Toolkit.Charts
 					{
 						LineBreakMode = LineBreakMode.NoWrap
 					};
-					label.SetBinding(Label.TextProperty, new Binding() { Path = "Label" });
+					label.SetBinding(Label.TextProperty, 
+						BindingHelper.CreateBinding(nameof(TrackballPointInfo.Label), getter: static(TrackballPointInfo info) => info.Label));
 					label.VerticalOptions = LayoutOptions.Fill;
 					label.HorizontalOptions = LayoutOptions.Fill;
 					label.VerticalTextAlignment = TextAlignment.Center;
 					label.HorizontalTextAlignment = TextAlignment.Center;
-					label.SetBinding(Label.TextColorProperty, new Binding() { Path = "LabelStyle.TextColor" });
-					label.SetBinding(Label.BackgroundProperty, new Binding() { Path = "LabelStyle.Background" });
-					label.SetBinding(Label.FontAttributesProperty, new Binding() { Path = "LabelStyle.FontAttributes" });
-					label.SetBinding(Label.FontFamilyProperty, new Binding() { Path = "LabelStyle.FontFamily" });
-					label.SetBinding(Label.FontSizeProperty, new Binding() { Path = "LabelStyle.FontSize" });
-					label.SetBinding(Label.MarginProperty, new Binding() { Path = "LabelStyle.Margin" });
-					return label;
+					label.SetBinding(Label.TextColorProperty, 
+						BindingHelper.CreateBinding(nameof(ChartLabelStyle.TextColor), getter: static(ChartLabelStyle labelStyle) => labelStyle.TextColor, source: LabelStyle));
+					label.SetBinding(Label.BackgroundProperty,
+						BindingHelper.CreateBinding(nameof(ChartLabelStyle.Background), getter: static (ChartLabelStyle labelStyle) => labelStyle.Background, source: LabelStyle));
+					label.SetBinding(Label.FontAttributesProperty, 
+						BindingHelper.CreateBinding(nameof(ChartLabelStyle.FontAttributes), getter: static (ChartLabelStyle labelStyle) => labelStyle.FontAttributes, source: LabelStyle));
+					label.SetBinding(Label.FontFamilyProperty, 
+						BindingHelper.CreateBinding(nameof(ChartLabelStyle.FontFamily), getter: static (ChartLabelStyle labelStyle) => labelStyle.FontFamily, source: LabelStyle));
+					label.SetBinding(Label.FontSizeProperty,
+						BindingHelper.CreateBinding(nameof(ChartLabelStyle.FontSize), getter: static (ChartLabelStyle labelStyle) => labelStyle.FontSize, source: LabelStyle));
+					label.SetBinding(Label.MarginProperty,
+						BindingHelper.CreateBinding(nameof(ChartLabelStyle.Margin), getter: static (ChartLabelStyle labelStyle) => labelStyle.Margin, source: LabelStyle));
+				return label;
 				});
 
 				BindableLayout.SetItemTemplate(layout, labelTemplate);

--- a/maui/src/Charts/Layouts/ChartSeriesView.cs
+++ b/maui/src/Charts/Layouts/ChartSeriesView.cs
@@ -21,7 +21,8 @@ namespace Syncfusion.Maui.Toolkit.Charts
 		{
 			_series = chartSeries;
 			_chartPlotArea = plotArea;
-			SetBinding(IsVisibleProperty, new Binding() { Source = chartSeries, Path = nameof(ChartSeries.IsVisible) });
+			SetBinding(IsVisibleProperty, 
+				BindingHelper.CreateBinding(nameof(ChartSeries.IsVisible), getter: static(ChartSeries series) => series.IsVisible, source: chartSeries));
 		}
 
 		#endregion

--- a/maui/src/Charts/Layouts/DataLabelLayout.cs
+++ b/maui/src/Charts/Layouts/DataLabelLayout.cs
@@ -22,7 +22,8 @@ namespace Syncfusion.Maui.Toolkit.Charts
             IsClippedToBounds = true;
             _source = source;
             BindableLayout.SetItemTemplate(this, GetItemTemplate());
-            SetBinding(IsVisibleProperty, new Binding(nameof(IDataTemplateDependent.IsVisible)) { Source = _source });
+            SetBinding(IsVisibleProperty, 
+				BindingHelper.CreateBinding(nameof(IDataTemplateDependent.IsVisible), getter: static(IDataTemplateDependent dataTemplateDependent) => dataTemplateDependent.IsVisible, source: _source));
         }
 
         DataTemplate GetItemTemplate()
@@ -34,17 +35,20 @@ namespace Syncfusion.Maui.Toolkit.Charts
                 {
 					Bindings =
 					[
-						new Binding(nameof(ChartDataLabel.XPosition)),
-                        new Binding(nameof(ChartDataLabel.YPosition)),
-                    ],
+						BindingHelper.CreateBinding(nameof(ChartDataLabel.XPosition), getter: static (ChartDataLabel label) => label.XPosition),
+						BindingHelper.CreateBinding(nameof(ChartDataLabel.YPosition), getter: static (ChartDataLabel label) => label.YPosition)
+					],
                     Converter = new TemplateVisibilityConverter(),
                 };
 
                 item.SetBinding(DataLabelItemView.IsVisibleProperty, binding);
-                item.SetBinding(DataLabelItemView.XPositionProperty, new Binding(nameof(ChartDataLabel.XPosition)));
-                item.SetBinding(DataLabelItemView.YPositionProperty, new Binding(nameof(ChartDataLabel.YPosition)));
-                item.SetBinding(SfTemplatedView.ItemTemplateProperty, new Binding(nameof(IDataTemplateDependent.LabelTemplate)) { Source = _source });
-                return item;
+				item.SetBinding(DataLabelItemView.XPositionProperty,
+					BindingHelper.CreateBinding(nameof(ChartDataLabel.XPosition), getter: static (ChartDataLabel label) => label.XPosition));
+				item.SetBinding(DataLabelItemView.YPositionProperty,
+					BindingHelper.CreateBinding(nameof(ChartDataLabel.YPosition), getter: static (ChartDataLabel label) => label.YPosition));
+				item.SetBinding(SfTemplatedView.ItemTemplateProperty,
+					BindingHelper.CreateBinding(nameof(IDataTemplateDependent.LabelTemplate), getter: static (IDataTemplateDependent source) => source.LabelTemplate, source: _source));
+				return item;
             });
         }
     }

--- a/maui/src/Charts/Series/BoxAndWhiskerSeries.cs
+++ b/maui/src/Charts/Series/BoxAndWhiskerSeries.cs
@@ -1238,11 +1238,11 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 					var labels = new[]
 					{
-					   new { LabelText = maximumFormat, ValueText = texts[0] },
-					   new { LabelText = Q3Format, ValueText = texts[1] },
-					   new { LabelText = medianFormat, ValueText = texts[2] },
-					   new { LabelText = Q1Format, ValueText = texts[3] },
-					   new { LabelText = minimumFormat, ValueText = texts[4] }
+						new TooltipLabelValue(maximumFormat, texts[0]),
+						new TooltipLabelValue(Q3Format, texts[1]),
+						new TooltipLabelValue(medianFormat, texts[2]),
+						new TooltipLabelValue(Q1Format, texts[3]),
+						new TooltipLabelValue(minimumFormat, texts[4])
 					};
 
 					BindableLayout.SetItemsSource(stackLayout, labels);
@@ -1275,8 +1275,10 @@ namespace Syncfusion.Maui.Toolkit.Charts
 							FontSize = info.FontSize,
 						});
 
-						((Label)stackLayout1.Children[0]).SetBinding(Microsoft.Maui.Controls.Label.TextProperty, new Binding("LabelText"));
-						((Label)stackLayout1.Children[1]).SetBinding(Microsoft.Maui.Controls.Label.TextProperty, new Binding("ValueText"));
+						((Label)stackLayout1.Children[0]).SetBinding(Microsoft.Maui.Controls.Label.TextProperty,
+							BindingHelper.CreateBinding(nameof(TooltipLabelValue.LabelText), getter: static (TooltipLabelValue label) => label.LabelText));
+						((Label)stackLayout1.Children[1]).SetBinding(Microsoft.Maui.Controls.Label.TextProperty,
+							BindingHelper.CreateBinding(nameof(TooltipLabelValue.ValueText), getter: static (TooltipLabelValue label) => label.ValueText));
 						return stackLayout1;
 					}));
 				}

--- a/maui/src/Charts/Series/HiLoOpenCloseSeries.cs
+++ b/maui/src/Charts/Series/HiLoOpenCloseSeries.cs
@@ -348,12 +348,12 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				string closeFormat = $"{SfCartesianChartResources.Close}  :";
 
 				var labels = new[]
-				{
-				   new {LabelText = highFormat,ValueText = texts[0]},
-				   new {LabelText = lowFormat,ValueText = texts[1]},
-				   new {LabelText = openFormat,ValueText = texts[2]},
-				   new {LabelText = closeFormat,ValueText = texts[3]},
-				};
+					{
+						new TooltipLabelValue(highFormat, texts[0]),
+						new TooltipLabelValue(lowFormat, texts[1]),
+						new TooltipLabelValue(openFormat, texts[2]),
+						new TooltipLabelValue(closeFormat, texts[3]),
+					};
 
 				StackLayout stackLayout = [];
 				BindableLayout.SetItemsSource(stackLayout, labels);
@@ -383,8 +383,10 @@ namespace Syncfusion.Maui.Toolkit.Charts
 						FontSize = info.FontSize,
 					});
 
-					((Label)stackLayout1.Children[0]).SetBinding(Microsoft.Maui.Controls.Label.TextProperty, new Binding("LabelText"));
-					((Label)stackLayout1.Children[1]).SetBinding(Microsoft.Maui.Controls.Label.TextProperty, new Binding("ValueText"));
+					((Label)stackLayout1.Children[0]).SetBinding(Microsoft.Maui.Controls.Label.TextProperty,
+							BindingHelper.CreateBinding(nameof(TooltipLabelValue.LabelText), getter: static (TooltipLabelValue label) => label.LabelText));
+					((Label)stackLayout1.Children[1]).SetBinding(Microsoft.Maui.Controls.Label.TextProperty,
+						BindingHelper.CreateBinding(nameof(TooltipLabelValue.ValueText), getter: static (TooltipLabelValue label) => label.ValueText));
 					return stackLayout1;
 				}));
 

--- a/maui/src/Charts/Utils/ChartDataUtils.cs
+++ b/maui/src/Charts/Utils/ChartDataUtils.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 
 namespace Syncfusion.Maui.Toolkit.Charts
 {
@@ -17,6 +18,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 		/// <param name="obj">Object to retrieve a property.</param>
 		/// <param name="path">Property name</param>
 		/// <returns>The property.</returns>
+		[RequiresUnreferencedCode("The GetPropertyInfo is not trim compatible")]
 		internal static PropertyInfo? GetPropertyInfo(object obj, string path)
 		{
 			//TODO: consider if it needed.

--- a/maui/src/Charts/Utils/ChartUtils.cs
+++ b/maui/src/Charts/Utils/ChartUtils.cs
@@ -5,6 +5,7 @@ using Microsoft.Maui.Controls.Shapes;
 using Core = Syncfusion.Maui.Toolkit;
 using Syncfusion.Maui.Toolkit.Graphics.Internals;
 using System.Reflection;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Syncfusion.Maui.Toolkit.Charts
 {
@@ -377,6 +378,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 			return inside;
 		}
 
+		[RequiresUnreferencedCode("The IsOverriddenMethod is not trim compatible")]
 		internal static bool IsOverriddenMethod(object classObject, string methodName)
 		{
 			var methodInfo = classObject.GetType().GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
@@ -451,12 +453,19 @@ namespace Syncfusion.Maui.Toolkit.Charts
 					VerticalTextAlignment = TextAlignment.Center,
 					HorizontalTextAlignment = TextAlignment.Center,					
 				};
-				label.SetBinding(Label.TextProperty, nameof(TooltipInfo.Text));
-				label.SetBinding(Label.TextColorProperty, nameof(TooltipInfo.TextColor));
-				label.SetBinding(Label.MarginProperty, nameof(TooltipInfo.Margin));
-				label.SetBinding(Label.FontSizeProperty, nameof(TooltipInfo.FontSize));
-				label.SetBinding(Label.FontFamilyProperty, nameof(TooltipInfo.FontFamily));
-				label.SetBinding(Label.FontAttributesProperty, nameof(TooltipInfo.FontAttributes));
+
+				label.SetBinding(Label.TextProperty,
+					BindingHelper.CreateBinding(nameof(TooltipInfo.Text), getter: static (TooltipInfo tooltipInfo) => tooltipInfo.Text));
+				label.SetBinding(Label.TextColorProperty,
+					BindingHelper.CreateBinding(nameof(TooltipInfo.TextColor), getter: static (TooltipInfo tooltipInfo) => tooltipInfo.TextColor));
+				label.SetBinding(Label.MarginProperty,
+					BindingHelper.CreateBinding(nameof(TooltipInfo.Margin), getter: static (TooltipInfo tooltipInfo) => tooltipInfo.Margin));
+				label.SetBinding(Label.FontSizeProperty,
+					BindingHelper.CreateBinding(nameof(TooltipInfo.FontSize), getter: static (TooltipInfo tooltipInfo) => tooltipInfo.FontSize));
+				label.SetBinding(Label.FontFamilyProperty,
+					BindingHelper.CreateBinding(nameof(TooltipInfo.FontFamily), getter: static (TooltipInfo tooltipInfo) => tooltipInfo.FontFamily));
+				label.SetBinding(Label.FontAttributesProperty,
+					BindingHelper.CreateBinding(nameof(TooltipInfo.FontAttributes), getter: static (TooltipInfo tooltipInfo) => tooltipInfo.FontAttributes));
 
 				return new ViewCell { View = label };
 			});
@@ -492,6 +501,18 @@ namespace Syncfusion.Maui.Toolkit.Charts
 			}
 
 			return size;
+		}
+	}
+
+	internal class TooltipLabelValue
+	{
+		public string LabelText { get; set; }
+		public string ValueText { get; set; }
+
+		public TooltipLabelValue(string labelText, string valueText)
+		{
+			LabelText = labelText;
+			ValueText = valueText;
 		}
 	}
 }

--- a/maui/src/Charts/Utils/FastReflection.cs
+++ b/maui/src/Charts/Utils/FastReflection.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq.Expressions;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
 using System.Reflection;
 
 namespace Syncfusion.Maui.Toolkit.Charts
@@ -11,6 +12,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 		{
 		}
 
+		[UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "<Pending>")]
 		internal bool SetPropertyName(string name, object obj)
 		{
 			var propertyInfo = ChartDataUtils.GetPropertyInfo(obj, name);

--- a/maui/src/Chip/SfChipGroup.cs
+++ b/maui/src/Chip/SfChipGroup.cs
@@ -2,6 +2,7 @@
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Windows.Input;
 using Microsoft.Maui.Controls.Internals;
 using Syncfusion.Maui.Toolkit.Themes;
@@ -1356,6 +1357,7 @@ namespace Syncfusion.Maui.Toolkit.Chips
 		/// <param name="propertyName">The property name.</param>
 		/// <param name="item">The element from chips collection.</param>
 		/// <returns>The property value from item.</returns>
+		[RequiresUnreferencedCode("The GetPropertyValue method is not trim compatible")] 
 		static object GetPropertyValue(string propertyName, object item)
 		{
 			var propertyInfo = item.GetType().GetProperty(propertyName);
@@ -1410,6 +1412,7 @@ namespace Syncfusion.Maui.Toolkit.Chips
 		/// </summary>
 		/// <param name="propertyName"></param>
 		/// <param name="collection">New value.</param>
+		[RequiresUnreferencedCode("The SubscribeCollectionChanged method is not trim compatible")] 
 		void SubscribeCollectionChanged(string propertyName, INotifyCollectionChanged? collection)
 		{
 			if (collection != null)
@@ -1451,6 +1454,7 @@ namespace Syncfusion.Maui.Toolkit.Chips
 		/// <param name="oldValue">Old value.</param>
 		/// <param name="newValue">New value.</param>
 		/// <param name="propertyName">Property name.</param>
+		[UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "<Pending>")]
 		void ChipGroupCollectionChanged(object oldValue, object newValue, string propertyName)
 		{
 			if (oldValue != null)
@@ -1614,6 +1618,7 @@ namespace Syncfusion.Maui.Toolkit.Chips
 		/// </summary>
 		/// <param name="propertyName">The property name.</param>
 		/// <param name="e">E.</param>
+		[UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "<Pending>")]
 		void CollectionChanged(string? propertyName, NotifyCollectionChangedEventArgs e)
 		{
 			if (e.NewItems != null && e.NewItems.Count > 0)
@@ -1744,6 +1749,7 @@ namespace Syncfusion.Maui.Toolkit.Chips
 		/// |         |          |                       |              |           
 		/// |         |          |      PADDING          |              |           
 		/// +---------+----------+-----------------------+--------------+CORNERRADIUS   
+		[UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "<Pending>")]
 		SfChip GetNewChip(object? chipData)
 		{
 			SfChip chip = InitializeChip();
@@ -1800,17 +1806,14 @@ namespace Syncfusion.Maui.Toolkit.Chips
 				customView.BindingContext = chipData;
 				if (customView is SfChip)
 				{
-					chip.SetBinding(SfChip.IsVisibleProperty, new Binding()
-					{
-						Source = customView,
-						Path = "IsVisible",
-					});
+					chip.SetBinding(SfChip.IsVisibleProperty, BindingHelper.CreateBinding(propertyName: "IsVisible", getter: static(View view) => view.IsVisible, source:customView));
 				}
 
 				chip.Add(customView);
 			}
 		}
 
+		[RequiresUnreferencedCode("The ConfigureChipWithoutTemplate method is not trim compatible")] 
 		void ConfigureChipWithoutTemplate(SfChip chip, object chipData)
 		{
 			chip.IsItemTemplate = false;
@@ -2333,6 +2336,7 @@ namespace Syncfusion.Maui.Toolkit.Chips
 		/// </summary>
 		/// <param name="oldValue">Old layout.</param>
 		/// <param name="isLayoutChanged">If set to <c>true</c> is layout changed.</param>
+		[UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "<Pending>")]
 		void ClearAndCreateChips(object? oldValue, bool isLayoutChanged)
 		{
 			if (oldValue != null || (_chipGroupChildren != null && _chipGroupChildren.Count > 0))

--- a/maui/src/Core/BaseView/PlatformView/LayoutViewExt.ios.cs
+++ b/maui/src/Core/BaseView/PlatformView/LayoutViewExt.ios.cs
@@ -176,7 +176,10 @@ namespace Syncfusion.Maui.Toolkit.Platform
 					}
 				}
 
-				Add(_nativeGraphicsView);
+				if(_nativeGraphicsView is not null)
+				{
+					Add(_nativeGraphicsView);
+				}
 			}
 			else if (_nativeGraphicsView != null)
 			{

--- a/maui/src/Core/Legend/LegendLayout.cs
+++ b/maui/src/Core/Legend/LegendLayout.cs
@@ -96,7 +96,7 @@ namespace Syncfusion.Maui.Toolkit.Internals
 			return base.ArrangeOverride(bounds);
         }
 
-        void UpdateLegendLayout(Rect bounds)
+		void UpdateLegendLayout(Rect bounds)
         {
             var areaBounds = new Rect(0, 0, bounds.Width, bounds.Height);
 
@@ -173,7 +173,7 @@ LegendLayout.GetMaximumCoeff(_legend.ItemsMaximumHeightRequest?.Invoke() ?? 0.25
             }
         }
 
-        void CreateLegendView()
+		void CreateLegendView()
         {
             //Todo: We need to reimplement the legend feature in chart, once fixed the Bindable layout issue and dynamically change scroll view content issue.
             //https://github.com/dotnet/maui/issues/1393
@@ -187,12 +187,17 @@ LegendLayout.GetMaximumCoeff(_legend.ItemsMaximumHeightRequest?.Invoke() ?? 0.25
                 var itemsView = Legend.CreateLegendView();
                 _legendItemsView = itemsView ?? [];
                 _legendItemsView.BindingContext = _legend;
-                _legendItemsView.SetBinding(SfLegend.ToggleVisibilityProperty, "ToggleSeriesVisibility");
-                _legendItemsView.SetBinding(SfLegend.PlacementProperty, nameof(Legend.Placement));
-                _legendItemsView.SetBinding(SfLegend.ItemTemplateProperty, nameof(Legend.ItemTemplate));
-                _legendItemsView.SetBinding(SfLegend.IsVisibleProperty, nameof(Legend.IsVisible));
-                _legendItemsView.SetBinding(SfLegend.ItemsLayoutProperty, nameof(Legend.ItemsLayout));
-                _legendItemsView.ItemsSource = _plotArea.LegendItems;
+				_legendItemsView.SetBinding(SfLegend.ToggleVisibilityProperty,
+					BindingHelper.CreateBinding(nameof(ILegend.ToggleVisibility), getter: static (ILegend legend) => legend.ToggleVisibility));
+				_legendItemsView.SetBinding(SfLegend.PlacementProperty,
+					BindingHelper.CreateBinding(nameof(ILegend.Placement), getter: static (ILegend legend) => legend.Placement));
+				_legendItemsView.SetBinding(SfLegend.ItemTemplateProperty,
+					BindingHelper.CreateBinding(nameof(ILegend.ItemTemplate), getter: static (ILegend legend) => legend.ItemTemplate));
+				_legendItemsView.SetBinding(SfLegend.IsVisibleProperty,
+					BindingHelper.CreateBinding(nameof(ILegend.IsVisible), getter: static (ILegend legend) => legend.IsVisible));
+				_legendItemsView.SetBinding(SfLegend.ItemsLayoutProperty,
+					BindingHelper.CreateBinding(nameof(ILegend.ItemsLayout), getter: static (ILegend legend) => legend.ItemsLayout));
+				_legendItemsView.ItemsSource = _plotArea.LegendItems;
                 _legendItemsView.ItemClicked += OnLegendItemToggled;
                 _legendItemsView.PropertyChanged += LegendItemsView_PropertyChanged;
                 ((ILegend)_legendItemsView).ItemsMaximumHeightRequest = Legend.ItemsMaximumHeightRequest;

--- a/maui/src/Core/Legend/SfLegend.cs
+++ b/maui/src/Core/Legend/SfLegend.cs
@@ -393,34 +393,34 @@ namespace Syncfusion.Maui.Toolkit
                     Padding = new Thickness(8, 10)
                 };
 
-                ToggleColorConverter toggleColorConverter = new ToggleColorConverter();
-                Binding binding;
-                Binding binding1;
-                MultiBinding multiBinding;
-                SfShapeView shapeView = CreateShapeView();
+				ToggleColorConverter toggleColorConverter = new ToggleColorConverter();
+				MultiBinding multiBinding;
+				SfShapeView shapeView = CreateShapeView();
 
-                if (shapeView != null)
-                {
-                    shapeView.HorizontalOptions = LayoutOptions.Start;
-                    shapeView.VerticalOptions = LayoutOptions.Center;
-					binding = new Binding(nameof(LegendItem.IsToggled))
+				if (shapeView != null)
+				{
+					shapeView.HorizontalOptions = LayoutOptions.Start;
+					shapeView.VerticalOptions = LayoutOptions.Center;
+
+					multiBinding = new MultiBinding()
 					{
-						Converter = toggleColorConverter,
+						Bindings =
+						[
+							BindingHelper.CreateBinding(nameof(LegendItem.IsToggled), getter: static (LegendItem item) => item.IsToggled, mode: BindingMode.Default, converter:toggleColorConverter, converterParameter: shapeView),
+							BindingHelper.CreateBinding(nameof(LegendItem.IconBrush), getter: static (LegendItem item) => item.IconBrush)
+						],
+						Converter = new MultiBindingIconBrushConverter(),
 						ConverterParameter = shapeView
 					};
-					binding1 = new Binding(nameof(LegendItem.IconBrush));
-                    multiBinding = new MultiBinding()
-                    {
-                        Bindings = [binding, binding1],
-                        Converter = new MultiBindingIconBrushConverter(),
-                        ConverterParameter = shapeView
-                    };
 
-                    shapeView.SetBinding(SfShapeView.IconBrushProperty, multiBinding);
-                    shapeView.SetBinding(SfShapeView.ShapeTypeProperty, nameof(LegendItem.IconType));
-                    shapeView.SetBinding(SfShapeView.HeightRequestProperty, nameof(LegendItem.IconHeight));
-                    shapeView.SetBinding(SfShapeView.WidthRequestProperty, nameof(LegendItem.IconWidth));
-                    stack.Children.Add(shapeView);
+					shapeView.SetBinding(SfShapeView.IconBrushProperty, multiBinding);
+					shapeView.SetBinding(SfShapeView.ShapeTypeProperty, 
+						BindingHelper.CreateBinding(nameof(LegendItem.IconType), getter: static (LegendItem item) => item.IconType));
+					shapeView.SetBinding(SfShapeView.HeightRequestProperty, 
+						BindingHelper.CreateBinding(nameof(LegendItem.IconHeight), getter: static (LegendItem item) => item.IconHeight));
+					shapeView.SetBinding(SfShapeView.WidthRequestProperty, 
+						BindingHelper.CreateBinding(nameof(LegendItem.IconWidth), getter: static (LegendItem item) => item.IconWidth));
+					stack.Children.Add(shapeView);
                 }
 
                 Label label = CreateLabelView();
@@ -428,12 +428,18 @@ namespace Syncfusion.Maui.Toolkit
                 if (label != null)
                 {
                     label.VerticalTextAlignment = TextAlignment.Center;
-                    label.SetBinding(Label.TextProperty, nameof(LegendItem.Text));
-                    label.SetBinding(Label.TextColorProperty, nameof(LegendItem.ActualTextColor));
-                    label.SetBinding(Label.MarginProperty, nameof(LegendItem.TextMargin));
-                    label.SetBinding(Label.FontSizeProperty, nameof(LegendItem.FontSize));
-                    label.SetBinding(Label.FontFamilyProperty, nameof(LegendItem.FontFamily));
-                    label.SetBinding(Label.FontAttributesProperty, nameof(LegendItem.FontAttributes));
+					label.SetBinding(Label.TextProperty,
+						BindingHelper.CreateBinding(nameof(LegendItem.Text), getter: static (LegendItem item) => item.Text));
+					label.SetBinding(Label.TextColorProperty,
+						BindingHelper.CreateBinding(nameof(LegendItem.ActualTextColor), getter: static (LegendItem item) => item.ActualTextColor));
+					label.SetBinding(Label.MarginProperty,
+						BindingHelper.CreateBinding(nameof(LegendItem.TextMargin), getter: static (LegendItem item) => item.TextMargin));
+					label.SetBinding(Label.FontSizeProperty,
+						BindingHelper.CreateBinding(nameof(LegendItem.FontSize), getter: static (LegendItem item) => item.FontSize));
+					label.SetBinding(Label.FontFamilyProperty,
+						BindingHelper.CreateBinding(nameof(LegendItem.FontFamily), getter: static (LegendItem item) => item.FontFamily));
+					label.SetBinding(Label.FontAttributesProperty,
+						BindingHelper.CreateBinding(nameof(LegendItem.FontAttributes), getter: static (LegendItem item) => item.FontAttributes));
                     stack.Children.Add(label);
                 }
                 return stack;

--- a/maui/src/Core/Localization/LocalizationResourceAccessor.cs
+++ b/maui/src/Core/Localization/LocalizationResourceAccessor.cs
@@ -70,11 +70,12 @@ namespace Syncfusion.Maui.Toolkit.Localization
 		/// Initializes the default localization resource with the specified base name.
 		/// </summary>
 		/// <param name="baseName">The base name of the resource to initialize.</param>
-		public static void InitializeDefaultResource(string baseName)
+		/// /// <param name="resourceType">The optional type used to determine the assembly where resources are located. Defaults to the calling assembly if not specified.</param>/// 
+		public static void InitializeDefaultResource(string baseName, Type? resourceType = null)
 		{
 			if (LocalizationResourceAccessor.ResourceManager == null)
 			{
-				Assembly assembly = Assembly.GetCallingAssembly();
+				Assembly assembly = resourceType?.Assembly ?? Assembly.GetCallingAssembly();
 				LocalizationResourceAccessor.ResourceManager = new System.Resources.ResourceManager(baseName, assembly);
 				LocalizationResourceAccessor.Culture = new CultureInfo("en-US");
 			}

--- a/maui/src/Core/Theme/Resources/DarkThemeColors.xaml.cs
+++ b/maui/src/Core/Theme/Resources/DarkThemeColors.xaml.cs
@@ -3,7 +3,7 @@
 	/// <summary>
 	/// Dark theme resource dictionary.
 	/// </summary>
-	[XamlCompilation(XamlCompilationOptions.Skip)]
+	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class DarkThemeColors : SyncfusionThemeDictionary
 	{
 		/// <summary>

--- a/maui/src/Core/Theme/Resources/DefaultTheme.xaml.cs
+++ b/maui/src/Core/Theme/Resources/DefaultTheme.xaml.cs
@@ -3,7 +3,7 @@
 	/// <summary>
 	/// Dark theme resource dictionary.
 	/// </summary>
-	[XamlCompilation(XamlCompilationOptions.Skip)]
+	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class DefaultTheme : SyncfusionThemeDictionary
 	{
 		/// <summary>

--- a/maui/src/Core/Theme/Resources/LightThemeColors.xaml.cs
+++ b/maui/src/Core/Theme/Resources/LightThemeColors.xaml.cs
@@ -3,7 +3,7 @@
 	/// <summary>
 	/// Dark theme resource dictionary.
 	/// </summary>
-	[XamlCompilation(XamlCompilationOptions.Skip)]
+	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class LightThemeColors : SyncfusionThemeDictionary
 	{
 		/// <summary>

--- a/maui/src/Core/Theme/Resources/SyncfusionThemeDictionary.xaml.cs
+++ b/maui/src/Core/Theme/Resources/SyncfusionThemeDictionary.xaml.cs
@@ -3,7 +3,7 @@
 	/// <summary>
 	/// ThemeDictionary class for Syncfusion in which controls themes are to be included.
 	/// </summary>
-	[XamlCompilation(XamlCompilationOptions.Skip)]
+	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class SyncfusionThemeDictionary : ResourceDictionary
 	{
 		/// <summary>

--- a/maui/src/Core/Theme/StaticThemeResourceExtension.cs
+++ b/maui/src/Core/Theme/StaticThemeResourceExtension.cs
@@ -13,10 +13,11 @@ namespace Syncfusion.Maui.Toolkit.Themes
 	/// ***
 	/// </example>
 
-	[Microsoft.Maui.Controls.Internals.Preserve(AllMembers = true)]
-
 	[ContentProperty(nameof(ResourceKey))]
 
+#if NET9_0
+	[RequireService([typeof(IProvideValueTarget)])]
+#endif
 	public class StaticThemeResourceExtension : IMarkupExtension
 	{
 		/// <summary>
@@ -36,9 +37,9 @@ namespace Syncfusion.Maui.Toolkit.Themes
 				return null;
 			}
 
-			if (serviceProvider.GetService(typeof(IRootObjectProvider)) is IRootObjectProvider rootObjectProvider)
+			if (serviceProvider.GetService(typeof(IProvideValueTarget)) is IProvideValueTarget provideValueTarget)
 			{
-				if (rootObjectProvider.RootObject is ResourceDictionary themeResourceDictionary)
+				if (provideValueTarget.TargetObject is ResourceDictionary themeResourceDictionary)
 				{
 					var mergedDictionaries = themeResourceDictionary.MergedDictionaries ?? Enumerable.Empty<ResourceDictionary>();
 

--- a/maui/src/Core/Theme/ThemeElement.cs
+++ b/maui/src/Core/Theme/ThemeElement.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Maui.Controls.Internals;
 
 namespace Syncfusion.Maui.Toolkit.Themes
@@ -49,6 +50,7 @@ namespace Syncfusion.Maui.Toolkit.Themes
 		/// <summary>
 		/// The implicit style property.
 		/// </summary>
+		[UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "<Pending>")]
 		private static readonly BindableProperty ImplicitStyleProperty = BindableProperty.Create(
 			"ImplicitStyle",
 			typeof(Style),
@@ -149,6 +151,7 @@ namespace Syncfusion.Maui.Toolkit.Themes
 		/// <param name="bindable">Bindable.</param>
 		/// <param name="oldValue">Old value.</param>
 		/// <param name="newValue">New value.</param>
+		[RequiresUnreferencedCode("The IsOverriddenMethod method is not trim compatible")]
 		private static void OnImplicitStyleChanged(BindableObject bindable, object oldValue, object newValue)
 		{
 			if (bindable is Element element && newValue is Style style && !ApplyStyle(element, style))
@@ -173,6 +176,7 @@ namespace Syncfusion.Maui.Toolkit.Themes
 		/// <param name="element"></param>
 		/// <param name="style"></param>
 		/// <returns></returns>
+		[RequiresUnreferencedCode("The IsOverriddenMethod method is not trim compatible")]
 		private static bool ApplyStyle(Element element, Style style)
 		{
 			var applyMethodInfo = typeof(Style).GetInterface("IStyle")?.GetMethod("Apply");

--- a/maui/src/Core/Theme/ThemeElement.cs
+++ b/maui/src/Core/Theme/ThemeElement.cs
@@ -50,7 +50,6 @@ namespace Syncfusion.Maui.Toolkit.Themes
 		/// <summary>
 		/// The implicit style property.
 		/// </summary>
-		[UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "<Pending>")]
 		private static readonly BindableProperty ImplicitStyleProperty = BindableProperty.Create(
 			"ImplicitStyle",
 			typeof(Style),
@@ -151,7 +150,7 @@ namespace Syncfusion.Maui.Toolkit.Themes
 		/// <param name="bindable">Bindable.</param>
 		/// <param name="oldValue">Old value.</param>
 		/// <param name="newValue">New value.</param>
-		[RequiresUnreferencedCode("The IsOverriddenMethod method is not trim compatible")]
+		[UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "<Pending>")]
 		private static void OnImplicitStyleChanged(BindableObject bindable, object oldValue, object newValue)
 		{
 			if (bindable is Element element && newValue is Style style && !ApplyStyle(element, style))
@@ -176,7 +175,7 @@ namespace Syncfusion.Maui.Toolkit.Themes
 		/// <param name="element"></param>
 		/// <param name="style"></param>
 		/// <returns></returns>
-		[RequiresUnreferencedCode("The IsOverriddenMethod method is not trim compatible")]
+		[RequiresUnreferencedCode("The ApplyStyle method is not trim compatible")]
 		private static bool ApplyStyle(Element element, Style style)
 		{
 			var applyMethodInfo = typeof(Style).GetInterface("IStyle")?.GetMethod("Apply");

--- a/maui/src/EffectsView/RippleEffectLayer.cs
+++ b/maui/src/EffectsView/RippleEffectLayer.cs
@@ -360,7 +360,7 @@ namespace Syncfusion.Maui.Toolkit.EffectsView
 			{
 				if (GetParent() != null && ((_drawable as View) as SfEffectsView) != null)
 				{
-					if ((GetParent() as View) is SfEffectsView effectView && ((effectView.TouchUpEffects == SfEffects.None || effectView.AutoResetEffects.GetAllItems().Contains(AutoResetEffects.Ripple) || effectView.TouchUpEffects == SfEffects.Ripple || effectView.TouchUpEffects.GetAllItems().Contains(SfEffects.Ripple) || effectView.TouchUpEffects.GetAllItems().Contains(SfEffects.None)) &&
+					if ((GetParent() as View) is SfEffectsView effectView && ((effectView.TouchUpEffects == SfEffects.None || effectView.AutoResetEffects.GetAllAutoResetEffectsItems().Contains(AutoResetEffects.Ripple) || effectView.TouchUpEffects == SfEffects.Ripple || effectView.TouchUpEffects.GetAllItems().Contains(SfEffects.Ripple) || effectView.TouchUpEffects.GetAllItems().Contains(SfEffects.None)) &&
 						(effectView.LongPressEffects.GetAllItems().Contains(SfEffects.None) || !effectView.LongPressHandled || effectView.LongPressEffects.GetAllItems().Contains(SfEffects.Ripple))))
 					{
 						effectView?.InvokeAnimationCompletedEvent();

--- a/maui/src/EffectsView/SfEffectsView.cs
+++ b/maui/src/EffectsView/SfEffectsView.cs
@@ -1503,7 +1503,7 @@ namespace Syncfusion.Maui.Toolkit.EffectsView
 		/// <param name="touchPoint">The touch point.</param>
 		void AddResetEffects(AutoResetEffects effects, Point touchPoint)
 		{
-			foreach (var effect in effects.GetAllItems().Select(v => (AutoResetEffects)v))
+			foreach (var effect in effects.GetAllAutoResetEffectsItems().Select(v => (AutoResetEffects)v))
 			{
 				if (effect == AutoResetEffects.None)
 				{
@@ -1931,7 +1931,7 @@ namespace Syncfusion.Maui.Toolkit.EffectsView
 							InvokeTouchUpEventAndCommand();
 						}
 					}
-					if (AutoResetEffects.GetAllItems().Contains(AutoResetEffects.Ripple))
+					if (AutoResetEffects.GetAllAutoResetEffectsItems().Contains(AutoResetEffects.Ripple))
 					{
 						if (_rippleEffectLayer != null)
 						{

--- a/maui/src/EffectsView/Utils.cs
+++ b/maui/src/EffectsView/Utils.cs
@@ -10,9 +10,25 @@
 		/// </summary>
 		/// <param name="targetEnum">Target enum.</param>
 		/// <returns>Available enum values.</returns>
-		internal static IEnumerable<Enum> GetAllItems(this Enum targetEnum)
+		internal static IEnumerable<Enum> GetAllItems(this SfEffects targetEnum)
 		{
-			foreach (Enum value in Enum.GetValues(targetEnum.GetType()))
+			foreach (Enum value in Enum.GetValues<SfEffects>())
+			{
+				//// If the flag value of the enum is zero, then the HasFlag method always returns true. Hence, the None is returned only if the value and the target enum is equals to None.
+				if (value.ToString() != "None" && targetEnum.HasFlag(value))
+				{
+					yield return value;
+				}
+				else if (value.ToString() == "None" && targetEnum.Equals(value))
+				{
+					yield return value;
+				}
+			}
+		}
+
+		internal static IEnumerable<Enum> GetAllAutoResetEffectsItems(this AutoResetEffects targetEnum)
+		{
+			foreach (Enum value in Enum.GetValues<AutoResetEffects>())
 			{
 				//// If the flag value of the enum is zero, then the HasFlag method always returns true. Hence, the None is returned only if the value and the target enum is equals to None.
 				if (value.ToString() != "None" && targetEnum.HasFlag(value))

--- a/maui/src/NumericEntry/SfNumericEntry.Methods.cs
+++ b/maui/src/NumericEntry/SfNumericEntry.Methods.cs
@@ -1128,7 +1128,7 @@ namespace Syncfusion.Maui.Toolkit.NumericEntry
 		void Initialize()
 		{
 			// Initialize resources for the numeric entry control.
-			SfNumericEntryResources.InitializeDefaultResource("Syncfusion.Maui.Toolkit.NumericEntry.Resources.SfNumericEntry");
+			SfNumericEntryResources.InitializeDefaultResource("Syncfusion.Maui.Toolkit.NumericEntry.Resources.SfNumericEntry", typeof(SfNumericEntry));
 
 			// Set the drawing order to ensure key elements are drawn correctly
 			DrawingOrder = DrawingOrder.AboveContent;

--- a/maui/src/NumericEntry/SfNumericEntry.Methods.cs
+++ b/maui/src/NumericEntry/SfNumericEntry.Methods.cs
@@ -340,10 +340,10 @@ namespace Syncfusion.Maui.Toolkit.NumericEntry
 			if (_textBox != null)
 			{
 				_textBox.BindingContext = this;
-				_textBox.SetBinding(SfEntryView.IsEnabledProperty, "IsEnabled");
-				_textBox.SetBinding(SfEntryView.IsVisibleProperty, "IsVisible");
-				_textBox.SetBinding(SfEntryView.CursorPositionProperty, "CursorPosition", BindingMode.TwoWay);
-				_textBox.SetBinding(SfEntryView.SelectionLengthProperty, "SelectionLength", BindingMode.TwoWay);
+				_textBox.SetBinding(SfEntryView.IsEnabledProperty, BindingHelper.CreateBinding(nameof(SfNumericEntry.IsEnabled), getter: static(SfNumericEntry entry) => entry.IsEnabled));	
+				_textBox.SetBinding(SfEntryView.IsVisibleProperty, BindingHelper.CreateBinding(nameof(SfNumericEntry.IsVisible), getter: static(SfNumericEntry entry) => entry.IsVisible));
+				_textBox.SetBinding(SfEntryView.CursorPositionProperty, BindingHelper.CreateBinding<SfNumericEntry, int>(nameof(SfNumericEntry.CursorPosition), getter: entry => entry.CursorPosition, setter: (entry, value) => entry.CursorPosition = value, mode: BindingMode.TwoWay));
+				_textBox.SetBinding(SfEntryView.SelectionLengthProperty, BindingHelper.CreateBinding<SfNumericEntry, int>(nameof(SfNumericEntry.SelectionLength), getter: entry => entry.SelectionLength, setter: (entry, value) => entry.SelectionLength = value, mode: BindingMode.TwoWay));
 
 #if WINDOWS
 				if(_textBox.Text != null)

--- a/maui/src/NumericEntry/SfNumericEntry.cs
+++ b/maui/src/NumericEntry/SfNumericEntry.cs
@@ -754,7 +754,10 @@ namespace Syncfusion.Maui.Toolkit.NumericEntry
             _lineView3 = SetupLineView();
             _lineView4 = SetupLineView();
 
-            _toolbarView.AddSubviews(_minusButton, _separatorButton, _returnButton, _lineView1, _lineView2, _lineView3, _lineView4);
+            if (_minusButton != null && _separatorButton != null && _returnButton != null)
+            {
+                _toolbarView.AddSubviews(_minusButton, _separatorButton, _returnButton, _lineView1, _lineView2, _lineView3, _lineView4);
+            }
             _toolbarView.BackgroundColor = UIColor.FromRGB(249, 249, 249);
 
             _toolbarView.BringSubviewToFront(_lineView1);

--- a/maui/src/NumericEntry/SfNumericUpDown.cs
+++ b/maui/src/NumericEntry/SfNumericUpDown.cs
@@ -1118,8 +1118,8 @@ namespace Syncfusion.Maui.Toolkit.NumericUpDown
 			{
 				if (_isClearButtonVisible)
 				{
-					AddSemanticsNode(_clearButtonRectF, 1, "Clear button");
-				}
+				AddSemanticsNode(_clearButtonRectF, 1, "Clear button");
+			}
 
 				AddSemanticsNode(upButtonRectF, 2, "Up button", upbuttonstate);
 				AddSemanticsNode(downButtonRectF, 3, "Down button", downbuttonstate);
@@ -1132,7 +1132,7 @@ namespace Syncfusion.Maui.Toolkit.NumericUpDown
 				if (_isClearButtonVisible)
 				{
 					AddSemanticsNode(_clearButtonRectF, 3, "Clear button");
-				}
+			}
 			}
 			else
 			{
@@ -1141,7 +1141,7 @@ namespace Syncfusion.Maui.Toolkit.NumericUpDown
 				if (_isClearButtonVisible)
 				{
 					AddSemanticsNode(_clearButtonRectF, 2, "Clear button");
-				}
+			}
 
 				AddSemanticsNode(downButtonRectF, 3, "Down button", downbuttonstate);
 			}
@@ -1320,7 +1320,7 @@ namespace Syncfusion.Maui.Toolkit.NumericUpDown
 			if (await IsLongPressActivate(StartDelay))
 			{
 				await RecursivePressedAsync(this);
-			}
+		}
 		}
 
 		/// <summary>
@@ -1354,7 +1354,7 @@ namespace Syncfusion.Maui.Toolkit.NumericUpDown
 		/// <param name="numericUpdown">The numericupdown instance</param>
 		/// <returns></returns>
 		static async Task RecursivePressedAsync(SfNumericUpDown numericUpdown)
-		{
+    	{
 			numericUpdown.HandleUpDownPressed();
 			numericUpdown.InitializeTokenSource();
 
@@ -1362,8 +1362,8 @@ namespace Syncfusion.Maui.Toolkit.NumericUpDown
 			// If the delay was completed and not cancelled
 			if (await numericUpdown.IsLongPressActivate(ContinueDelay))
 			{
-				await SfNumericUpDown.RecursivePressedAsync(numericUpdown);
-			}
+        	await SfNumericUpDown.RecursivePressedAsync(numericUpdown);
+    	}
 		}
 
 		/// <summary>
@@ -1897,11 +1897,7 @@ namespace Syncfusion.Maui.Toolkit.NumericUpDown
 		/// <param name="path">The path of the property in the data context to bind to.</param>
 		static void SetupViewBinding(View view, string path)
 		{
-			view.SetBinding(SfNumericEntry.IsVisibleProperty, new Binding
-			{
-				Source = view,
-				Path = path
-			});
+ 			view.SetBinding(SfNumericEntry.IsVisibleProperty, BindingHelper.CreateBinding(nameof(View.IsVisible), getter: static(View view) => view.IsVisible, source:view));
 		}
 
 		/// <summary>

--- a/maui/src/SegmentedControl/SfSegmentedControl.cs
+++ b/maui/src/SegmentedControl/SfSegmentedControl.cs
@@ -84,7 +84,7 @@ namespace Syncfusion.Maui.Toolkit.SegmentedControl
 		/// </summary>
 		public SfSegmentedControl()
 		{
-			SfSegmentedResources.InitializeDefaultResource("Syncfusion.Maui.Buttons.SegmentedControl.Resources.SfSegmentedControl");
+			SfSegmentedResources.InitializeDefaultResource("Syncfusion.Maui.Toolkit.SegmentedControl.Resources.SfSegmentedControl",typeof(SfSegmentedControl));
 			ThemeElement.InitializeThemeResources(this, "SfSegmentedControlTheme");
 			SetDynamicResource(HoveredBackgroundProperty, "SfSegmentedControlHoveredBackground");
 			SetDynamicResource(KeyboardFocusStrokeProperty, "SfSegmentedControlKeyboardFocusStroke");

--- a/maui/src/Syncfusion.Maui.Toolkit.csproj
+++ b/maui/src/Syncfusion.Maui.Toolkit.csproj
@@ -44,6 +44,10 @@
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net9.0-android' or '$(TargetFramework)' == 'net9.0-ios' or '$(TargetFramework)' == 'net9.0-maccatalyst' or '$(TargetFramework)' == 'net9.0-windows10.0.19041.0'">
+		<IsAotCompatible>true</IsAotCompatible>
+	</PropertyGroup>
+
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0-android' OR '$(TargetFramework)' == 'net9.0-android' ">
 		<AndroidGenerateResourceDesigner>false</AndroidGenerateResourceDesigner>
 		<AndroidUseIntermediateDesignerFile>false</AndroidUseIntermediateDesignerFile>
@@ -115,5 +119,5 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
-  
+
 </Project>

--- a/maui/src/TabView/Control/HorizontalContent/SfHorizontalContent.cs
+++ b/maui/src/TabView/Control/HorizontalContent/SfHorizontalContent.cs
@@ -274,13 +274,13 @@ namespace Syncfusion.Maui.Toolkit.TabView
 		/// <returns>It returns the size</returns>
 		protected override Size MeasureContent(double widthConstraint, double heightConstraint)
 		{
-			if (widthConstraint > 0 && widthConstraint != double.PositiveInfinity)
+			if (widthConstraint > 0 && widthConstraint != double.PositiveInfinity )
 			{
 				ContentWidth = widthConstraint;
 				UpdateTabItemContentSize();
 				UpdateTabItemContentPosition();
 			}
-			if (heightConstraint > 0 && heightConstraint != double.PositiveInfinity)
+			if (heightConstraint > 0 && heightConstraint != double.PositiveInfinity )
 			{
 				UpdateTabItemContentSize();
 				UpdateTabItemContentPosition();
@@ -508,7 +508,7 @@ namespace Syncfusion.Maui.Toolkit.TabView
 				else
 				{
 					SfGrid parentGrid = [];
-					parentGrid.SetBinding(SfGrid.IsVisibleProperty, new Binding("IsVisible", source: item));
+					parentGrid.SetBinding(SfGrid.IsVisibleProperty, BindingHelper.CreateBinding(nameof(SfTabItem.IsVisible), getter: static (SfTabItem item)=> item.IsVisible, source: item));
 					if (index >= 0)
 					{
 						_horizontalStackLayout?.Children.Insert(index, parentGrid);
@@ -541,7 +541,7 @@ namespace Syncfusion.Maui.Toolkit.TabView
 				Style = new Style(typeof(SfGrid))
 			};
 			parentGrid.Children.Add(item.Content);
-			parentGrid.SetBinding(Grid.IsVisibleProperty, new Binding(nameof(SfTabItem.IsVisible), source: item));
+			parentGrid.SetBinding(Grid.IsVisibleProperty, BindingHelper.CreateBinding(nameof(SfTabItem.IsVisible), getter: static (SfTabItem item) => item.IsVisible, source: item));
 			return parentGrid;
 		}
 

--- a/maui/src/TabView/Control/SfTabBar.cs
+++ b/maui/src/TabView/Control/SfTabBar.cs
@@ -939,7 +939,7 @@ namespace Syncfusion.Maui.Toolkit.TabView
             {
                 Style = new Style(typeof(SfGrid))
             };
-            touchEffectGrid.SetBinding(SfGrid.IsVisibleProperty, new Binding("IsVisible", source: item));
+            touchEffectGrid.SetBinding(SfGrid.IsVisibleProperty, BindingHelper.CreateBinding(nameof(SfTabItem.IsVisible), getter: static (SfTabItem item) => item.IsVisible, source: item));
 
             CalculateTabItemWidth();
 

--- a/maui/src/TabView/Styles/TabViewMaterialVisualStyle.cs
+++ b/maui/src/TabView/Styles/TabViewMaterialVisualStyle.cs
@@ -319,27 +319,27 @@ namespace Syncfusion.Maui.Toolkit.TabView
         void SetBinding()
         {
             BindingContext = Parent;
-            _image?.SetBinding(SfImage.SourceProperty, nameof(SfTabItem.ImageSource));
+            _image?.SetBinding(SfImage.SourceProperty, BindingHelper.CreateBinding(nameof(SfTabItem.ImageSource), getter: static (SfTabItem item) => item.ImageSource));
 
             SetHeaderBinding();
 
-            this.SetBinding(TabViewMaterialVisualStyle.ImagePositionProperty, nameof(SfTabItem.ImagePosition), BindingMode.TwoWay);
-            _horizontalLayout?.SetBinding(StackBase.SpacingProperty, nameof(SfTabItem.ImageTextSpacing));
-            _verticalLayout?.SetBinding(StackBase.SpacingProperty, nameof(SfTabItem.ImageTextSpacing));
-			_image.SetBinding(SfImage.WidthRequestProperty, "ImageSize");
-			_image.SetBinding(SfImage.HeightRequestProperty, "ImageSize");
+            this.SetBinding(TabViewMaterialVisualStyle.ImagePositionProperty, BindingHelper.CreateBinding(nameof(SfTabItem.ImagePosition), getter: static (SfTabItem item) => item.ImagePosition, mode: BindingMode.TwoWay));
+            _horizontalLayout?.SetBinding(StackBase.SpacingProperty, BindingHelper.CreateBinding(nameof(SfTabItem.ImageTextSpacing), getter: static (SfTabItem item) => item.ImageTextSpacing));
+            _verticalLayout?.SetBinding(StackBase.SpacingProperty, BindingHelper.CreateBinding(nameof(SfTabItem.ImageTextSpacing), getter: static (SfTabItem item) => item.ImageTextSpacing));
+			_image?.SetBinding(SfImage.WidthRequestProperty, BindingHelper.CreateBinding(nameof(SfTabItem.ImageSize), getter: static (SfTabItem item) => item.ImageSize));
+			_image?.SetBinding(SfImage.HeightRequestProperty, BindingHelper.CreateBinding(nameof(SfTabItem.ImageSize), getter: static (SfTabItem item) => item.ImageSize));
 		}
 
         void SetHeaderBinding()
         {
             if (_header != null)
             {
-                _header.SetBinding(SfLabel.TextProperty, nameof(SfTabItem.Header), BindingMode.OneWay);
-                _header.SetBinding(SfLabel.TextColorProperty, nameof(SfTabItem.TextColor));
-                _header.SetBinding(SfLabel.FontSizeProperty, nameof(SfTabItem.FontSize));
-                _header.SetBinding(SfLabel.FontAttributesProperty, nameof(SfTabItem.FontAttributes));
-                _header.SetBinding(SfLabel.FontFamilyProperty, nameof(SfTabItem.FontFamily));
-                _header.SetBinding(SfLabel.FontAutoScalingEnabledProperty, nameof(SfTabItem.FontAutoScalingEnabled));
+                _header.SetBinding(SfLabel.TextProperty, BindingHelper.CreateBinding(nameof(SfTabItem.Header), getter: static (SfTabItem item) => item.Header, mode: BindingMode.OneWay));
+                _header.SetBinding(SfLabel.TextColorProperty, BindingHelper.CreateBinding(nameof(SfTabItem.TextColor), getter: static (SfTabItem item) => item.TextColor));
+                _header.SetBinding(SfLabel.FontSizeProperty, BindingHelper.CreateBinding(nameof(SfTabItem.FontSize), getter: static (SfTabItem item) => item.FontSize));
+                _header.SetBinding(SfLabel.FontAttributesProperty, BindingHelper.CreateBinding(nameof(SfTabItem.FontAttributes), getter: static (SfTabItem item) => item.FontAttributes));
+                _header.SetBinding(SfLabel.FontFamilyProperty, BindingHelper.CreateBinding(nameof(SfTabItem.FontFamily), getter: static (SfTabItem item) => item.FontFamily));
+                _header.SetBinding(SfLabel.FontAutoScalingEnabledProperty, BindingHelper.CreateBinding(nameof(SfTabItem.FontAutoScalingEnabled), getter: static (SfTabItem item) => item.FontAutoScalingEnabled));
             }
         }
 

--- a/maui/src/Themes/SfBottomSheetStyle.xaml.cs
+++ b/maui/src/Themes/SfBottomSheetStyle.xaml.cs
@@ -5,6 +5,7 @@ namespace Syncfusion.Maui.Toolkit.BottomSheet;
 /// <summary>
 /// SfBottomSheetStyle provides a set of predefined styles for SfBottomSheet control.
 /// </summary>
+[XamlCompilation(XamlCompilationOptions.Compile)]
 public partial class SfBottomSheetStyle : ResourceDictionary
 {
     /// <summary>

--- a/maui/src/Themes/SfButtonStyles.xaml.cs
+++ b/maui/src/Themes/SfButtonStyles.xaml.cs
@@ -3,6 +3,7 @@ namespace Syncfusion.Maui.Toolkit.Buttons;
 /// <summary>
 /// SfButtonStyles class provides a set of predefined styles for SfButton control.
 /// </summary>
+[XamlCompilation(XamlCompilationOptions.Compile)]
 public partial class SfButtonStyles : ResourceDictionary
 {
 	/// <summary>

--- a/maui/src/Themes/SfCalendarStyles.xaml.cs
+++ b/maui/src/Themes/SfCalendarStyles.xaml.cs
@@ -5,6 +5,7 @@ using Microsoft.Maui.Controls;
 /// <summary>
 /// Represents <see cref="SfCalendarStyles"/> class.
 /// </summary>
+[XamlCompilation(XamlCompilationOptions.Compile)]
 public partial class SfCalendarStyles : ResourceDictionary
 {
     #region Constructor

--- a/maui/src/Themes/SfChipGroupStyles.xaml.cs
+++ b/maui/src/Themes/SfChipGroupStyles.xaml.cs
@@ -4,6 +4,7 @@ namespace Syncfusion.Maui.Toolkit.Chips
 	/// Represents a collection of styles for the <see cref="SfChipGroup"/> control.
 	/// </summary>
 	/// <exclude/>
+	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class SfChipGroupStyles : ResourceDictionary
 	{
 		/// <summary>

--- a/maui/src/Themes/SfChipStyles.xaml.cs
+++ b/maui/src/Themes/SfChipStyles.xaml.cs
@@ -4,6 +4,7 @@ namespace Syncfusion.Maui.Toolkit.Chips
 	/// Represents a collection of styles for the <see cref="SfChip"/> control.
 	/// </summary>
 	/// <exclude/>
+	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class SfChipStyles : ResourceDictionary
 	{
 		/// <summary>

--- a/maui/src/Themes/SfEffectsViewStyles.xaml.cs
+++ b/maui/src/Themes/SfEffectsViewStyles.xaml.cs
@@ -3,6 +3,7 @@ namespace Syncfusion.Maui.Toolkit.EffectsView
 	/// <summary>
 	/// Initializing SfEffectsViewStyles class
 	/// </summary>
+	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class SfEffectsViewStyles : ResourceDictionary
 	{
 		/// <summary>

--- a/maui/src/Themes/SfNavigationDrawerStyle.xaml.cs
+++ b/maui/src/Themes/SfNavigationDrawerStyle.xaml.cs
@@ -3,6 +3,7 @@ namespace Syncfusion.Maui.Toolkit.NavigationDrawer
 	/// <summary>
 	/// SfNavigationDrawerStyle provides a set of predefined styles for SfNavigationDrawer control.
 	/// </summary>
+	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class SfNavigationDrawerStyle : ResourceDictionary
 	{
 		/// <summary>

--- a/maui/src/Themes/SfNumericEntryStyles.xaml.cs
+++ b/maui/src/Themes/SfNumericEntryStyles.xaml.cs
@@ -5,6 +5,7 @@ namespace Syncfusion.Maui.Toolkit.NumericEntry;
 /// <summary>
 /// Initializing SfNumericEntryStyles class
 /// </summary>
+[XamlCompilation(XamlCompilationOptions.Compile)]
 public partial class SfNumericEntryStyles : ResourceDictionary
 {
 	/// <summary>

--- a/maui/src/Themes/SfNumericUpDownStyles.xaml.cs
+++ b/maui/src/Themes/SfNumericUpDownStyles.xaml.cs
@@ -5,6 +5,7 @@ namespace Syncfusion.Maui.Toolkit.NumericUpDown;
 /// <summary>
 /// Initializes the SfNumericUpDownStyles class.
 /// </summary>
+[XamlCompilation(XamlCompilationOptions.Compile)]
 public partial class SfNumericUpDownStyles : ResourceDictionary
 {
 	/// <summary>

--- a/maui/src/Themes/SfPullToRefreshStyles.xaml.cs
+++ b/maui/src/Themes/SfPullToRefreshStyles.xaml.cs
@@ -4,6 +4,7 @@ namespace Syncfusion.Maui.Toolkit.PullToRefresh
 	/// Dictionary for theming the pulltorefresh control.
 	/// </summary>
 	/// <exclude/>
+	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class SfPullToRefreshStyles : ResourceDictionary
 	{
 		/// <summary>

--- a/maui/src/Themes/SfSegmentedControlStyles.xaml.cs
+++ b/maui/src/Themes/SfSegmentedControlStyles.xaml.cs
@@ -3,6 +3,7 @@ namespace Syncfusion.Maui.Toolkit.SegmentedControl
 	/// <summary>
 	/// Represents a class which is used to styles.
 	/// </summary>
+	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class SfSegmentedControlStyles : ResourceDictionary
 	{
 		/// <summary>

--- a/maui/src/Themes/SfShimmerStyles.xaml.cs
+++ b/maui/src/Themes/SfShimmerStyles.xaml.cs
@@ -5,6 +5,7 @@ namespace Syncfusion.Maui.Toolkit.Shimmer
 	/// Shimmer theme resource dictionary.
 	/// </summary>
 	/// <exclude/>
+	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class SfShimmerStyles : ResourceDictionary
 	{
 		/// <summary>

--- a/maui/src/Themes/SfTabViewStyles.xaml.cs
+++ b/maui/src/Themes/SfTabViewStyles.xaml.cs
@@ -4,6 +4,7 @@ namespace Syncfusion.Maui.Toolkit.TabView
 	/// <summary>
 	/// Represents a collection of styles and resources used in the <see cref="SfTabView"/> control for consistent theming and styling.
 	/// </summary>
+	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class SfTabViewStyles : ResourceDictionary
 	{
 		/// <summary>

--- a/maui/src/Themes/SfTextInputLayoutStyles.xaml.cs
+++ b/maui/src/Themes/SfTextInputLayoutStyles.xaml.cs
@@ -4,6 +4,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 	/// Initiates <see cref="SfTextInputLayout"/> class.
 	/// </summary>
 	/// <exclude/>
+	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class SfTextInputLayoutStyles : ResourceDictionary
 	{
 		/// <summary>


### PR DESCRIPTION
### Description of Change

Enable .NET Native AOT (Ahead-of-Time) compilation and Trimming support for core controls to improve application startup time, reduce binary size, and enhance runtime performance.

### Analysis and design

 Trimming: Removes unused code from the final application, reducing the application size
 AOT Compilation: Compiles code ahead of time rather than at runtime, improving startup performance
 Analyzers: Help identify compatibility issues early in development

### Screenshots

NA
