### PR TITLE
Fix the chart axis label overlapping the chart area when perform navigation.

### DIFF
--- a/maui/src/Charts/Utils/ChartUtils.cs
+++ b/maui/src/Charts/Utils/ChartUtils.cs
@@ -84,6 +84,11 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				return handler.GetFontManager();
 			}
 
+			if (IPlatformApplication.Current != null)
+			{
+				return IPlatformApplication.Current.Services.GetRequiredService<IFontManager>();
+			}
+
 			return default;
 		}
 


### PR DESCRIPTION
### Root Cause of the Issue

The issue occurred because the text measure font manager wasn't set when the chart view handler was null, especially after navigating back to the base view. This caused the chart axis labels to overlap the chart area.

### Description of Change

We fixed the issue by implementing a fallback to provide a default font manager when the chart view handler is null. This ensures the axis labels are always measured and rendered correctly, even after navigation.

### Issues Fixed

Fixes: https://github.com/syncfusion/maui-toolkit/issues/85

### Screenshots

#### Before:

https://github.com/user-attachments/assets/73b58518-927b-4b20-be88-00c8c40120fc

#### After:

https://github.com/user-attachments/assets/0b1e0301-75dd-4f55-9e10-db95cf401bb8
