### PR TITLE
Implement the Fast Scatter series support in the Cartesian Chart in MAUI Toolkit

### DIFF
--- a/maui/samples/Gallery/SampleList/CartesianChartSamplesList.xml
+++ b/maui/samples/Gallery/SampleList/CartesianChartSamplesList.xml
@@ -57,6 +57,8 @@
 			  </CardLayout>
 		  </SubCategory>
 
+		  <Sample Title="Fast Scatter" StatusTag="New" SampleName="FastScatterChart" SearchTags="scatter, scatter chart, scatter plot, fast scatter, fast scatter chart, fast scatter plot, high performance chart"/>
+
 		  <SubCategory Title="Spline">
 			  <CardLayout>
 				  <Sample Title="Default spline chart" SampleName="SplineChart" Description="This sample demonstrates the default spline chart. The marker, tooltip, and legend are enabled in the model. Tap the data point to view information about that data point in a tooltip." SearchTags="spline"/>

--- a/maui/samples/Gallery/Samples/CartesianChart/FastScatterChart/FastScatterChart.xaml
+++ b/maui/samples/Gallery/Samples/CartesianChart/FastScatterChart/FastScatterChart.xaml
@@ -1,0 +1,54 @@
+<localCore:SampleView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Syncfusion.Maui.ControlsGallery.CartesianChart.SfCartesianChart.FastScatterChart"
+             xmlns:local="clr-namespace:Syncfusion.Maui.ControlsGallery.CartesianChart.SfCartesianChart"
+             xmlns:localCore="clr-namespace:Syncfusion.Maui.ControlsGallery;assembly=Syncfusion.Maui.ControlsGallery"
+             xmlns:chart="clr-namespace:Syncfusion.Maui.Toolkit.Charts;assembly=Syncfusion.Maui.Toolkit">
+
+  <localCore:SampleView.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <local:CartesianChartColorResources/>
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </localCore:SampleView.Resources>
+
+  <localCore:SampleView.Content>
+    <chart:SfCartesianChart x:Name="fastScatterChart" PaletteBrushes="{AppThemeBinding Light={StaticResource PaletteBrushesDark}, Dark={StaticResource PaletteBrushesDark}}" HorizontalOptions="Fill" VerticalOptions="Fill">
+      <chart:SfCartesianChart.BindingContext>
+        <local:FastScatterSeriesViewModel/>
+      </chart:SfCartesianChart.BindingContext>
+      <chart:SfCartesianChart.Legend>
+        <chart:ChartLegend ToggleSeriesVisibility="True"/>
+      </chart:SfCartesianChart.Legend>
+      <chart:SfCartesianChart.Title>
+        <Label Text="Transportation Network Travel Speed Across City Clusters" LineBreakMode="WordWrap" Margin="0" HorizontalOptions="Fill" HorizontalTextAlignment="Center" VerticalOptions="Center" FontSize="16" />
+      </chart:SfCartesianChart.Title>
+      <chart:SfCartesianChart.XAxes>
+        <chart:NumericalAxis Maximum="1500" Interval="100" EdgeLabelsDrawingMode="Shift" ShowMajorGridLines="False" >
+          <chart:NumericalAxis.Title>
+            <chart:ChartAxisTitle Text="Euclidean Distance (km)"></chart:ChartAxisTitle>
+          </chart:NumericalAxis.Title>
+        </chart:NumericalAxis>
+      </chart:SfCartesianChart.XAxes>
+      <chart:SfCartesianChart.YAxes>
+        <chart:NumericalAxis Interval="30" ShowMajorGridLines="False" >
+          <chart:NumericalAxis.Title>
+            <chart:ChartAxisTitle Text="Transportation Network Travel Speed (km/h)" ></chart:ChartAxisTitle>
+          </chart:NumericalAxis.Title>
+        </chart:NumericalAxis>
+      </chart:SfCartesianChart.YAxes>
+      <chart:FastScatterSeries ItemsSource="{Binding AutomobileTravelData}" 
+                               XBindingPath="Value" 
+                               YBindingPath="Size" 
+                               EnableTooltip="True"
+                               Label="Train travel"/>
+
+      <chart:FastScatterSeries ItemsSource="{Binding TrainTravelData}" 
+                               XBindingPath="Value" 
+                               YBindingPath="Size" 
+                               EnableTooltip="True"
+                               Label="Automobile travel"/>
+    </chart:SfCartesianChart>
+  </localCore:SampleView.Content>
+</localCore:SampleView>

--- a/maui/samples/Gallery/Samples/CartesianChart/FastScatterChart/FastScatterChart.xaml.cs
+++ b/maui/samples/Gallery/Samples/CartesianChart/FastScatterChart/FastScatterChart.xaml.cs
@@ -1,0 +1,16 @@
+namespace Syncfusion.Maui.ControlsGallery.CartesianChart.SfCartesianChart
+{
+	public partial class FastScatterChart : SampleView
+	{
+		public FastScatterChart()
+		{
+			InitializeComponent();
+		}
+
+		public override void OnDisappearing()
+		{
+			base.OnDisappearing();
+			fastScatterChart.Handler?.DisconnectHandler();
+		}
+	}
+}

--- a/maui/samples/Gallery/Samples/CartesianChart/FastScatterChart/FastScatterSeriesViewModel.cs
+++ b/maui/samples/Gallery/Samples/CartesianChart/FastScatterChart/FastScatterSeriesViewModel.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.ObjectModel;
+
+namespace Syncfusion.Maui.ControlsGallery.CartesianChart.SfCartesianChart
+{
+	public partial class FastScatterSeriesViewModel : BaseViewModel
+	{
+		public ObservableCollection<ChartDataModel> TrainTravelData { get; set; }
+		public ObservableCollection<ChartDataModel> AutomobileTravelData { get; set; }
+
+		public FastScatterSeriesViewModel()
+		{
+			TrainTravelData = new ObservableCollection<ChartDataModel>();
+			AutomobileTravelData = new ObservableCollection<ChartDataModel>();
+
+			for (int i = 1; i <= 2000; i++)
+			{
+				double distance = i * 0.7 + ((i % 15 - 7) * (i / 400.0));
+
+				double variationFactor = ((i / 5) % 5) * 3.0;
+				double increaseFactor = (i / 150.0);
+
+				double trainScatter = ((i % 9 - 4) * 3.2 + (i % 13 - 6) * 2.1 + variationFactor) * (1 + i / 800.0);
+				double trainSpeed = 12 + (Math.Log(i + 1) * 9) + (Math.Sin(i * 0.1) * 12) + trainScatter + increaseFactor * 5;
+
+				double autoScatter = ((i % 6 - 3) * 3.8 + (i % 10 - 5) * 2.5 + variationFactor) * (1 + i / 900.0);
+				double autoSpeed = 35 + (Math.Log(i + 1) * 11) + (Math.Cos(i * 0.15) * 10) + autoScatter + increaseFactor * 6;
+
+				TrainTravelData.Add(new ChartDataModel(distance, Math.Max(10, trainSpeed)));
+				AutomobileTravelData.Add(new ChartDataModel(distance, Math.Max(20, autoSpeed)));
+			}
+		}
+	}
+}

--- a/maui/src/Charts/Segment/FastScatterSegment.cs
+++ b/maui/src/Charts/Segment/FastScatterSegment.cs
@@ -1,0 +1,254 @@
+﻿namespace Syncfusion.Maui.Toolkit.Charts
+{
+	/// <summary>
+	/// Represents a segment of the <see cref="FastScatterSeries"/> chart, responsible for drawing the scatter and managing its visual appearance.
+	/// </summary>
+	public partial class FastScatterSegment : CartesianSegment
+	{
+		#region Fields
+
+		float _preXPos;
+		float _preYPos;
+		float _preXValue;
+		float _preYValue;
+		readonly List<PointF> _fastScatterPlottingPoints = [];
+		RectF _actualRectF;
+
+		#endregion
+
+		#region Internal Properties
+
+		internal List<double>? XValues { get; set; }
+		internal IList<double>? YValues { get; set; }
+
+		#endregion
+
+		#region Methods
+
+		#region Internal Methods
+
+		internal void SetData(List<double> xValues, IList<double> yValues)
+		{
+			if (Series is XYDataSeries series)
+			{
+				// Initialize min/max values
+				double xMin = double.MaxValue, xMax = double.MinValue, yMin = double.MaxValue, yMax = double.MinValue;
+				XValues = xValues;
+				YValues = yValues;
+				int dataCount = series.PointsCount;
+
+				if (dataCount == 0)
+				{
+					return;
+				}
+
+				// Adjust for indexed series by setting xMin/xMax
+				if (series.IsIndexed && dataCount > 0)
+				{
+					xMin = XValues[0];
+					xMax = XValues[dataCount - 1];
+				}
+
+				for (int i = 0; i < dataCount; i++)
+				{
+					// Ensure we are in range for both lists
+					if (i >= XValues.Count)
+					{
+						break;
+					}
+
+					double xValue = XValues[i];
+					double yValue = YValues[i];
+
+					// Mark as empty if any NaN values are encountered
+					if (double.IsNaN(xValue) || double.IsNaN(yValue))
+					{						
+						continue;
+					}
+
+					if (!series.IsIndexed)
+					{
+						// Use Math.Min/Max for cleaner comparisons
+						xMin = Math.Min(xMin, xValue);
+						xMax = Math.Max(xMax, xValue);
+					}
+
+					yMin = Math.Min(yMin, yValue);
+					yMax = Math.Max(yMax, yValue);
+				}
+
+				// Handle no valid entries scenario by setting NaNs
+				if (xMin == double.MaxValue)
+				{
+					xMin = double.NaN;
+				}
+
+				if (xMax == double.MinValue)
+				{
+					xMax = double.NaN;
+				}
+
+				if (yMin == double.MaxValue)
+				{
+					yMin = double.NaN;
+				}
+
+				if (yMax == double.MinValue)
+				{
+					yMax = double.NaN;
+				}
+
+				// Update series range
+				Series.XRange += new DoubleRange(xMin, xMax);
+				Series.YRange += new DoubleRange(yMin, yMax);
+			}
+		}
+
+		#endregion
+
+		#region Override Methods
+		/// <inheritdoc/>
+		protected internal override void OnLayout()
+		{
+			if (Series is FastScatterSeries series && series.ActualXAxis is ChartAxis xAxis && series.ActualYAxis is ChartAxis yAxis && XValues is not null && YValues is not null)
+			{
+				int dataCount = series.PointsCount;
+
+				var _xRange = xAxis.VisibleRange;
+				var _yRange = yAxis.VisibleRange;
+
+				double xStart = _xRange.Start;
+				double xEnd = _xRange.End;
+
+				double yStart = _yRange.Start;
+				double yEnd = _yRange.End;
+
+				_preXValue = (float)XValues[0];
+				_preYValue = (float)YValues[0];
+
+				_preXPos = series.TransformToVisibleX(_preXValue, _preYValue);
+				_preYPos = series.TransformToVisibleY(_preXValue, _preYValue);
+
+				_fastScatterPlottingPoints.Clear();
+
+				if (!series.IsIndexed)
+				{
+					for (int i = 1; i < dataCount; i++)
+					{
+						double xValue = XValues[i];
+						double yValue = YValues[i];
+
+						if (xEnd <= xValue && xStart >= XValues[i - 1])
+						{
+							float x = series.TransformToVisibleX(xValue, yValue);
+							float y = series.TransformToVisibleY(xValue, yValue);
+							_preXPos = series.TransformToVisibleX(XValues[i - 1], YValues[i - 1]);
+							_preYPos = series.TransformToVisibleY(XValues[i - 1], YValues[i - 1]);
+
+							_fastScatterPlottingPoints.Add(new PointF(_preXPos, _preYPos));
+
+							_preXPos = x;
+							_preYPos = y;
+							_preXValue = (float)xValue;
+							_preYValue = (float)yValue;
+						}
+						else if ((xValue <= xEnd && xValue >= xStart) || (yValue >= yStart && yValue <= yEnd))
+						{
+							float x = series.TransformToVisibleX(xValue, yValue);
+							float y = series.TransformToVisibleY(xValue, yValue);
+
+							_fastScatterPlottingPoints.Add(new PointF(_preXPos, _preYPos));
+
+							_preXPos = x;
+							_preYPos = y;
+							_preXValue = (float)xValue;
+							_preYValue = (float)yValue;
+						}
+					}
+				}
+				else
+				{
+					for (int i = 1; i < dataCount; i++)
+					{
+						double yValue = YValues[i];
+
+						if ((i <= xEnd + 1) && (i >= xStart - 1))
+						{
+							float x = series.TransformToVisibleX(i, yValue);
+							float y = series.TransformToVisibleY(i, yValue);
+
+							_fastScatterPlottingPoints.Add(new PointF(_preXPos, _preYPos));
+
+							_preXPos = x;
+							_preYPos = y;
+							_preXValue = (float)i;
+							_preYValue = (float)yValue;
+						}
+					}
+				}
+
+				if (_fastScatterPlottingPoints.Count != dataCount)
+				{
+					float lastX = series.TransformToVisibleX(XValues[dataCount - 1], YValues[dataCount - 1]);
+					float lastY = series.TransformToVisibleY(XValues[dataCount - 1], YValues[dataCount - 1]);
+					_fastScatterPlottingPoints.Add(new PointF(lastX, lastY));
+				}
+			}
+		}
+
+		/// <inheritdoc/>
+		protected internal override void Draw(ICanvas canvas)
+		{
+			if (Series is FastScatterSeries series)
+			{
+				float scatterHeight = (float)series.PointHeight;
+				float scatterWidth = (float)series.PointWidth;
+
+				float halfHeight = scatterHeight / 2;
+				float halfWidth = scatterWidth / 2;
+
+				if (HasStroke)
+				{
+					canvas.StrokeColor = Stroke.ToColor();
+					canvas.StrokeSize = (float)StrokeWidth;
+				}
+
+				if (series.Type == ShapeType.Circle)
+				{
+					foreach (var point in _fastScatterPlottingPoints)
+					{
+						if((double.IsNaN(point.Y) || double.IsNaN(point.X)))
+						{
+							continue;
+						}
+
+						_actualRectF = new RectF((float)point.X - halfWidth, point.Y - halfHeight, scatterWidth, scatterHeight);
+
+						canvas.SetFillPaint(Fill, _actualRectF);
+						canvas.FillEllipse(_actualRectF);
+
+						if (HasStroke)
+						{
+							canvas.DrawEllipse(_actualRectF);
+						}
+					}
+				}
+				else
+				{
+					foreach (var point in _fastScatterPlottingPoints)
+					{
+						_actualRectF = new RectF((float)point.X - halfWidth, point.Y - halfHeight, scatterWidth, scatterHeight);
+
+						canvas.SetFillPaint(Fill, _actualRectF);
+
+						canvas.DrawShape(_actualRectF, series.Type, HasStroke, false);
+					}
+
+				}
+			}
+		}
+
+		#endregion
+		#endregion
+	}
+}

--- a/maui/src/Charts/Series/FastLineSeries.cs
+++ b/maui/src/Charts/Series/FastLineSeries.cs
@@ -16,6 +16,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 	/// <para> <b>Data Label - </b> Data labels are used to display values related to a chart segment. To render the data labels, you need to set the <see cref="ChartSeries.ShowDataLabels"/> property as <b>true</b> in <see cref="FastLineSeries"/> class. To customize the chart data labels alignment, placement, and label styles, you need to create an instance of <see cref="CartesianDataLabelSettings"/> and set to the <see cref="CartesianSeries.DataLabelSettings"/> property.</para>
 	/// <para> <b>Animation - </b> To animate the series, set <b>True</b> to the <see cref="ChartSeries.EnableAnimation"/> property.</para>
 	/// <para> <b>LegendIcon - </b> To customize the legend icon using the <see cref="ChartSeries.LegendIcon"/> property.</para>
+	/// <para>The FastLineSeries does not support empty points.</para>
 	/// </remarks>
 	/// <example>
 	/// # [Xaml](#tab/tabid-1)

--- a/maui/src/Charts/Series/FastScatterSeries.cs
+++ b/maui/src/Charts/Series/FastScatterSeries.cs
@@ -1,0 +1,461 @@
+﻿using Syncfusion.Maui.Toolkit.Graphics.Internals;
+
+namespace Syncfusion.Maui.Toolkit.Charts
+{
+	/// <summary>
+	/// The <see cref="FastScatterSeries"/> is a special kind of scatter series that can render a collection with a large number of data points.
+	/// </summary>
+	/// <remarks>
+	/// <para>To render a series, create an instance of <see cref="FastScatterSeries"/> class, and add it to the <see cref="SfCartesianChart.Series"/> collection.</para>
+	/// 
+	/// <para>It provides options for <see cref="ChartSeries.Fill"/>, <see cref="XYDataSeries.StrokeWidth"/> to customize the appearance.</para>
+	/// 
+	/// <para> <b>EnableTooltip - </b> A tooltip displays information while tapping or mouse hovering above a segment. To display the tooltip on a chart, you need to set the <see cref="ChartSeries.EnableTooltip"/> property as <b>true</b> in <see cref="FastScatterSeries"/> class, and also refer <seealso cref="ChartBase.TooltipBehavior"/> property.</para>
+	/// <para> <b>LegendIcon - </b> To customize the legend icon using the <see cref="ChartSeries.LegendIcon"/> property.</para>
+	/// <para>Considering performance, animation, data labels, selection, and palette brushes are currently not supported for the <see cref="FastScatterSeries"/>.</para>
+	/// <para>The FastScatterSeries does not support empty points.</para>
+	/// </remarks>
+	/// <example>
+	/// # [Xaml](#tab/tabid-1)
+	/// <code><![CDATA[
+	///     <chart:SfCartesianChart>
+	///
+	///           <chart:SfCartesianChart.XAxes>
+	///               <chart:NumericalAxis/>
+	///           </chart:SfCartesianChart.XAxes>
+	///
+	///           <chart:SfCartesianChart.YAxes>
+	///               <chart:NumericalAxis/>
+	///           </chart:SfCartesianChart.YAxes>
+	///
+	///           <chart:SfCartesianChart.Series>
+	///               <chart:FastScatterSeries
+	///                   ItemsSource="{Binding Data}"
+	///                   XBindingPath="XValue"
+	///                   YBindingPath="YValue"/>
+	///           </chart:SfCartesianChart.Series>  
+	///           
+	///     </chart:SfCartesianChart>
+	/// ]]></code>
+	/// # [C#](#tab/tabid-2)
+	/// <code><![CDATA[
+	///     SfCartesianChart chart = new SfCartesianChart();
+	///     
+	///     NumericalAxis xAxis = new NumericalAxis();
+	///     NumericalAxis yAxis = new NumericalAxis();
+	///     
+	///     chart.XAxes.Add(xAxis);
+	///     chart.YAxes.Add(yAxis);
+	///     
+	///     ViewModel viewModel = new ViewModel();
+	/// 
+	///     FastScatterSeries series = new FastScatterSeries();
+	///     series.ItemsSource = viewModel.Data;
+	///     series.XBindingPath = "XValue";
+	///     series.YBindingPath = "YValue";
+	///     chart.Series.Add(series);
+	///     
+	/// ]]></code>
+	/// # [ViewModel](#tab/tabid-3)
+	/// <code><![CDATA[
+	///     public ObservableCollection<Model> Data { get; set; }
+	/// 
+	///     public ViewModel()
+	///     {
+	///        Data = new ObservableCollection<Model>();
+	///        Data.Add(new Model() { XValue = 10, YValue = 100 });
+	///        Data.Add(new Model() { XValue = 20, YValue = 150 });
+	///        Data.Add(new Model() { XValue = 30, YValue = 110 });
+	///        Data.Add(new Model() { XValue = 40, YValue = 230 });
+	///     }
+	/// ]]></code>
+	/// ***
+	/// </example>
+	public partial class FastScatterSeries : XYDataSeries, IDrawCustomLegendIcon
+	{
+		#region Bindable Properties
+
+		/// <summary>
+		/// Identifies the <see cref="PointHeight"/> bindable property.
+		/// </summary>
+		/// <remarks>
+		/// The <see cref="PointHeight"/> property defines the height of the fastscatter segment size.
+		/// </remarks>
+		public static readonly BindableProperty PointHeightProperty = BindableProperty.Create(nameof(PointHeight), typeof(double), typeof(FastScatterSeries), 5d, BindingMode.Default, null, OnScatterInvalidatePropertyChanged);
+
+		/// <summary>
+		/// Identifies the <see cref="PointWidth"/> bindable property.
+		/// </summary>
+		/// <remarks>
+		/// The <see cref="PointWidth"/> property defines the width of the fastscatter segment size.
+		/// </remarks>
+		public static readonly BindableProperty PointWidthProperty = BindableProperty.Create(nameof(PointWidth), typeof(double), typeof(FastScatterSeries), 5d, BindingMode.Default, null, OnScatterInvalidatePropertyChanged);
+
+		/// <summary>
+		/// Identifies the <see cref="Stroke"/> bindable property.
+		/// </summary>
+		/// <remarks>
+		/// The <see cref="Stroke"/> property helps to customize the stroke appearance of the fastscatter segment.
+		/// </remarks>
+		public static readonly BindableProperty StrokeProperty = BindableProperty.Create(nameof(Stroke), typeof(Brush), typeof(FastScatterSeries), null, BindingMode.Default, null, OnStrokeColorPropertyChanged);
+
+		/// <summary>
+		/// Identifies the <see cref="Type"/> bindable property.
+		/// </summary>
+		/// <remarks>
+		/// The <see cref="Type"/> property indicates the shape of the fastscatter segment.
+		/// </remarks>
+		public static readonly BindableProperty TypeProperty = BindableProperty.Create(nameof(Type), typeof(ShapeType), typeof(FastScatterSeries), ShapeType.Circle, BindingMode.Default, null, OnScatterInvalidatePropertyChanged);
+
+		#endregion
+
+		#region Public Properties
+
+		/// <summary>
+		/// Gets or sets a value that defines the height of the fastscatter segment size.
+		/// </summary>
+		/// <value>It accepts <c>double</c> values and its default value is 5.</value>
+		/// <example>
+		/// # [Xaml](#tab/tabid-4)
+		/// <code><![CDATA[
+		///     <chart:SfCartesianChart>
+		///
+		///     <!-- ... Eliminated for simplicity-->
+		///
+		///          <chart:FastScatterSeries ItemsSource = "{Binding Data}"
+		///                               XBindingPath = "XValue"
+		///                               YBindingPath = "YValue"
+		///                               PointHeight = "20"/>
+		///
+		///     </chart:SfCartesianChart>
+		/// ]]></code>
+		/// # [C#](#tab/tabid-5)
+		/// <code><![CDATA[
+		///     SfCartesianChart chart = new SfCartesianChart();
+		///     ViewModel viewModel = new ViewModel();
+		///
+		///     // Eliminated for simplicity
+		///
+		///     FastScatterSeries series = new FastScatterSeries()
+		///     {
+		///           ItemsSource = viewModel.Data,
+		///           XBindingPath = "XValue",
+		///           YBindingPath = "YValue",
+		///           PointHeight = 20,
+		///     };
+		///     
+		///     chart.Series.Add(series);
+		///
+		/// ]]></code>
+		/// ***
+		/// </example>
+		public double PointHeight
+		{
+			get { return (double)GetValue(PointHeightProperty); }
+			set { SetValue(PointHeightProperty, value); }
+		}
+
+		/// <summary>
+		/// Gets or sets a value that defines the width of the fastscatter segment size.
+		/// </summary>
+		/// <value>It accepts <c>double</c> values and its default value is 5.</value>
+		/// <example>
+		/// # [Xaml](#tab/tabid-4)
+		/// <code><![CDATA[
+		///     <chart:SfCartesianChart>
+		///
+		///     <!-- ... Eliminated for simplicity-->
+		///
+		///          <chart:FastScatterSeries ItemsSource = "{Binding Data}"
+		///                               XBindingPath = "XValue"
+		///                               YBindingPath = "YValue"
+		///                               PointWidth = "20"/>
+		///
+		///     </chart:SfCartesianChart>
+		/// ]]></code>
+		/// # [C#](#tab/tabid-5)
+		/// <code><![CDATA[
+		///     SfCartesianChart chart = new SfCartesianChart();
+		///     ViewModel viewModel = new ViewModel();
+		///
+		///     // Eliminated for simplicity
+		///
+		///     FastScatterSeries series = new FastScatterSeries()
+		///     {
+		///           ItemsSource = viewModel.Data,
+		///           XBindingPath = "XValue",
+		///           YBindingPath = "YValue",
+		///           PointWidth = 20,
+		///     };
+		///     
+		///     chart.Series.Add(series);
+		///
+		/// ]]></code>
+		/// ***
+		/// </example>
+		public double PointWidth
+		{
+			get { return (double)GetValue(PointWidthProperty); }
+			set { SetValue(PointWidthProperty, value); }
+		}
+
+		/// <summary>
+		/// Gets or sets a value to customize the stroke appearance of the fastscatter segment.
+		/// </summary>
+		/// <value>It accepts <see cref="Brush"/> values and its default value is null.</value>
+		/// <example>
+		/// # [Xaml](#tab/tabid-8)
+		/// <code><![CDATA[
+		///     <chart:SfCartesianChart>
+		///
+		///     <!-- ... Eliminated for simplicity-->
+		///
+		///          <chart:FastScatterSeries ItemsSource = "{Binding Data}"
+		///                               XBindingPath = "XValue"
+		///                               YBindingPath = "YValue"
+		///                               StrokeWidth = "2"
+		///                               Stroke = "Red" />
+		///
+		///     </chart:SfCartesianChart>
+		/// ]]>
+		/// </code>
+		/// # [C#](#tab/tabid-9)
+		/// <code><![CDATA[
+		///     SfCartesianChart chart = new SfCartesianChart();
+		///     ViewModel viewModel = new ViewModel();
+		///
+		///     // Eliminated for simplicity
+		///
+		///     FastScatterSeries series = new FastScatterSeries()
+		///     {
+		///           ItemsSource = viewModel.Data,
+		///           XBindingPath = "XValue",
+		///           YBindingPath = "YValue",
+		///           Stroke = new SolidColorBrush(Colors.Red),
+		///           StrokeWidth = 2,
+		///     };
+		///     
+		///     chart.Series.Add(series);
+		///
+		/// ]]>
+		/// </code>
+		/// ***
+		/// </example>
+		public Brush Stroke
+		{
+			get { return (Brush)GetValue(StrokeProperty); }
+			set { SetValue(StrokeProperty, value); }
+		}
+
+		/// <summary>
+		/// Gets or sets a value that indicates the shape of the fastscatter segment.
+		/// </summary>
+		/// <value>It accepts <see cref="ShapeType"/> values and its default value is <see cref="ShapeType.Circle"/>.</value>
+		/// <example>
+		/// # [Xaml](#tab/tabid-10)
+		/// <code><![CDATA[
+		///     <chart:SfCartesianChart>
+		///
+		///     <!-- ... Eliminated for simplicity-->
+		///
+		///          <chart:FastScatterSeries ItemsSource = "{Binding Data}"
+		///                               XBindingPath = "XValue"
+		///                               YBindingPath = "YValue"
+		///                               Type = "Diamond"/>
+		///
+		///     </chart:SfCartesianChart>
+		/// ]]></code>
+		/// # [C#](#tab/tabid-11)
+		/// <code><![CDATA[
+		///     SfCartesianChart chart = new SfCartesianChart();
+		///     ViewModel viewModel = new ViewModel();
+		///
+		///     // Eliminated for simplicity
+		///
+		///     FastScatterSeries series = new FastScatterSeries()
+		///     {
+		///           ItemsSource = viewModel.Data,
+		///           XBindingPath = "XValue",
+		///           YBindingPath = "YValue",
+		///           Type = ShapeType.Diamond,
+		///     };
+		///     
+		///     chart.Series.Add(series);
+		///
+		/// ]]></code>
+		/// ***
+		/// </example>
+		public ShapeType Type
+		{
+			get { return (ShapeType)GetValue(TypeProperty); }
+			set { SetValue(TypeProperty, value); }
+		}
+
+		#endregion
+
+		#region Constructor
+
+		/// <summary>
+		/// Initialize the constructor
+		/// </summary>
+		public FastScatterSeries() : base()
+		{
+
+		}
+		#endregion
+
+		#region Interface Implementation
+
+		void IDrawCustomLegendIcon.DrawSeriesLegend(ICanvas canvas, RectF rect, Brush fillColor, bool isSaveState)
+		{
+			if (isSaveState)
+			{
+				canvas.CanvasSaveState();
+			}
+
+			RectF circleRect1 = new(3, 6, 1, 1);
+			canvas.SetFillPaint(fillColor, circleRect1);
+			canvas.FillEllipse(circleRect1);
+
+			RectF circleRect2 = new(6, 3, 1, 1);
+			canvas.SetFillPaint(fillColor, circleRect2);
+			canvas.FillEllipse(circleRect2);
+
+			RectF circleRect3 = new(8, 6, 1, 1);
+			canvas.SetFillPaint(fillColor, circleRect3);
+			canvas.FillEllipse(circleRect3);
+
+			RectF circleRect4 = new(2, 2, 1, 1);
+			canvas.SetFillPaint(fillColor, circleRect4);
+			canvas.FillEllipse(circleRect4);
+
+			RectF circleRect5 = new(10, 2, 1, 1);
+			canvas.SetFillPaint(fillColor, circleRect5);
+			canvas.FillEllipse(circleRect5);
+
+			RectF circleRect6 = new(6, 10, 1, 1);
+			canvas.SetFillPaint(fillColor, circleRect6);
+			canvas.FillEllipse(circleRect6);
+
+			RectF circleRect7 = new(10, 9, 1, 1);
+			canvas.SetFillPaint(fillColor, circleRect7);
+			canvas.FillEllipse(circleRect7);
+
+			RectF circleRect8 = new(2, 10, 1, 1);
+			canvas.SetFillPaint(fillColor, circleRect8);
+			canvas.FillEllipse(circleRect8);
+
+			if (isSaveState)
+			{
+				canvas.CanvasRestoreState();
+			}
+		}
+
+		#endregion
+
+		#region Methods
+
+		#region Override Methods
+
+		/// <inheritdoc/>
+		protected override ChartSegment? CreateSegment()
+		{
+			return new FastScatterSegment();
+		}
+
+		internal override void SetStrokeColor(ChartSegment segment)
+		{
+			segment.Stroke = Stroke;
+		}
+
+		internal override void GenerateSegments(SeriesView seriesView)
+		{
+			var xValues = GetXValues();
+
+			if (xValues == null || xValues.Count == 0 || ActualData == null)
+			{
+				return;
+			}
+
+			if (_segments.Count == 0)
+			{
+				var segment = CreateSegment() as FastScatterSegment;
+
+				if (segment != null)
+				{
+					segment.Series = this;
+					segment.SeriesView = seriesView;
+					segment.Item = ActualData;
+					segment.SetData(xValues, YValues);
+					_segments.Add(segment);
+				}
+			}
+			else
+			{
+				foreach (FastScatterSegment segment in _segments)
+				{
+					segment.SetData(xValues, YValues);
+				}
+			}
+		}
+
+		/// <inheritdoc/>
+		public override int GetDataPointIndex(float pointX, float pointY)
+		{
+			RectF seriesBounds = AreaBounds;
+			float xPos = pointX - seriesBounds.Left;
+			float yPos = pointY - seriesBounds.Top;
+
+			foreach (FastScatterSegment segment in _segments)
+			{
+				var xValues = segment.XValues;
+				var yValues = segment.YValues;
+
+				if (xValues == null || yValues == null)
+				{
+					return -1;
+				}
+
+				for (int i = 0; i < xValues.Count; i++)
+				{
+					var xval = xValues[i];
+					var yval = yValues[i];
+					float xPoint = TransformToVisibleX(xval, yval);
+					float yPoint = TransformToVisibleY(xval, yval);
+
+					if (ChartSegment.IsRectContains(xPoint, yPoint, xPos, yPos, (float)StrokeWidth))
+					{
+						return i;
+					}
+				}
+			}
+
+			return -1;
+		}
+
+		#endregion
+
+		#region Private Methods
+
+		static void OnScatterInvalidatePropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (bindable is FastScatterSeries series)
+			{
+				series.InvalidateSeries();
+			}
+		}
+
+		static void OnStrokeColorPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (bindable is FastScatterSeries series)
+			{
+				series.UpdateStrokeColor();
+				series.InvalidateSeries();
+			}
+		}
+
+		#endregion
+
+		#endregion
+	}
+}


### PR DESCRIPTION
### Description ###

The Fast Scatter Series in .NET MAUI Charts to efficiently render large datasets with improved performance. Unlike the standard Scatter Series, the Fast Scatter Series is optimized for handling thousands or even millions of data points without compromising rendering speed or UI responsiveness.

### Purpose/benefits of the feature ###
- Performance: Faster rendering compared to traditional Scatter Series, especially when handling large datasets.
- Scalability: Capable of plotting millions of data points without performance degradation.
- Smooth Interactions: Provides a fluid user experience when zooming and panning.
- Optimized for Real-Time Data: Best suited for applications with frequently updating data points.

### ScreenShot ###

![Screenshot 2025-03-10 170925](https://github.com/user-attachments/assets/52ffad4f-bd04-4309-ae95-de81d1ac8498)

![Screenshot 2025-03-10 182306](https://github.com/user-attachments/assets/e67d0c06-4100-4e6c-9179-501a1589fa3e)
