### PR TITLE
Improve the touch interaction in Maui toolkit Navigation drawer.

### DIFF
--- a/maui/src/NavigationDrawer/SfNavigationDrawer.Android.cs
+++ b/maui/src/NavigationDrawer/SfNavigationDrawer.Android.cs
@@ -77,7 +77,7 @@ namespace Syncfusion.Maui.Toolkit.NavigationDrawer
 				switch (ev.Action)
 				{
 					case MotionEventActions.Down:
-						return HandleActionDown(currentTouchPoint);
+						return HandleActionDown(ev, currentTouchPoint);
 
 					case MotionEventActions.Up:
 						_initialPoint = new Point(0, 0);
@@ -95,18 +95,23 @@ namespace Syncfusion.Maui.Toolkit.NavigationDrawer
 
 		#region Private Methods
 
-		private bool HandleActionDown(Point currentTouchPoint)
+		private bool HandleActionDown(MotionEvent? ev, Point currentTouchPoint)
 		{
-			_downX = currentTouchPoint.X;
-			_downY = currentTouchPoint.Y;
-			_initialPoint = currentTouchPoint;
-
-			if (DrawerSettings.Position == Position.Left || DrawerSettings.Position == Position.Right)
+			if (ev != null)
 			{
-				return HandleHorizontalActionDown(currentTouchPoint);
+				_downX = ev.GetX();
+				_downY = ev.GetY();
+				_initialPoint = currentTouchPoint;
+
+				if (DrawerSettings.Position == Position.Left || DrawerSettings.Position == Position.Right)
+				{
+					return HandleHorizontalActionDown(currentTouchPoint);
+				}
+
+				return HandleVerticalActionDown(currentTouchPoint);
 			}
 
-			return HandleVerticalActionDown(currentTouchPoint);
+			return false;
 		}
 
 		private bool HandleHorizontalActionDown(Point currentTouchPoint)


### PR DESCRIPTION
### Root Cause of the Issue

The issue arises due to incorrect initialization of touch coordinates, preventing proper detection of scroll gestures on Android when items exceed the height of the scroll view.

### Description of Change

To resolve the scrolling issue, the touch coordinates are now correctly updated:
- `_downX` and `_downY` are set using the touch event's current X and Y positions with `ev.GetX()` and `ev.GetY()`.
- `_initialPoint` is updated to `currentTouchPoint`, ensuring the touch start point is accurately stored.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #[106](https://github.com/syncfusion/maui-toolkit/issues/106)

### Screenshots

#### Before:

https://github.com/user-attachments/assets/54ddd516-4600-44f3-82b9-8ccae38bde53

#### After:

https://github.com/user-attachments/assets/825984f8-17b3-4150-af48-ad178496b96d
