### PR TITLE
Fixed SfPopup does not show up after repeated opening issue.

### DIFF
--- a/maui/src/Popup/SfPopup/SfPopup.cs
+++ b/maui/src/Popup/SfPopup/SfPopup.cs
@@ -3155,11 +3155,11 @@ namespace Syncfusion.Maui.Toolkit.Popup
 					{
 						_popupOverlayContainer.Parent = page;
 
-						// The issue occurs due to framework changes in version 9.0.50 [https://github.com/dotnet/maui/pull/20154].
-						// We will set _popupOverlayContainer visibility to false after dismissing the popup.
-						// We will set _popupOverlayContainer as the parent to popupView on display.
+						// _popupOverlayContainer visibility is set to false after dismissing the popup.
+						// _popupOverlayContainer will be set as the parent to popupView here from DisplayPopup().
 						// Due to the framework changes, the IsVisible property of _popupView is set to false when reopening with the same instance of the popup, since _popupOverlayContainer visibility will now be false.
-						// We will set the visibility of _popupOverlayContainer to true in a later section and _popupViewvisibility will still remains false.
+						// _popupOverlayContainer visibility is set to true in a later section, but _popupView visibility will still remain false.
+						// causes popup to appear blank for second time.
 						_popupOverlayContainer.IsVisible = true;
 						_popupView.Parent = _popupOverlayContainer;
 					}

--- a/maui/src/Popup/SfPopup/SfPopup.cs
+++ b/maui/src/Popup/SfPopup/SfPopup.cs
@@ -2261,8 +2261,6 @@ namespace Syncfusion.Maui.Toolkit.Popup
 				{
 					_popupOverlayContainer.ApplyBackgroundColor(Colors.Transparent);
 				}
-
-				_popupOverlayContainer.IsVisible = true;
 			}
 		}
 
@@ -3156,6 +3154,9 @@ namespace Syncfusion.Maui.Toolkit.Popup
 					if (_popupOverlayContainer.Parent is null || _popupView.Parent is null)
 					{
 						_popupOverlayContainer.Parent = page;
+
+						// Due to framework change in 9.0.50, popupView visibility was becoming false while setting parent. Framework PR URL(https://github.com/dotnet/maui/pull/20154).
+						_popupOverlayContainer.IsVisible = true;
 						_popupView.Parent = _popupOverlayContainer;
 					}
 				}

--- a/maui/src/Popup/SfPopup/SfPopup.cs
+++ b/maui/src/Popup/SfPopup/SfPopup.cs
@@ -3157,9 +3157,10 @@ namespace Syncfusion.Maui.Toolkit.Popup
 
 						// _popupOverlayContainer visibility is set to false after dismissing the popup.
 						// _popupOverlayContainer will be set as the parent to popupView here from DisplayPopup().
-						// Due to the framework changes, the IsVisible property of _popupView is set to false when reopening with the same instance of the popup, since _popupOverlayContainer visibility will now be false.
+						// Due to the framework changes [https://github.com/dotnet/maui/pull/20154],
+						// the IsVisible property of _popupView is set to false when reopening with the same instance of the popup, since _popupOverlayContainer visibility will now be false.
 						// _popupOverlayContainer visibility is set to true in a later section, but _popupView visibility will still remain false.
-						// causes popup to appear blank for second time.
+						// causes popup to appear blank for second time
 						_popupOverlayContainer.IsVisible = true;
 						_popupView.Parent = _popupOverlayContainer;
 					}

--- a/maui/src/Popup/SfPopup/SfPopup.cs
+++ b/maui/src/Popup/SfPopup/SfPopup.cs
@@ -3157,10 +3157,10 @@ namespace Syncfusion.Maui.Toolkit.Popup
 
 						// _popupOverlayContainer visibility is set to false after dismissing the popup.
 						// _popupOverlayContainer will be set as the parent to popupView here from DisplayPopup().
-						// Due to the framework changes [https://github.com/dotnet/maui/pull/20154],
+						// Due to Maui 9.0.50 changes [https://github.com/dotnet/maui/pull/20154],
 						// the IsVisible property of _popupView is set to false when reopening with the same instance of the popup, since _popupOverlayContainer visibility will now be false.
 						// _popupOverlayContainer visibility is set to true in a later section, but _popupView visibility will still remain false.
-						// causes popup to appear blank for second time
+						// causes popup to appear blank for second time.
 						_popupOverlayContainer.IsVisible = true;
 						_popupView.Parent = _popupOverlayContainer;
 					}

--- a/maui/src/Popup/SfPopup/SfPopup.cs
+++ b/maui/src/Popup/SfPopup/SfPopup.cs
@@ -3155,7 +3155,11 @@ namespace Syncfusion.Maui.Toolkit.Popup
 					{
 						_popupOverlayContainer.Parent = page;
 
-						// Due to framework change in 9.0.50, popupView visibility was becoming false while setting parent. Framework PR URL(https://github.com/dotnet/maui/pull/20154).
+						// The issue occurs due to framework changes in version 9.0.50 [https://github.com/dotnet/maui/pull/20154].
+						// We will set _popupOverlayContainer visibility to false after dismissing the popup.
+						// We will set _popupOverlayContainer as the parent to popupView on display.
+						// Due to the framework changes, the IsVisible property of _popupView is set to false when reopening with the same instance of the popup, since _popupOverlayContainer visibility will now be false.
+						// We will set the visibility of _popupOverlayContainer to true in a later section and _popupViewvisibility will still remains false.
 						_popupOverlayContainer.IsVisible = true;
 						_popupView.Parent = _popupOverlayContainer;
 					}


### PR DESCRIPTION
### Root Cause of the Issue

The issue occurs due to framework changes in version 9.0.50 [https://github.com/dotnet/maui/pull/20154].
We will set _popupOverlayContainer visibility to false after dismissing the popup.
We will set _popupOverlayContainer as the parent to popupView on display. Due to the framework changes, the IsVisible property of _popupView is set to false when reopening with the same instance of the popup, since _popupOverlayContainer visibility will now be false. We will set the visibility of _popupOverlayContainer to true in a later section and _popupViewvisibility will still remains false.

### Description of Change

To resolve the issue, setting the IsVisible property of the _popupOverlayContainer to true when setting it as parent to the _popupView.

### Issue Fixed

[[Bug] SfPopup does not show up after repeated openning · Issue #139 · syncfusion/maui-toolkit](https://github.com/syncfusion/maui-toolkit/issues/139)

### Screenshots

#### Before:

https://github.com/user-attachments/assets/132c9dd4-0c81-4cc1-9e30-8aa268ab14e3



#### After:

https://github.com/user-attachments/assets/c9af12eb-dfb4-4137-9fb7-768803fdd28f

