### PR TITLE
Resolved MauiMaterialAssets font icon issue

### DIFF
--- a/maui/src/Core/AppHostBuilder.cs
+++ b/maui/src/Core/AppHostBuilder.cs
@@ -37,6 +37,11 @@ namespace Syncfusion.Maui.Toolkit.Hosting
 #endif
 			});
 
+			builder.ConfigureFonts(fonts =>
+			{
+				fonts.AddFont("MauiMaterialAssets.ttf", "MauiMaterialAssets");
+			});
+
 #if WINDOWS
 			builder.Services.TryAddEnumerable(ServiceDescriptor.Transient<IMauiInitializeService, MauiControlsInitializer>());
 #endif

--- a/maui/src/Syncfusion.Maui.Toolkit.csproj
+++ b/maui/src/Syncfusion.Maui.Toolkit.csproj
@@ -106,7 +106,9 @@
   </ItemGroup>
   
   <ItemGroup>
-    <MauiFont Include="Resources\Fonts\MauiMaterialAssets.ttf" />
+    <MauiFont Include="Resources\Fonts\MauiMaterialAssets.ttf" >
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </MauiFont>
   </ItemGroup>
   
   <ItemGroup>

--- a/maui/src/Syncfusion.Maui.Toolkit.props
+++ b/maui/src/Syncfusion.Maui.Toolkit.props
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+    <ItemGroup>
+        <!-- Set the correct build action for font files -->
+        <MauiFont Include="$(MSBuildThisFileDirectory)..\buildTransitive\Resources\Fonts\MauiMaterialAssets.ttf">
+            <Link>Resources\Fonts\MauiMaterialAssets.ttf</Link>
+        </MauiFont>
+    </ItemGroup>
+</Project>


### PR DESCRIPTION
### Root Cause of the Issue

The built-in MauiMaterialAssets font icons in the .NET MAUI toolkit are not rendered in the application.

### Description of Change

The MauiMaterialAssets file was missing from the NuGet package, causing the icons not to render in the application.

### Issues Fixed

Manually included the MauiMaterialAssets file inside the NuGet package to ensure proper rendering of the icons.
