### PR TITLE
Resolved the issue where Numeric Entry does not gain focus when its visibility is changed.

### DIFF
--- a/maui/src/NumericEntry/SfNumericEntry.cs
+++ b/maui/src/NumericEntry/SfNumericEntry.cs
@@ -457,6 +457,13 @@ namespace Syncfusion.Maui.Toolkit.NumericEntry
                     }
                     break;
 
+	 			case nameof(IsVisible):
+					if (_textBox != null)
+					{
+						_textBox.IsVisible = IsVisible;
+					}
+					break;
+
         #if WINDOWS
                 case nameof(FlowDirection):
                     SetFlowDirection();


### PR DESCRIPTION
### Root Cause of the Issue

When the IsVisible property is initially set to false and then changed to true, the SfNumericEntry control does not gain focus and remains in a disabled state.

### Description of Change

Handled the IsVisible property of the Entry based on the visibility state of the SfNumericEntry control to ensure it regains focus and functions correctly.

### Issues Fixed

Fixes #138 

### Screenshots

#### Before:

https://github.com/user-attachments/assets/dfcc0212-2a89-407b-b822-11ca110fc7f2

#### After:

https://github.com/user-attachments/assets/f6dcbcd4-795b-46d5-8a8d-a82f2f98eb3b
