### PR TITLE
Resolved the issue where the Empty Point support was applied to the histogram, and the trackball was not visible for a value of 0 in the Cartesian Chart in the MAUI Toolkit.

### DIFF
--- a/maui/src/Charts/Area/Partial/CartesianChartArea.cs
+++ b/maui/src/Charts/Area/Partial/CartesianChartArea.cs
@@ -421,7 +421,6 @@ namespace Syncfusion.Maui.Toolkit.Charts
 					}
 
 					stackingSeries.ValidateYValues();
-
 					var stackingGroup = stackingSeries.GroupingLabel;
 					var stackingXAxis = stackingSeries.ActualXAxis;
 					var stackingYAxis = stackingSeries.ActualYAxis;

--- a/maui/src/Charts/Layouts/ChartSeriesView.cs
+++ b/maui/src/Charts/Layouts/ChartSeriesView.cs
@@ -120,7 +120,6 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				}
 
 				_series.UpdateEmptyPointSettings();
-
 				_series.SegmentsCreated = true;
 			}
 		}

--- a/maui/src/Charts/Series/BoxAndWhiskerSeries.cs
+++ b/maui/src/Charts/Series/BoxAndWhiskerSeries.cs
@@ -609,6 +609,10 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 		#region Internal Methods 
 
+		internal override void ValidateYValues()
+		{
+		}
+
 		internal override void OnDataSourceChanged(object oldValue, object newValue)
 		{
 			if (YDataCollection != null)

--- a/maui/src/Charts/Series/BubbleSeries.cs
+++ b/maui/src/Charts/Series/BubbleSeries.cs
@@ -567,6 +567,11 @@ namespace Syncfusion.Maui.Toolkit.Charts
 			ResetAutoScroll();
 			YValues.Clear();
 			_sizeValues.Clear();
+			foreach (var item in EmptyPointIndexes)
+			{
+				item?.Clear();
+			}
+
 			GeneratePoints([YBindingPath, SizeValuePath], YValues, _sizeValues);
 		}
 
@@ -599,7 +604,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				{
 					foreach (var index in EmptyPointIndexes[0])
 					{
-						if (YValues != null && YValues.Count != 0)
+						if (YValues != null && YValues.Count != 0 && index < YValues.Count)
 						{
 							YValues[(int)index] = double.NaN;
 						}
@@ -610,7 +615,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				{
 					foreach (var index in EmptyPointIndexes[1])
 					{
-						if (_sizeValues != null && _sizeValues.Count != 0)
+						if (_sizeValues != null && _sizeValues.Count != 0 && index < _sizeValues.Count)
 						{
 							_sizeValues[(int)index] = double.NaN;
 						}

--- a/maui/src/Charts/Series/CartesianSeries.cs
+++ b/maui/src/Charts/Series/CartesianSeries.cs
@@ -52,6 +52,10 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 		internal override ChartDataLabelSettings ChartDataLabelSettings => DataLabelSettings;
 
+		internal bool RequiredEmptyPointReset { get; set; } = false;
+
+		internal virtual bool IsFillEmptyPoint { get { return true; } }
+
 		#endregion
 
 		#region Bindable properties
@@ -723,10 +727,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 					_actualYAxis = value;
 				}
 			}
-		}
-
-		internal bool RequiredEmptyPointReset { get; set; } = false;
-		internal virtual bool IsFillEmptyPoint { get { return true; } }
+		} 
 
 		#endregion
 

--- a/maui/src/Charts/Series/ErrorBarSeries.cs
+++ b/maui/src/Charts/Series/ErrorBarSeries.cs
@@ -988,6 +988,11 @@ namespace Syncfusion.Maui.Toolkit.Charts
 			HorizontalErrorValues?.Clear();
 			VerticalErrorValues?.Clear();
 			YValues.Clear();
+			foreach (var item in EmptyPointIndexes)
+			{
+				item?.Clear();
+			}
+
 			GeneratePoints();
 			ScheduleUpdateChart();
 		}
@@ -1020,6 +1025,12 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 		internal override void RemoveData(int index, NotifyCollectionChangedEventArgs e)
 		{
+			ResetEmptyPointIndexes();
+			foreach (var item in EmptyPointIndexes)
+			{
+				item?.Clear();
+			}
+
 			if (XValues is IList<double> list1)
 			{
 				list1.RemoveAt(index);

--- a/maui/src/Charts/Series/FinancialSeriesBase.cs
+++ b/maui/src/Charts/Series/FinancialSeriesBase.cs
@@ -585,7 +585,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				{
 					foreach (var index in EmptyPointIndexes[0])
 					{
-						if (HighValues != null && HighValues.Count != 0)
+						if (HighValues != null && HighValues.Count != 0 && index < HighValues.Count)
 						{
 							HighValues[(int)index] = double.NaN;
 						}
@@ -596,7 +596,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				{
 					foreach (var index in EmptyPointIndexes[1])
 					{
-						if (LowValues != null && LowValues.Count != 0)
+						if (LowValues != null && LowValues.Count != 0 && index < LowValues.Count)
 						{
 							LowValues[(int)index] = double.NaN;
 						}
@@ -607,7 +607,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				{
 					foreach (var index in EmptyPointIndexes[2])
 					{
-						if (OpenValues != null && OpenValues.Count != 0)
+						if (OpenValues != null && OpenValues.Count != 0 && index < OpenValues.Count)
 						{
 							OpenValues[(int)index] = double.NaN;
 						}
@@ -618,7 +618,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				{
 					foreach (var index in EmptyPointIndexes[3])
 					{
-						if (CloseValues != null && CloseValues.Count != 0)
+						if (CloseValues != null && CloseValues.Count != 0 && index < CloseValues.Count)
 						{
 							CloseValues[(int)index] = double.NaN;
 						}

--- a/maui/src/Charts/Series/HistogramSeries.cs
+++ b/maui/src/Charts/Series/HistogramSeries.cs
@@ -437,6 +437,10 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 		#region Internal Methods
 
+		internal override void ValidateYValues()
+		{
+		}
+
 		internal override void GenerateSegments(SeriesView seriesView)
 		{
 			var xValues = GetXValues();

--- a/maui/src/Charts/Series/RangeAreaSeries.cs
+++ b/maui/src/Charts/Series/RangeAreaSeries.cs
@@ -83,17 +83,19 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
         internal override bool IsMultipleYPathRequired => true;
 
-        #endregion
+		internal override bool IsFillEmptyPoint { get { return false; } }
 
-        #region Bindable Properties
+		#endregion
 
-        /// <summary>
-        /// Identifies the <see cref="ShowMarkers"/> bindable property.
-        /// </summary>
-        /// <remarks>
-        /// The <see cref="ShowMarkers"/> property determines whether markers are displayed on the chart points.
-        /// </remarks>      
-        public static readonly BindableProperty ShowMarkersProperty = ChartMarker.ShowMarkersProperty;
+		#region Bindable Properties
+
+		/// <summary>
+		/// Identifies the <see cref="ShowMarkers"/> bindable property.
+		/// </summary>
+		/// <remarks>
+		/// The <see cref="ShowMarkers"/> property determines whether markers are displayed on the chart points.
+		/// </remarks>      
+		public static readonly BindableProperty ShowMarkersProperty = ChartMarker.ShowMarkersProperty;
 
         /// <summary>
         /// Identifies the <see cref="MarkerSettings"/> bindable property.

--- a/maui/src/Charts/Series/RangeColumnSeries.cs
+++ b/maui/src/Charts/Series/RangeColumnSeries.cs
@@ -417,8 +417,12 @@ namespace Syncfusion.Maui.Toolkit.Charts
                     double yValue = yValues[index];
                     double yValue1 = yValues1[index];
                     string label = string.Format("{0} : {1:#.##}\n{2} : {3:#.##}", SfCartesianChartResources.High, yValue, SfCartesianChartResources.Low, yValue1);
+					if (yValue == 0 || yValue1 == 0)
+					{
+						label = string.Format("{0} : {1:0.##}\n{2} : {3:0.##}", SfCartesianChartResources.High, yValue, SfCartesianChartResources.Low, yValue1);
+					}
 
-                    if (IsSideBySide)
+					if (IsSideBySide)
                     {
                         isSideBySide = true;
                         double xMidVal = xValue + SbsInfo.Start + ((SbsInfo.End - SbsInfo.Start) / 2);

--- a/maui/src/Charts/Series/RangeSeriesBase .cs
+++ b/maui/src/Charts/Series/RangeSeriesBase .cs
@@ -377,7 +377,7 @@
 				{
 					foreach (var index in EmptyPointIndexes[0])
 					{
-						if (HighValues != null && HighValues.Count != 0)
+						if (HighValues != null && HighValues.Count != 0 && index < HighValues.Count)
 						{
 							HighValues[(int)index] = double.NaN;
 						}
@@ -388,7 +388,7 @@
 				{
 					foreach (var index in EmptyPointIndexes[1])
 					{
-						if (LowValues != null && LowValues.Count != 0)
+						if (LowValues != null && LowValues.Count != 0 && index < LowValues.Count)
 						{
 							LowValues[(int)index] = double.NaN;
 						}

--- a/maui/src/Charts/Series/SplineRangeAreaSeries.cs
+++ b/maui/src/Charts/Series/SplineRangeAreaSeries.cs
@@ -76,17 +76,19 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
         bool _needToAnimateMarker;
 
-        #endregion
+		internal override bool IsFillEmptyPoint { get { return false; } }
 
-        #region Bindable Properties
+		#endregion
 
-        /// <summary>
-        /// Identifies the <see cref="ShowMarkers"/> bindable property.
-        /// </summary>
-        /// <remarks>
-        /// The <see cref="ShowMarkers"/> property determines whether the chart markers are visible on the series.
-        /// </remarks>
-        public static readonly BindableProperty ShowMarkersProperty = ChartMarker.ShowMarkersProperty;
+		#region Bindable Properties
+
+		/// <summary>
+		/// Identifies the <see cref="ShowMarkers"/> bindable property.
+		/// </summary>
+		/// <remarks>
+		/// The <see cref="ShowMarkers"/> property determines whether the chart markers are visible on the series.
+		/// </remarks>
+		public static readonly BindableProperty ShowMarkersProperty = ChartMarker.ShowMarkersProperty;
 
         /// <summary>
         /// Identifies the <see cref="MarkerSettings"/> bindable property.
@@ -503,7 +505,12 @@ namespace Syncfusion.Maui.Toolkit.Charts
                     double highValue = highValues[index];
                     double lowValue = lowValues[index];
                     string label = string.Format("{0} : {1:#.##}\n{2} : {3:#.##}", SfCartesianChartResources.High, highValue, SfCartesianChartResources.Low, lowValue);
-                    var xPoint = TransformToVisibleX(xValue, topValue);
+					if (highValue == 0 || lowValue == 0)
+					{
+						label = string.Format("{0} : {1:0.##}\n{2} : {3:0.##}", SfCartesianChartResources.High, highValue, SfCartesianChartResources.Low, lowValue);
+					}
+
+					var xPoint = TransformToVisibleX(xValue, topValue);
                     var yPoint = TransformToVisibleY(xValue, topValue);
 
                     TrackballPointInfo? chartPointInfo = CreateTrackballPointInfo(xPoint, yPoint, label, point);

--- a/maui/src/Charts/Series/StackingAreaSeries.cs
+++ b/maui/src/Charts/Series/StackingAreaSeries.cs
@@ -103,6 +103,12 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 		#endregion
 
+		#region Internal Properties
+
+		internal override bool IsFillEmptyPoint { get { return false; } }
+
+		#endregion
+
 		#region Bindable Properties
 
 		/// <summary>

--- a/maui/src/Charts/Series/XYDataSeries.cs
+++ b/maui/src/Charts/Series/XYDataSeries.cs
@@ -207,7 +207,7 @@
 					{
 						foreach (var index in item)
 						{
-							if (YValues != null && YValues.Count != 0)
+							if (YValues != null && YValues.Count != 0 && index < YValues.Count)
 							{
 								YValues[(int)index] = double.NaN;
 							}


### PR DESCRIPTION
 
### Description ###
- The `IsFillEmptyPoint` property has been added to the `RangeAreaSeries`, `SplineRangeAreaSeries`, and `StackingAreaSeries` to prevent the `EmptyPointSettings` fill from being assigned to the series.
- The overridden `ValidateYValues` method has been invoked in the `BoxAndWhiskerSeries` and `HistogramSeries` to prevent support for empty points.
- The `EmptyPointIndexes` have been cleared in the `OnDataSourceChanged` method for the `BubbleSeries` and `ErrorBarSeries` to ensure proper functionality during dynamic data collection changes.
- A condition has been added for the trackball to display the 0 value in the `RangeColumnSeries` and `SplineRangeAreaSeries`.
- A condition for index bounds has been added in the `BubbleSeries`, `FinancialSeriesBase`, `RangeSeriesBase`, and `XYDataSeries`.
### Output screenshots ###

**Windows**




 