### PR TITLE
Resolved the crash in TextInputLayout when resizing the Window.

### DIFF
--- a/maui/src/Core/Extensions/CanvasExtensions.Windows.cs
+++ b/maui/src/Core/Extensions/CanvasExtensions.Windows.cs
@@ -129,7 +129,10 @@ namespace Syncfusion.Maui.Toolkit.Graphics.Internals
 
 						format.HorizontalAlignment = canvasHorizontalAlignment;
 						format.Options = CanvasDrawTextOptions.Clip;
-						w2DCanvas.Session.DrawText(value, new Windows.Foundation.Rect(rect.X, rect.Y, rect.Width, rect.Height), textElement.TextColor.AsColor(), format);
+						if(rect.Width >= 0 && rect.Height >= 0)
+						{
+							w2DCanvas.Session.DrawText(value, new Windows.Foundation.Rect(rect.X, rect.Y, rect.Width, rect.Height), textElement.TextColor.AsColor(), format);
+						}
 					}
 				}
 			}

--- a/maui/src/TextInputLayout/SfTextInputLayout.Methods.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.Methods.cs
@@ -1943,7 +1943,10 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 			if (((IsLayoutFocused && !string.IsNullOrEmpty(Hint)) || IsHintFloated) && ShowHint)
 			{
 				CalculateClipRect();
-				canvas.SubtractFromClip(_clipRect);
+				if(_clipRect.Width >= 0 && _clipRect.Height >= 0)
+				{
+					canvas.SubtractFromClip(_clipRect);
+				}
 			}
 
 			SetOutlinedContainerBackground(canvas);


### PR DESCRIPTION
### Root Cause of the Issue

The crash occurred on the Windows platform when the container width and text width were reduced to a negative value because of padding applied to the parent layout of the TextInputLayout control.

### Description of Change

Implemented restrictions to prevent negative value updates for container width and text width, ensuring stability in such scenarios.

### Issues Fixed

Fixes #136

### Screenshots

#### Before:

https://github.com/user-attachments/assets/24bb5642-e3c3-4aaa-be67-a0da56c1db0d

#### After:

https://github.com/user-attachments/assets/73dd93ca-60b6-4e6c-b083-0583a77a54c5
