### PR TITLE
949491 & 938705- 'LoadCommand' property not found warning thrown when using Refresh Command & [iOS] App hangs when using TreeView inside PullToRefresh in .NET 9  

### DIFF
--- a/maui/src/Core/BaseView/DrawableLayoutView/SfView.cs
+++ b/maui/src/Core/BaseView/DrawableLayoutView/SfView.cs
@@ -25,6 +25,11 @@ namespace Syncfusion.Maui.Toolkit
 
         private bool clipToBounds = true;
 
+        /// <summary>
+		/// The field indicates whether it is layout based control.
+		/// </summary>
+		private bool isLayoutControl = false;
+
         private Thickness padding = new(0);
 
         readonly List<IView> children = [];
@@ -63,6 +68,21 @@ namespace Syncfusion.Maui.Toolkit
                 ignoreSafeArea = value;
             }
         }
+
+        /// <summary>
+		/// Gets or sets a value indicating whether it is layout based control.
+		/// </summary>
+		internal bool IsLayoutControl
+		{
+			get
+			{
+				return this.isLayoutControl;
+			}
+			set
+			{
+				this.isLayoutControl = value;
+			}
+		}
 
         /// <summary>
         /// Gets the collection of child views contained within this view.

--- a/maui/src/Core/BaseView/PlatformView/LayoutViewExt.ios.cs
+++ b/maui/src/Core/BaseView/PlatformView/LayoutViewExt.ios.cs
@@ -203,7 +203,7 @@ namespace Syncfusion.Maui.Toolkit.Platform
 			var widthConstraint = bounds.Width;
 			var heightConstraint = bounds.Height;
 
-			if (!IsMeasureValid(widthConstraint, heightConstraint) && Superview is not Microsoft.Maui.Platform.MauiView)
+			if (!IsMeasureValid(widthConstraint, heightConstraint) && Superview is not Microsoft.Maui.Platform.MauiView && View is SfView sfView && !sfView.IsLayoutControl)
 			{
 				layout.CrossPlatformMeasure(bounds.Width, bounds.Height);
 				CacheMeasureConstraints(widthConstraint, heightConstraint);

--- a/maui/src/PullToRefresh/SfPullToRefresh.cs
+++ b/maui/src/PullToRefresh/SfPullToRefresh.cs
@@ -112,7 +112,7 @@ namespace Syncfusion.Maui.Toolkit.PullToRefresh
 				typeof(ICommand),
 				typeof(SfPullToRefresh),
 				null,
-				BindingMode.TwoWay,
+				BindingMode.Default,
 				null);
 
 		/// <summary>
@@ -127,7 +127,7 @@ namespace Syncfusion.Maui.Toolkit.PullToRefresh
 			   typeof(object),
 			   typeof(SfPullToRefresh),
 			   null,
-			   BindingMode.TwoWay,
+			   BindingMode.Default,
 			   null);
 
 		/// <summary>
@@ -360,6 +360,7 @@ namespace Syncfusion.Maui.Toolkit.PullToRefresh
 			Children.Add(_progressCircleView);
 			ClipToBounds = true;
 			ThemeElement.InitializeThemeResources(this, "SfPullToRefreshTheme");
+			this.IsLayoutControl = true;
 		}
 
 		#endregion


### PR DESCRIPTION
## Bug Description

1. LoadCommand property not found warning thrown when using Refresh Command.
2. App hangs when using TreeView inside PullToRefresh in .NET 9

## Root Cause

1. The Refresh command's binding was configured as TwoWay, which was the primary cause of the issue.
2. In the LayoutSubviews method, the measurements are inconsistent, which results in an infinite loop of measure calls. This is the main issue.

## Reason for not identifying earlier
NA

## Is Breaking issue?
No

## Solution description

1. The binding for the Refresh Command has now been altered to Default.
2. Initially, the app would hang when scrolled and tapped due to infinite measurement calls. A condition was added to restrict measurement if it is a Maui view.

## Ticket and Task ID:
Ticket ID - https://mauitoolkit.syncfusion.com/agent/tickets/705073
Task ID - https://dev.azure.com/EssentialStudio/Mobile%20and%20Desktop/_workitems/edit/949491

## Output screenshots
### Before changes:
 
![image](https://github.com/user-attachments/assets/774077e8-a745-4c3d-a805-7d4f925c9451)

https://github.com/user-attachments/assets/c0f35f57-5729-4a09-96d0-70985b504f7b



### After changes: 

![image](https://github.com/user-attachments/assets/34d85981-b813-4c7c-b1d6-30bbef825ec9)

https://github.com/user-attachments/assets/b923baef-ffe7-4261-a5eb-eafca8d06b2a


## Areas affected and ensured
NA

## Test cases

1. NA
2. Tested with PullToRefresh, ListView and DataGrid

## Does it have any known issues?
No

## MR CheckList
- [x] Have you ensured in iOS, Android, WinUI, and macOS(if supported)? Windows, Android, Mac, iOS
- [ ] If there is any API change, did you get approval from PLO through [JIRA Tasks](https://syncfusion.atlassian.net/issues/?filter=66496)? No
- [ ] Is there any existing behavior change of other features due to this code change? No
- [ ] Did you perform the automation / manual testing against your fix? No
- [ ] Did you record this case in the unit test or UI test? No
- [ ] Have you suppressed any warning or binding errors? No
- [ ] Is there any existing behavior change of other features due to this code change? No
- [ ] Does it need localization? If so did you ensure the cases mentioned in [this](https://syncfusion.sharepoint.com/sites/MAUI/SitePages/Localization.aspx) link? NA
- [ ] Whether the new APIs and its comments are added as per [standard](https://syncfusion.sharepoint.com/sites/MAUI/SitePages/Coding.aspx)? NA
- [ ] Did you ensure the cases mentioned in [this](https://syncfusion.sharepoint.com/sites/MAUI/SitePages/Testing-Scenarios.aspx) link? No
- [ ] Did you ensure the fix (if applicable) met [accessibility](https://syncfusion.sharepoint.com/sites/MAUI/SitePages/Accessibility-in-.NET-MAUI.aspx) requirements? NA
- [ ] If you added any interaction related code, have you used touch and gesture APIs from core project? NA
- [ ] Does it contain code that reflects any internal framework API?
- [ ] Did you ensure the cases mentioned in [this](https://syncfusion.sharepoint.com/sites/MAUI/SitePages/Testing-Scenarios.aspx) link? No
- [ ] Did you ensure [RTL](https://syncfusion.sharepoint.com/sites/MAUI/SitePages/RTL%20(Flow%20Direction).aspx)? No
- [ ] Did you test the [memory](https://syncfusion.sharepoint.com/sites/MAUI/SitePages/Memory.aspx) leak
with the fix? No
- [ ] Did you ensure the ? Check [this](https://syncfusion.sharepoint.com/sites/MAUI/SitePages/Performance.aspx) link
to know more about performance optimization and how to automate? No
- [ ] If you use a third-party package, did you get approval to use it? If not, please get approval before merging. NA