### PR TITLE
Fix the view annotation was not cleared issue when clear the annotations collection in MAUI Charts.

### DIFF
--- a/maui/src/Charts/SfCartesianChart.cs
+++ b/maui/src/Charts/SfCartesianChart.cs
@@ -1959,6 +1959,17 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
         void ResetAnnotation()
         {
+            int i = _annotationLayout.Children.Count - 1;
+            if (i < 0) return; 
+
+            do
+            {
+                if (_annotationLayout.Children[i] is not AnnotationDrawableView view)
+                {
+                    _annotationLayout.Children.RemoveAt(i);
+                }
+                i--;
+            } while (i >= 0);
         }
 
         void RemoveAnnotation(int index, object item)


### PR DESCRIPTION
### Bug Description ###

When clear the annotations collection the view annotation was not cleared in MAUI Charts.

### Root Cause ###

Reset part of the code was not implemented. 

### Reason for the bug (maybe some wrong condition or wrong code)

Not tested this case previously.

**Action taken:**

- The ResetAnnotation method was implemented to clear all annotations. It traverses the annotation layout collection in reverse and removes view item only because, in Annotation layout have annotation drawable view and this was need for again for other drawable annotations. If clear, the invalidate drawable was called and cleared. So, removed the view only from layout. 
              
### Is Breaking issue? ###

No

### Solution description ###

- The solution involves implementing a loop within the ResetAnnotation method to remove all views (ViewAnnotation.View) from the AnnotationLayout.

### Output screenshots ###

**Before changes:**


https://github.com/user-attachments/assets/4d28d750-fb6f-4183-a9e0-0c96dafd1269


**After changes:**


https://github.com/user-attachments/assets/6c592e4f-7aeb-4eba-95ad-cb8002dca416


### Areas affected and ensured ###

- SfCartesianChart

### New Test cases ###

List out the test cases.

* Test the annotation add and remove dynamically.
* Test the clear function dynamically in annotation collection. 
* Test with Rectangle annotation (Drawable annotation) layout and view annotation.


### Does it have any known issues?

No
