### PR TITLE
BottomSheet StateChanged Event Not Triggering on Negative Touch Inputs

### DIFF
--- a/maui/src/BottomSheet/SfBottomSheet.cs
+++ b/maui/src/BottomSheet/SfBottomSheet.cs
@@ -2330,7 +2330,7 @@ namespace Syncfusion.Maui.Toolkit.BottomSheet
 		    _initialTouchY = 0;
 		    _isPointerPressed = false;
 
-		    if(_bottomSheet is not null && touchY >= _bottomSheet.TranslationY)
+		    if(_bottomSheet is not null)
 			{
 				UpdatePosition();
 			}


### PR DESCRIPTION
### Root Cause of the Issue

When the bottom sheet transitions quickly to the half or fully expanded state, the state changed event is not triggered

### Description of Change

Updated the StateChanged event to handle negative touch points received beyond the bounds of the bottom sheet, ensuring accurate state changes.

### Issues Fixed

Fixes: https://github.com/syncfusion/maui-toolkit/issues/152
Resolved an issue where the StateChanged event failed to trigger due to touch inputs with negative coordinates outside the bottom sheet’s bounds, causing inaccurate state tracking.

### Screenshots

#### Before:

https://github.com/user-attachments/assets/2af53ab4-6f15-4108-89d7-d8b70ff0761f

#### After:

https://github.com/user-attachments/assets/000dbd68-7eeb-4518-a891-18741ae35e3c

