### PR TITLE
954484-Fix the PullToRefresh issues in the Maui Toolkit that occurs during testing.

### DIFF
--- a/maui/samples/Gallery/Samples/PullToRefresh/ListViewPullToRefresh/View/ListViewPullToRefresh.xaml.cs
+++ b/maui/samples/Gallery/Samples/PullToRefresh/ListViewPullToRefresh/View/ListViewPullToRefresh.xaml.cs
@@ -4,13 +4,13 @@ namespace Syncfusion.Maui.ControlsGallery.PullToRefresh.SfPullToRefresh
 	{
 		public ListViewPullToRefresh()
 		{
-			InitializeComponent();
-			this.Unloaded += ListViewPullToRefresh_Unloaded;
+			InitializeComponent();			
 		}
 
-		private void ListViewPullToRefresh_Unloaded(object? sender, EventArgs e)
+		public override void OnDisappearing()
 		{
-			pullToRefresh.DisconnectHandlers();
+			base.OnDisappearing();
+			pullToRefresh.Handler?.DisconnectHandler();
 		}
 	}
 }

--- a/maui/samples/Gallery/Samples/PullToRefresh/ListViewPullToRefresh/View/ListViewPullToRefresh.xaml.cs
+++ b/maui/samples/Gallery/Samples/PullToRefresh/ListViewPullToRefresh/View/ListViewPullToRefresh.xaml.cs
@@ -5,6 +5,12 @@ namespace Syncfusion.Maui.ControlsGallery.PullToRefresh.SfPullToRefresh
 		public ListViewPullToRefresh()
 		{
 			InitializeComponent();
+			this.Unloaded += ListViewPullToRefresh_Unloaded;
+		}
+
+		private void ListViewPullToRefresh_Unloaded(object? sender, EventArgs e)
+		{
+			pullToRefresh.DisconnectHandlers();
 		}
 	}
 }

--- a/maui/samples/Gallery/Samples/PullToRefresh/PullToRefreshView/View/PullToRefreshView.xaml.cs
+++ b/maui/samples/Gallery/Samples/PullToRefresh/PullToRefreshView/View/PullToRefreshView.xaml.cs
@@ -5,6 +5,12 @@ namespace Syncfusion.Maui.ControlsGallery.PullToRefresh.SfPullToRefresh
 		public PullToRefreshView()
 		{
 			InitializeComponent();
+			this.Unloaded += PullToRefreshView_Unloaded;
+		}
+
+		private void PullToRefreshView_Unloaded(object? sender, EventArgs e)
+		{
+			pullToRefresh.DisconnectHandlers();
 		}
 	}
 }

--- a/maui/samples/Gallery/Samples/PullToRefresh/PullToRefreshView/View/PullToRefreshView.xaml.cs
+++ b/maui/samples/Gallery/Samples/PullToRefresh/PullToRefreshView/View/PullToRefreshView.xaml.cs
@@ -4,13 +4,13 @@ namespace Syncfusion.Maui.ControlsGallery.PullToRefresh.SfPullToRefresh
 	{
 		public PullToRefreshView()
 		{
-			InitializeComponent();
-			this.Unloaded += PullToRefreshView_Unloaded;
+			InitializeComponent();			
 		}
 
-		private void PullToRefreshView_Unloaded(object? sender, EventArgs e)
+		public override void OnDisappearing()
 		{
-			pullToRefresh.DisconnectHandlers();
+			base.OnDisappearing();
+			pullToRefresh.Handler?.DisconnectHandler();
 		}
 	}
 }


### PR DESCRIPTION
### Root Cause of the Issue

**Windows:** 
The main cause of the issue was when we navigate to next page, DisconnectHandlers are not called when navigating to the next page.

### Description of Change

**Windows:**
- Before navigating to another page, we have to disconnect it manually in the sample level
- So that, it works properly

### Screenshots

#### Before:


https://github.com/user-attachments/assets/759ee84e-7e0a-45fd-9578-c47f3bc14ac9


#### After:


https://github.com/user-attachments/assets/474b23ed-b4dc-4d1c-87a3-48727c9c0430

