### PR TITLE
Resolve Accessibility Issue in TextInputLayout

### DIFF
--- a/maui/src/NumericEntry/SfNumericEntry.cs
+++ b/maui/src/NumericEntry/SfNumericEntry.cs
@@ -486,8 +486,12 @@ namespace Syncfusion.Maui.Toolkit.NumericEntry
 		{
             // Ensure any necessary size updates are performed
 			UpdateSemanticsSizes();
-			if (SemanticsDataIsCurrent() && IsTextInputLayout)
+			if (SemanticsDataIsCurrent() || IsTextInputLayout)
 			{
+				if(IsTextInputLayout)
+				{
+					_numericEntrySemanticsNodes.Clear();
+				}
 				return _numericEntrySemanticsNodes;
 			}
 

--- a/maui/src/NumericEntry/SfNumericUpDown.cs
+++ b/maui/src/NumericEntry/SfNumericUpDown.cs
@@ -1142,6 +1142,10 @@ namespace Syncfusion.Maui.Toolkit.NumericUpDown
 
 			if (SemanticsDataIsCurrent() || IsTextInputLayout)
 			{
+				if (IsTextInputLayout)
+				{
+					_numericUpDownSemanticsNodes.Clear();
+				}
 				return _numericUpDownSemanticsNodes;
 			}
 			var upbuttonstate = !(_valueStates == ValueStates.Maximum) || AutoReverse;

--- a/maui/src/TextInputLayout/SfTextInputLayout.Methods.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.Methods.cs
@@ -243,6 +243,18 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 		#region Private Methods
 
 		/// <summary>
+		/// This refresh the semantic nodes of the textinputlayout
+		/// </summary>
+		void ResetSemantics()
+		{
+			if (_textInputLayoutSemanticsNodes != null)
+			{
+				_textInputLayoutSemanticsNodes.Clear();
+				this.InvalidateSemantics();
+			}
+		}
+
+		/// <summary>
 		/// Gets the button size based on the vertical alignment and icon templates.
 		/// </summary>
 		/// <returns>

--- a/maui/src/TextInputLayout/SfTextInputLayout.Methods.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.Methods.cs
@@ -255,6 +255,23 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 		}
 
 		/// <summary>
+		/// Resets semantics on first character input or when text is cleared.
+		/// </summary>
+		void HandleSemanticsReset()
+		{
+			if (string.IsNullOrEmpty(_text))
+			{
+				_hasResetSemantics = false;
+				ResetSemantics();
+			}
+			else if (_text.Length == 1 && !_hasResetSemantics)
+			{
+				ResetSemantics();
+				_hasResetSemantics = true;
+			}
+		}
+
+		/// <summary>
 		/// Gets the button size based on the vertical alignment and icon templates.
 		/// </summary>
 		/// <returns>

--- a/maui/src/TextInputLayout/SfTextInputLayout.Properties.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.Properties.cs
@@ -1787,7 +1787,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 				if (value != _text)
 				{
 					_text = value;
-					ResetSemantics();
+					HandleSemanticsReset();
 				}
 			}
 		}
@@ -2160,9 +2160,9 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 		{
 			if (bindable is SfTextInputLayout inputLayout)
 			{
-				inputLayout.ResetSemantics();
 				inputLayout.ChangeVisualState();
 				inputLayout.StartAnimation();
+				inputLayout.ResetSemantics();
 			}
 		}
 

--- a/maui/src/TextInputLayout/SfTextInputLayout.Properties.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.Properties.cs
@@ -1779,7 +1779,18 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 		/// <summary>
 		/// Gets the value of the input text of the <see cref="SfTextInputLayout"/>.
 		/// </summary>
-		public string Text { get; internal set; } = string.Empty;
+		public string Text
+		{
+			get => _text;
+			internal set
+			{
+				if (value != _text)
+				{
+					_text = value;
+					ResetSemantics();
+				}
+			}
+		}
 
 		/// <summary>
 		/// Gets a value indicating whether the background mode is outline.
@@ -2149,6 +2160,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 		{
 			if (bindable is SfTextInputLayout inputLayout)
 			{
+				inputLayout.ResetSemantics();
 				inputLayout.ChangeVisualState();
 				inputLayout.StartAnimation();
 			}
@@ -2399,6 +2411,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 			if (bindable is SfTextInputLayout inputLayout && inputLayout._initialLoaded)
 			{
 				inputLayout.UpdateViewBounds();
+				inputLayout.ResetSemantics();
 			}
 		}
 

--- a/maui/src/TextInputLayout/SfTextInputLayout.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.cs
@@ -179,10 +179,20 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
         /// </summary>
         readonly double _defaultLeadAndTrailViewWidth = 24;
 
-        /// <summary>
-        /// Gets or sets a value of leading view width.
-        /// </summary>
-        double _leadViewWidth = 0;
+		/// <summary>
+		/// The list to add the bounds values of drawing elements as nodes.
+		/// </summary>
+		readonly List<SemanticsNode> _textInputLayoutSemanticsNodes = new();
+
+		/// <summary>
+		/// List of semantic nodes for numeric entry.
+		/// </summary>
+		readonly List<SemanticsNode> _numericSemanticsNodes = new();
+
+		/// <summary>
+		/// Gets or sets a value of leading view width.
+		/// </summary>
+		double _leadViewWidth = 0;
 
         /// <summary>
         /// Gets or sets a value of trailing view width.
@@ -277,10 +287,20 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
         /// </summary>
         float _fontsize = DefaultHintFontSize;
 
-        /// <summary>
-        /// Gets the stroke color of the clear button
-        /// </summary>
-        static readonly Color ClearIconStrokeColor = Color.FromArgb("#49454F");
+		/// <summary>
+		/// The field sets and checks the new size of the drawn elements.
+		/// </summary>
+		Size _controlSize = Size.Zero;
+		
+		/// <summary>
+		/// The field sets and checks the text.
+		/// </summary>
+		string _text = string.Empty;
+
+		/// <summary>
+		/// Gets the stroke color of the clear button
+		/// </summary>
+		static readonly Color ClearIconStrokeColor = Color.FromArgb("#49454F");
 
         readonly EffectsRenderer _effectsRenderer;
 
@@ -665,9 +685,108 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
             }
             InvalidateDrawable();
         }
-#endregion
+
+		/// <summary>
+		/// Populates the list of numeric semantics nodes.
+		/// </summary>
+		/// <param name="content">The content object.</param>
+		void PopulateNumericSemanticsNodes(object? content)
+		{
+			_numericSemanticsNodes.Clear();
+
+			switch (content)
+			{
+				case SfNumericUpDown numericUpDown:
+					AddNumericUpDownNodes(numericUpDown);
+					break;
+				case SfNumericEntry when IsClearIconVisible:
+					AddSemanticsNode(_clearIconRectF, 2, "Clear button");
+					break;
+			}
+		}
+
+		/// <summary>
+		/// Adds semantic nodes for the numeric up-down control.
+		/// </summary>
+		/// <param name="numericUpDown">The numeric up/down control.</param>
+		void AddNumericUpDownNodes(SfNumericUpDown numericUpDown)
+		{
+			bool isUpEnabled = numericUpDown.AutoReverse || numericUpDown._valueStates != ValueStates.Maximum;
+			bool isDownEnabled = numericUpDown.AutoReverse || numericUpDown._valueStates != ValueStates.Minimum;
+			AddUpDownNodes(numericUpDown, isUpEnabled, isDownEnabled);
+		}
+
+		/// <summary>
+		/// Adds semantic nodes for up-down buttons.
+		/// </summary>
+		void AddUpDownNodes(SfNumericUpDown numericUpDown, bool isUpEnabled, bool isDownEnabled)
+		{
+			bool isVerticalInline = numericUpDown.IsInlineVerticalPlacement();
+			bool isLeftAlignment = numericUpDown.UpDownButtonAlignment == UpDownButtonAlignment.Left;
+			bool addClearIconFirst = isVerticalInline ? !isLeftAlignment : !isVerticalInline && !isLeftAlignment;
+
+			if (addClearIconFirst && IsClearIconVisible)
+			{
+				AddSemanticsNode(_clearIconRectF, 2, "Clear button");
+			}
+
+			AddSemanticsNode(isVerticalInline ? _downIconRectF : _upIconRectF, addClearIconFirst ? 3 : 2, "Up button", isUpEnabled);
+			AddSemanticsNode(isVerticalInline ? _upIconRectF : _downIconRectF, addClearIconFirst ? 4 : 3, "Down button", isDownEnabled);
+
+			if (!addClearIconFirst && IsClearIconVisible)
+			{
+				AddSemanticsNode(_clearIconRectF, 4, "Clear button");
+			}
+		}
+
+		/// <summary>
+		/// Adds a semantic node with specified properties.
+		/// </summary>
+		void AddSemanticsNode(RectF bounds, int id, string description, bool isEnabled = true)
+		{
+			string stateDescription = isEnabled ? $"{description}, double tap to activate" : $"{description}, disabled";
+			if (bounds.Width > 0 && bounds.Height > 0)
+			{
+				_numericSemanticsNodes.Add(CreateSemanticsNode(id, new Rect(bounds.X, bounds.Y, bounds.Width, bounds.Height), stateDescription));
+			}
+		}
+
+		/// <summary>
+		/// Creates a semantic node with specified ID, bounds, and description.
+		/// </summary>
+		/// <param name="id">The ID of the semantics node.</param>
+		/// <param name="rect">The bounds of the node.</param>
+		/// <param name="description">The description associated with the node.</param>
+		/// <returns>A newly created SemanticsNode object.</returns>
+		SemanticsNode CreateSemanticsNode(int id, Rect rect, string description) =>
+			new SemanticsNode
+			{
+				Id = id,
+				Bounds = rect,
+				Text = description
+			};
+		#endregion
 
 		#region Override Methods
+
+		/// <summary>
+		/// Returns the semantics node list.
+		/// </summary>
+		/// <param name="width">The width of the element.</param>
+		/// <param name="height">The height of the element.</param>
+		/// <returns>A list of semantics nodes.</returns>
+		protected override List<SemanticsNode> GetSemanticsNodesCore(double width, double height)
+		{
+			Size newControlSize = new(Width, Height);
+			if (_controlSize == newControlSize && _textInputLayoutSemanticsNodes.Count != 0)
+			{
+				return _textInputLayoutSemanticsNodes;
+			}
+			_controlSize = newControlSize;
+			PopulateNumericSemanticsNodes(Content);
+			_textInputLayoutSemanticsNodes.AddRange(_numericSemanticsNodes);
+			return _textInputLayoutSemanticsNodes;
+		}
 
 		/// <summary>
 		/// Invoked when the size of the element is allocated.
@@ -718,8 +837,11 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
             {
                 if (numericEntryContent.Children[0] is Entry numericInputView)
                 {
-					numericInputView.Opacity = IsHintFloated ? 1 : (DeviceInfo.Platform == DevicePlatform.iOS ? 0.00001 : 0);
-					AutomationProperties.SetIsInAccessibleTree(numericInputView, false); // Exclude numeric entry view from accessibility.
+#if ANDROID || IOS
+					numericInputView.Opacity = IsHintFloated ? 1 : 0.00001;
+#else
+					numericInputView.Opacity = IsHintFloated ? 1 : 0;
+#endif
 				}
             }
             else if (newValue is Picker picker)
@@ -728,7 +850,6 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
                 {
 					picker.Opacity = IsHintFloated ? 1 : (DeviceInfo.Platform == DevicePlatform.iOS ? 0.00001 : 0);
 				}
-				AutomationProperties.SetIsInAccessibleTree(picker, false); // Exclude picker from accessibility.
 			}
 
             base.OnContentChanged(oldValue, newValue);
@@ -737,8 +858,8 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
             {
                 OnEnabledPropertyChanged(IsEnabled);
             }
-
 			SetCustomDescription(newValue);
+			ResetSemantics();
         }
 
 		/// <summary>

--- a/maui/src/TextInputLayout/SfTextInputLayout.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.cs
@@ -293,6 +293,11 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 		Size _controlSize = Size.Zero;
 		
 		/// <summary>
+		/// Indicates whether semantics need to be reset.
+		/// </summary>
+		bool _hasResetSemantics = false;
+
+		/// <summary>
 		/// The field sets and checks the text.
 		/// </summary>
 		string _text = string.Empty;
@@ -700,7 +705,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 					AddNumericUpDownNodes(numericUpDown);
 					break;
 				case SfNumericEntry when IsClearIconVisible:
-					AddSemanticsNode(_clearIconRectF, 2, "Clear button");
+					AddClearButtonNodes(2);
 					break;
 			}
 		}
@@ -727,7 +732,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 
 			if (addClearIconFirst && IsClearIconVisible)
 			{
-				AddSemanticsNode(_clearIconRectF, 2, "Clear button");
+				AddClearButtonNodes(2);
 			}
 
 			AddSemanticsNode(isVerticalInline ? _downIconRectF : _upIconRectF, addClearIconFirst ? 3 : 2, "Up button", isUpEnabled);
@@ -735,8 +740,18 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 
 			if (!addClearIconFirst && IsClearIconVisible)
 			{
-				AddSemanticsNode(_clearIconRectF, 4, "Clear button");
+				AddClearButtonNodes(4);
 			}
+		}
+
+		/// <summary>
+		/// Adds a semantic node for clear button.
+		/// </summary>
+		void AddClearButtonNodes(int index)
+		{
+			var tempBounds = _clearIconRectF;
+			tempBounds.Width = tempBounds.Height = IconSize;
+			AddSemanticsNode(tempBounds, index, "Clear button");
 		}
 
 		/// <summary>


### PR DESCRIPTION
### Description
Accessibility was not functioning correctly when Picker and NumericEntry were placed inside the TextInputLayout control.

### Root Cause of the Issue
The issue occurred because accessibility for the Picker and numeric control was explicitly restricted within the TextInputLayout implementation.

### Description of Change
Removed the accessibility restriction for the Picker control.

Enabled accessibility support for both NumericEntry and its associated up/down buttons.

### Issues Fixed
#171 

### Screenshots

#### Before:

https://github.com/user-attachments/assets/096101c6-4c3c-45b8-b687-a5a209df9311


#### After:

https://github.com/user-attachments/assets/f96532e5-459b-4ef7-9e6e-bf6eec36abc2

