### PR TITLE
Provide animation duration support for Bottom sheet control

### DIFF
--- a/maui/src/BottomSheet/SfBottomSheet.cs
+++ b/maui/src/BottomSheet/SfBottomSheet.cs
@@ -1197,7 +1197,7 @@ namespace Syncfusion.Maui.Toolkit.BottomSheet
 		}
 
 		/// <summary> 
-		/// Gets or sets a value that can be used to adjust the duration of the opening and closing animations.
+		/// Gets or sets the duration, in milliseconds, for the opening and closing animations.
 		/// </summary> 
 		/// <value> 
 		/// It accepts double values, and the default value is 150ms.

--- a/maui/src/BottomSheet/SfBottomSheet.cs
+++ b/maui/src/BottomSheet/SfBottomSheet.cs
@@ -1285,7 +1285,7 @@ namespace Syncfusion.Maui.Toolkit.BottomSheet
 		/// <summary>
 		/// Updates the animation duration with the given value.
 		/// </summary>
-		int SetAnimationDuration()
+		int GetClampedAnimationDuration()
 		{
 			return (int)Math.Max(0, AnimationDuration);
 		}
@@ -2127,7 +2127,7 @@ namespace Syncfusion.Maui.Toolkit.BottomSheet
 				_overlayGrid.AbortAnimation("overlayGridAnimation");
 			}
 
-			int animationDuration = this.SetAnimationDuration();
+			int animationDuration = this.GetClampedAnimationDuration();
 			const int topPadding = 2;
 			_isSheetOpen = true;
 			if (_bottomSheet is not null)

--- a/maui/src/BottomSheet/SfBottomSheet.cs
+++ b/maui/src/BottomSheet/SfBottomSheet.cs
@@ -1283,8 +1283,11 @@ namespace Syncfusion.Maui.Toolkit.BottomSheet
 		}
 
 		/// <summary>
-		/// Updates the animation duration with the given value.
+		/// Returns the value of <c>AnimationDuration</c>, ensuring it is clamped to a non-negative integer.
+		/// This method is useful when passing the duration to animation APIs that require a <c>uint</c> value,
+		/// preventing issues caused by negative durations.
 		/// </summary>
+		/// <returns>A non-negative integer representing the animation duration.</returns>
 		int GetClampedAnimationDuration()
 		{
 			return (int)Math.Max(0, AnimationDuration);
@@ -2169,6 +2172,7 @@ namespace Syncfusion.Maui.Toolkit.BottomSheet
 
 					var overlayGridAnimation = new Animation(d =>
 					{
+						// Ensure the opacity is only updated with valid numeric values to avoid rendering issues.
 						if (!double.IsNaN(d))
 						{
 							_overlayGrid.Opacity = d;

--- a/maui/src/BottomSheet/SfBottomSheet.cs
+++ b/maui/src/BottomSheet/SfBottomSheet.cs
@@ -489,6 +489,19 @@ namespace Syncfusion.Maui.Toolkit.BottomSheet
 			BindingMode.Default
 			);
 
+		/// <summary>
+		/// Identifies the <see cref="AnimationDuration"/> bindable property.
+		/// </summary>
+		/// <value>
+		/// The identifier for <see cref="AnimationDuration"/> bindable property.
+		/// </value>
+		public static readonly BindableProperty AnimationDurationProperty = BindableProperty.Create(
+			nameof(AnimationDuration),
+			typeof(double),
+			typeof(SfBottomSheet),
+			150d,
+			BindingMode.Default);
+
 		#endregion
 
 		#region Internal Bindable Properties
@@ -1183,6 +1196,19 @@ namespace Syncfusion.Maui.Toolkit.BottomSheet
 			set => SetValue(CollapseOnOverlayTapProperty, value);
 		}
 
+		/// <summary> 
+		/// Gets or sets a value that can be used to adjust the duration of the opening and closing animations.
+		/// </summary> 
+		/// <value> 
+		/// It accepts double values, and the default value is 150ms.
+		/// </value> 
+
+		public double AnimationDuration
+		{
+			get => (double)GetValue(AnimationDurationProperty);
+			set => SetValue(AnimationDurationProperty, value);
+		}
+
 		#endregion
 
 		#region Internal Properties
@@ -1254,6 +1280,14 @@ namespace Syncfusion.Maui.Toolkit.BottomSheet
 				IsOpen = false;
 				State = BottomSheetState.Hidden;
 		    }
+		}
+
+		/// <summary>
+		/// Updates the animation duration with the given value.
+		/// </summary>
+		int SetAnimationDuration()
+		{
+			return (int)Math.Max(0, AnimationDuration);
 		}
 
 		#endregion
@@ -2093,13 +2127,13 @@ namespace Syncfusion.Maui.Toolkit.BottomSheet
 				_overlayGrid.AbortAnimation("overlayGridAnimation");
 			}
 
-			const int animationDuration = 150;
-		    const int topPadding = 2;
+			int animationDuration = this.SetAnimationDuration();
+			const int topPadding = 2;
 			_isSheetOpen = true;
 			if (_bottomSheet is not null)
 			{
 				var bottomSheetAnimation = new Animation(d => _bottomSheet.TranslationY = d, _bottomSheet.TranslationY, targetPosition + topPadding);
-				_bottomSheet?.Animate("bottomSheetAnimation", bottomSheetAnimation, length: animationDuration, easing: Easing.Linear, finished: (v, e) =>
+				_bottomSheet?.Animate("bottomSheetAnimation", bottomSheetAnimation, length: (uint)animationDuration, easing: Easing.Linear, finished: (v, e) => 
 				{
 					UpdateBottomSheetHeight();
 					onFinish?.Invoke();
@@ -2133,7 +2167,14 @@ namespace Syncfusion.Maui.Toolkit.BottomSheet
 						endValue = DefaultOverlayOpacity;
 					}
 
-					var overlayGridAnimation = new Animation(d => _overlayGrid.Opacity = d, startValue, endValue);
+					var overlayGridAnimation = new Animation(d =>
+					{
+						if (!double.IsNaN(d))
+						{
+							_overlayGrid.Opacity = d;
+						}
+					}
+					, startValue, endValue);
 					_overlayGrid.Animate("overlayGridAnimation", overlayGridAnimation,
 						length: (uint)animationDuration,
 						easing: Easing.Linear,

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Navigation/SfBottomSheetUnitTests.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Navigation/SfBottomSheetUnitTests.cs
@@ -38,6 +38,7 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 			Assert.Equal(4d, _bottomSheet.GrabberHeight);
 			Assert.Equal(32d, _bottomSheet.GrabberWidth);
 			Assert.Equal(12d, _bottomSheet.GrabberCornerRadius);
+			Assert.Equal(150d, _bottomSheet.AnimationDuration);
 			if (_bottomSheet.GrabberBackground is SolidColorBrush grabberBrush)
 			{
 				var grabberColor = grabberBrush.Color;
@@ -475,6 +476,19 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 			Assert.Equal(expected, actual);
 		}
 
+		[Theory]
+		[InlineData(500d, 500d)]
+		[InlineData(0d, 0d)]
+		[InlineData(-500d, -500d)]
+		public void AnimationDuration(double input, double expected)
+		{
+			_bottomSheet.AnimationDuration = input;
+
+			var actual = _bottomSheet.AnimationDuration;
+
+			Assert.Equal(expected, actual);
+		}
+
 		#endregion
 
 		#region Internal Properties
@@ -731,6 +745,14 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 			SfBorder? grabber = (SfBorder?)GetPrivateField(_bottomSheet, "_grabber");
 			var actual = grabber?.HeightRequest;
 			Assert.Equal(expected, actual);
+		}
+
+		[Fact]
+		public void SetAnimationDuration()
+		{
+			_bottomSheet.AnimationDuration = -500;
+			var actual = InvokePrivateMethod(_bottomSheet, "SetAnimationDuration");
+			Assert.Equal(0, actual);
 		}
 
 		[Theory]

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Navigation/SfBottomSheetUnitTests.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Navigation/SfBottomSheetUnitTests.cs
@@ -748,10 +748,10 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 		}
 
 		[Fact]
-		public void SetAnimationDuration()
+		public void GetClampedAnimationDuration()
 		{
 			_bottomSheet.AnimationDuration = -500;
-			var actual = InvokePrivateMethod(_bottomSheet, "SetAnimationDuration");
+			var actual = InvokePrivateMethod(_bottomSheet, "GetClampedAnimationDuration");
 			Assert.Equal(0, actual);
 		}
 

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Navigation/SfBottomSheetUnitTests.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Navigation/SfBottomSheetUnitTests.cs
@@ -480,7 +480,7 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 		[InlineData(500d, 500d)]
 		[InlineData(0d, 0d)]
 		[InlineData(-500d, -500d)]
-		public void AnimationDuration(double input, double expected)
+		public void AnimationDurationProperty_ReturnsSetValue(double input, double expected)
 		{
 			_bottomSheet.AnimationDuration = input;
 


### PR DESCRIPTION
### Root Cause of the Issue ###
 
The transition animation lacked customization, as the duration was fixed and not configurable through the API.
 
### Description of change ###
 
Introduced **AnimationDuration** property to allow developers to configure the duration of the bottom sheet transition animations, enabling smoother or faster UI experiences based on application requirements.

### API Summary ###
API Name: AnimationDuration
Namespace: Syncfusion.Maui.Toolkit.BottomSheet
Input type: bool
Access specifier: public

### Issues Fixed

https://github.com/syncfusion/maui-toolkit/issues/99

### Screenshots

**Default Animation Duration**


https://github.com/user-attachments/assets/37af4f31-fbde-4ac9-a94d-8d2a2cc45a20


**Animation Duration = 1000**


https://github.com/user-attachments/assets/a9e86c14-d5a1-4ee5-9fee-463a107e20e4

