### PR TITLE
I159-Fix tooltip background was not updated when the theme was changed.

### DIFF
--- a/maui/src/Charts/Behaviors/ChartTooltipBehavior.cs
+++ b/maui/src/Charts/Behaviors/ChartTooltipBehavior.cs
@@ -68,7 +68,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
             null,
             BindingMode.Default,
             null,
-            defaultValueCreator: BackgroundDefaultValueCreator);
+            null);
 
         /// <summary>
         /// Identifies the <see cref="Duration"/> bindable property.
@@ -98,7 +98,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
             null,
             BindingMode.Default,
             null,
-            defaultValueCreator: TextColorDefaultValueCreator);
+            null);
 
         /// <summary>
         /// Identifies the <see cref="Margin"/> bindable property.
@@ -125,7 +125,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
             nameof(FontSize),
             typeof(float),
             typeof(ChartTooltipBehavior),
-            14f,
+            float.NaN,
             BindingMode.Default,
             null);
 
@@ -736,16 +736,6 @@ namespace Syncfusion.Maui.Toolkit.Charts
             }
 
             return view;
-        }
-
-        static object TextColorDefaultValueCreator(BindableObject bindable)
-        {
-            return Color.FromArgb("#F4EFF4");
-        }
-
-        static object BackgroundDefaultValueCreator(BindableObject bindable)
-        {
-            return new SolidColorBrush(Color.FromArgb("#1C1B1F"));
         }
 
         #endregion

--- a/maui/src/Charts/ChartBase.cs
+++ b/maui/src/Charts/ChartBase.cs
@@ -117,6 +117,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 			typeof(ChartBase),
 			null,
 			BindingMode.Default,
+			null,
 			null);
 
 		/// <summary>
@@ -603,7 +604,6 @@ namespace Syncfusion.Maui.Toolkit.Charts
 					continue;
 				}
 
-				SetDefaultTooltipValue(behavior);
 				var tooltipInfo = chartSeries.GetTooltipInfo(behavior, x, y);
 				if (tooltipInfo != null)
 				{
@@ -682,7 +682,6 @@ namespace Syncfusion.Maui.Toolkit.Charts
 					if (_defaultToolTipBehavior == null)
 					{
 						_defaultToolTipBehavior = new ChartTooltipBehavior();
-						SetDefaultTooltipValue(_defaultToolTipBehavior);
 						_defaultToolTipBehavior.Chart = this;
 						// defaultToolTipBehavior.IsDefault = true;
 					}
@@ -696,13 +695,6 @@ namespace Syncfusion.Maui.Toolkit.Charts
 			{
 				_toolTipBehavior = value;
 			}
-		}
-
-		internal void SetDefaultTooltipValue(ChartTooltipBehavior behavior)
-		{
-			behavior.Background = TooltipBackground ?? behavior.Background;
-			behavior.TextColor = TooltipTextColor ?? behavior.TextColor;
-			behavior.FontSize = !double.IsNaN(TooltipFontSize) ? (float)TooltipFontSize : behavior.FontSize;
 		}
 
 		SfTooltip? IChart.TooltipView

--- a/maui/src/Charts/Series/BoxAndWhiskerSeries.cs
+++ b/maui/src/Charts/Series/BoxAndWhiskerSeries.cs
@@ -1185,13 +1185,12 @@ namespace Syncfusion.Maui.Toolkit.Charts
 						Y = yPosition,
 						Index = index,
 						Margin = tooltipBehavior.Margin,
-						TextColor = tooltipBehavior.TextColor,
 						FontFamily = tooltipBehavior.FontFamily,
-						FontSize = tooltipBehavior.FontSize,
 						FontAttributes = tooltipBehavior.FontAttributes,
-						Background = tooltipBehavior.Background,
 						Item = dataPoint
 					};
+
+					UpdateTooltipAppearance(tooltipInfo, tooltipBehavior);
 
 					if (IsOutlierTouch)
 					{

--- a/maui/src/Charts/Series/CartesianSeries.cs
+++ b/maui/src/Charts/Series/CartesianSeries.cs
@@ -1340,14 +1340,14 @@ namespace Syncfusion.Maui.Toolkit.Charts
 					Y = yPosition,
 					Index = index,
 					Margin = tooltipBehavior.Margin,
-					TextColor = tooltipBehavior.TextColor,
 					FontFamily = tooltipBehavior.FontFamily,
-					FontSize = tooltipBehavior.FontSize,
 					FontAttributes = tooltipBehavior.FontAttributes,
-					Background = tooltipBehavior.Background,
 					Text = yValue == 0 ? yValue.ToString("0.##") : yValue.ToString("#.##"),
 					Item = dataPoint
 				};
+
+				UpdateTooltipAppearance(tooltipInfo, tooltipBehavior);
+
 				return tooltipInfo;
 			}
 

--- a/maui/src/Charts/Series/ChartSeries.cs
+++ b/maui/src/Charts/Series/ChartSeries.cs
@@ -1737,6 +1737,12 @@ namespace Syncfusion.Maui.Toolkit.Charts
 		{
 		}
 
+		/// <summary>
+		/// Updates the tooltip appearance including background, text color, and font size.
+		/// 
+		/// ChartTooltipBehavior Background with AppThemeBinding · Issue #159 · syncfusion/maui-toolkit
+		/// Resolved the issue where tooltip background doesn't update dynamically by changing the theme when using AppThemeBinding.
+		/// </summary>
 		internal void UpdateTooltipAppearance(TooltipInfo info, ChartTooltipBehavior tooltipBehavior)
 		{
 			if (Chart is ChartBase chart)

--- a/maui/src/Charts/Series/ChartSeries.cs
+++ b/maui/src/Charts/Series/ChartSeries.cs
@@ -1737,6 +1737,16 @@ namespace Syncfusion.Maui.Toolkit.Charts
 		{
 		}
 
+		internal void UpdateTooltipAppearance(TooltipInfo info, ChartTooltipBehavior tooltipBehavior)
+		{
+			if (Chart is ChartBase chart)
+			{
+				info.Background = tooltipBehavior.Background ?? chart.TooltipBackground ?? new SolidColorBrush(Color.FromArgb("#1C1B1F"));
+				info.TextColor = tooltipBehavior.TextColor ?? chart.TooltipTextColor ?? Color.FromArgb("#F4EFF4");
+				info.FontSize = !float.IsNaN(tooltipBehavior.FontSize) ? tooltipBehavior.FontSize : !float.IsNaN((float)chart.TooltipFontSize) ? (float)chart.TooltipFontSize : 14.0f;
+			}
+		}	
+
 		internal virtual void InitiateDataLabels(ChartSegment segment)
 		{
 			if (DataLabels.Count > _segments.Count)

--- a/maui/src/Charts/Series/HiLoOpenCloseSeries.cs
+++ b/maui/src/Charts/Series/HiLoOpenCloseSeries.cs
@@ -322,13 +322,12 @@ namespace Syncfusion.Maui.Toolkit.Charts
 					Index = index,
 					Text = (yValue == 0 ? yValue.ToString(" 0.##") : yValue.ToString(" #.##")) + "/" + (lowValue == 0 ? lowValue.ToString(" 0.##") : lowValue.ToString(" #.##")) + "/" + (openValue == 0 ? openValue.ToString(" 0.##") : openValue.ToString(" #.##")) + "/" + (closeValue == 0 ? closeValue.ToString(" 0.##") : closeValue.ToString(" #.##")),
 					Margin = tooltipBehavior.Margin,
-					TextColor = tooltipBehavior.TextColor,
 					FontFamily = tooltipBehavior.FontFamily,
-					FontSize = tooltipBehavior.FontSize,
 					FontAttributes = tooltipBehavior.FontAttributes,
-					Background = tooltipBehavior.Background,
 					Item = dataPoint
 				};
+
+				UpdateTooltipAppearance(tooltipInfo, tooltipBehavior);
 
 				return tooltipInfo;
 			}

--- a/maui/src/Charts/Series/PieSeries.cs
+++ b/maui/src/Charts/Series/PieSeries.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Specialized;
+using Microsoft.Maui.Controls;
 using Syncfusion.Maui.Toolkit.Graphics.Internals;
 
 namespace Syncfusion.Maui.Toolkit.Charts
@@ -642,14 +643,13 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				Y = yPosition,
 				Index = index,
 				Margin = tooltipBehavior.Margin,
-				TextColor = tooltipBehavior.TextColor,
 				FontFamily = tooltipBehavior.FontFamily,
-				FontSize = tooltipBehavior.FontSize,
 				FontAttributes = tooltipBehavior.FontAttributes,
-				Background = tooltipBehavior.Background,
 				Text = yValue.ToString("#.##"),
 				Item = dataPoint
 			};
+
+			UpdateTooltipAppearance(tooltipInfo, tooltipBehavior);
 
 			return tooltipInfo;
 		}

--- a/maui/src/Charts/Series/PolarSeries.cs
+++ b/maui/src/Charts/Series/PolarSeries.cs
@@ -866,14 +866,13 @@ namespace Syncfusion.Maui.Toolkit.Charts
 					Y = yPosition,
 					Index = index,
 					Margin = tooltipBehavior.Margin,
-					TextColor = tooltipBehavior.TextColor,
 					FontFamily = tooltipBehavior.FontFamily,
-					FontSize = tooltipBehavior.FontSize,
 					FontAttributes = tooltipBehavior.FontAttributes,
-					Background = tooltipBehavior.Background,
 					Text = yValue.ToString("#.##"),
 					Item = dataPoint
 				};
+
+				UpdateTooltipAppearance(tooltipInfo, tooltipBehavior);
 				return tooltipInfo;
 			}
 

--- a/maui/src/Charts/Series/RadialBarSeries.cs
+++ b/maui/src/Charts/Series/RadialBarSeries.cs
@@ -764,14 +764,13 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				Y = yPosition,
 				Index = index,
 				Margin = tooltipBehavior.Margin,
-				TextColor = tooltipBehavior.TextColor,
 				FontFamily = tooltipBehavior.FontFamily,
-				FontSize = tooltipBehavior.FontSize,
 				FontAttributes = tooltipBehavior.FontAttributes,
-				Background = tooltipBehavior.Background,
 				Text = yValue.ToString("#.##"),
 				Item = dataPoint
 			};
+
+			UpdateTooltipAppearance(tooltipInfo, tooltipBehavior);
 			return tooltipInfo;
 		}
 

--- a/maui/src/Charts/Series/StackingAreaSeries.cs
+++ b/maui/src/Charts/Series/StackingAreaSeries.cs
@@ -542,15 +542,13 @@ namespace Syncfusion.Maui.Toolkit.Charts
 					Y = yPosition,
 					Index = index,
 					Margin = tooltipBehavior.Margin,
-					TextColor = tooltipBehavior.TextColor,
 					FontFamily = tooltipBehavior.FontFamily,
-					FontSize = tooltipBehavior.FontSize,
 					FontAttributes = tooltipBehavior.FontAttributes,
-					Background = tooltipBehavior.Background,
 					Text = content.ToString(),
 					Item = dataPoint
 				};
 
+				UpdateTooltipAppearance(tooltipInfo, tooltipBehavior);
 				return tooltipInfo;
 			}
 

--- a/maui/src/Charts/Series/StackingColumnSeries.cs
+++ b/maui/src/Charts/Series/StackingColumnSeries.cs
@@ -596,14 +596,12 @@ namespace Syncfusion.Maui.Toolkit.Charts
 					Y = yPosition,
 					Index = index,
 					Margin = tooltipBehavior.Margin,
-					TextColor = tooltipBehavior.TextColor,
 					FontFamily = tooltipBehavior.FontFamily,
-					FontSize = tooltipBehavior.FontSize,
 					FontAttributes = tooltipBehavior.FontAttributes,
-					Background = tooltipBehavior.Background,
 					Text = content.ToString()
 				};
-				;
+
+				UpdateTooltipAppearance(tooltipInfo, tooltipBehavior);
 				tooltipInfo.Item = dataPoint;
 
 				return tooltipInfo;

--- a/maui/src/Charts/Series/StackingLineSeries.cs
+++ b/maui/src/Charts/Series/StackingLineSeries.cs
@@ -505,15 +505,13 @@ namespace Syncfusion.Maui.Toolkit.Charts
 					Y = yPosition,
 					Index = index,
 					Margin = tooltipBehavior.Margin,
-					TextColor = tooltipBehavior.TextColor,
 					FontFamily = tooltipBehavior.FontFamily,
-					FontSize = tooltipBehavior.FontSize,
 					FontAttributes = tooltipBehavior.FontAttributes,
-					Background = tooltipBehavior.Background,
 					Text = content.ToString(),
 					Item = dataPoint
 				};
 
+				UpdateTooltipAppearance(tooltipInfo, tooltipBehavior);
 				return tooltipInfo;
             }
 

--- a/maui/src/Charts/SfFunnelChart.cs
+++ b/maui/src/Charts/SfFunnelChart.cs
@@ -1199,7 +1199,6 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				object dataPoint = _actualData[index];
 				double yValue = _yValues[index];
 				var segment = (FunnelSegment)_segments[index];
-				SetDefaultTooltipValue(behavior);
 
 				TooltipInfo tooltipInfo = new TooltipInfo(this)
 				{
@@ -1207,11 +1206,11 @@ namespace Syncfusion.Maui.Toolkit.Charts
 					Y = segment.SegmentBounds.Center.Y + (float)_seriesBounds.Top,
 					Index = index,
 					Margin = behavior.Margin,
-					TextColor = behavior.TextColor,
+					TextColor = behavior.TextColor ?? TooltipTextColor ?? Color.FromArgb("#F4EFF4"),
 					FontFamily = behavior.FontFamily,
-					FontSize = behavior.FontSize,
+					FontSize = !float.IsNaN(behavior.FontSize) ? behavior.FontSize : !float.IsNaN((float)TooltipFontSize) ? (float)TooltipFontSize : 14.0f,
 					FontAttributes = behavior.FontAttributes,
-					Background = behavior.Background,
+					Background = behavior.Background ?? TooltipBackground ?? new SolidColorBrush(Color.FromArgb("#1C1B1F")),
 					Text = yValue.ToString("#.##"),
 					Item = dataPoint
 				};

--- a/maui/src/Charts/SfPolarChart.cs
+++ b/maui/src/Charts/SfPolarChart.cs
@@ -881,7 +881,6 @@ namespace Syncfusion.Maui.Toolkit.Charts
                         continue;
                     }
 
-                    SetDefaultTooltipValue(behavior);
                     TooltipInfo? tooltipInfo = chartSeries.GetTooltipInfo(behavior, x, y);
 
                     if (tooltipInfo != null)

--- a/maui/src/Charts/SfPyramidChart.cs
+++ b/maui/src/Charts/SfPyramidChart.cs
@@ -1223,18 +1223,18 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				object dataPoint = _actualData[index];
 				double yValue = _yValues[index];
 				var segment = (ChartSegment)_segments[index];
-				SetDefaultTooltipValue(behavior);
+
 				TooltipInfo tooltipInfo = new TooltipInfo(this)
 				{
 					X = segment.SegmentBounds.Center.X + (float)_seriesBounds.Left,
 					Y = segment.SegmentBounds.Center.Y + (float)_seriesBounds.Top,
 					Index = index,
 					Margin = behavior.Margin,
-					TextColor = behavior.TextColor,
+					TextColor = behavior.TextColor ?? TooltipTextColor ?? Color.FromArgb("#F4EFF4"),
 					FontFamily = behavior.FontFamily,
-					FontSize = behavior.FontSize,
+					FontSize = !float.IsNaN(behavior.FontSize) ? behavior.FontSize : !float.IsNaN((float)TooltipFontSize) ? (float)TooltipFontSize : 14.0f,
 					FontAttributes = behavior.FontAttributes,
-					Background = behavior.Background,
+					Background = behavior.Background ?? TooltipBackground ?? new SolidColorBrush(Color.FromArgb("#1C1B1F")),
 					Text = yValue.ToString("#.##"),
 					Item = dataPoint
 				};

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Chart/DefaultTests/BehaviorDefaultTests.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Chart/DefaultTests/BehaviorDefaultTests.cs
@@ -54,13 +54,11 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 			var behavior = new ChartTooltipBehavior();
 
 			// ChartTooltipBehavior specific properties
-			Assert.NotNull(behavior.Background);
-			Assert.IsType<SolidColorBrush>(behavior.Background);
-			Assert.Equal(Color.FromArgb("#1C1B1F"), ((SolidColorBrush)behavior.Background).Color);
+			Assert.Null(behavior.Background);
 			Assert.Equal(2, behavior.Duration);
-			Assert.Equal(Color.FromArgb("#F4EFF4"), behavior.TextColor);
+			Assert.Null(behavior.TextColor);
 			Assert.Equal(new Thickness(0), behavior.Margin);
-			Assert.Equal(14f, behavior.FontSize);
+			Assert.Equal(float.NaN, behavior.FontSize);
 			Assert.Null(behavior.FontFamily);
 			Assert.Equal(FontAttributes.None, behavior.FontAttributes);
 

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Chart/Features/ChartUnitTests.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Chart/Features/ChartUnitTests.cs
@@ -43,14 +43,12 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 		{
 
 			var chartTooltipBehavior = new ChartTooltipBehavior();
-			var sfCartesianChart = new SfCartesianChart();
 			var background = Colors.Blue;
 			var textColor = Colors.Orange;
 			var fontSize = 14;
 			chartTooltipBehavior.Background = background;
 			chartTooltipBehavior.TextColor = textColor;
 			chartTooltipBehavior.FontSize = fontSize;
-			sfCartesianChart.SetDefaultTooltipValue(chartTooltipBehavior);
 			Assert.Equal(chartTooltipBehavior.Background, background);
 			Assert.Equal(chartTooltipBehavior.TextColor, textColor);
 			Assert.Equal(chartTooltipBehavior.FontSize, fontSize);
@@ -63,8 +61,7 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 			var chartTooltipBehavior = new ChartTooltipBehavior();
 			var sfCartesianChart = new SfCartesianChart { TooltipBackground = Colors.Red };
 			var background = Colors.Red;
-			sfCartesianChart.SetDefaultTooltipValue(chartTooltipBehavior);
-			Assert.Equal(background, chartTooltipBehavior.Background);
+			Assert.Equal(background, sfCartesianChart.TooltipBackground);
 		}
 
 		[Fact]
@@ -74,9 +71,7 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 			var chartTooltipBehavior = new ChartTooltipBehavior();
 			var sfCartesianChart = new SfCartesianChart { TooltipTextColor = Colors.Blue };
 			var textColor = Colors.Blue;
-			sfCartesianChart.SetDefaultTooltipValue(chartTooltipBehavior);
-
-			Assert.Equal(textColor, chartTooltipBehavior.TextColor);
+			Assert.Equal(textColor, sfCartesianChart.TooltipTextColor);
 		}
 
 		[Fact]
@@ -86,18 +81,65 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 			var chartTooltipBehavior = new ChartTooltipBehavior();
 			var sfCartesianChart = new SfCartesianChart { TooltipFontSize = 12.0 };
 			var fontSize = 12.0;
-			sfCartesianChart.SetDefaultTooltipValue(chartTooltipBehavior);
-			Assert.Equal(fontSize, chartTooltipBehavior.FontSize);
+			Assert.Equal(fontSize, sfCartesianChart.TooltipFontSize);
+		}
+
+		[Fact]
+		public void UpdateTooltipAppearance_TestWithTooltipBehaviorValues()
+		{
+			var backgroundColor = Colors.Red;
+			var textColor = Colors.Blue;
+			var fontSize = 12.0f;
+
+			var chartTooltipBehavior = new ChartTooltipBehavior();
+			var sfCartesianChart = new SfCartesianChart();
+
+			chartTooltipBehavior.Background = backgroundColor;
+			chartTooltipBehavior.TextColor = textColor;
+			chartTooltipBehavior.FontSize = fontSize;
+
+			var columnSeries  = new ColumnSeries();
+			columnSeries.Chart = sfCartesianChart;
+			TooltipInfo info = new TooltipInfo(columnSeries);
+
+			columnSeries.UpdateTooltipAppearance(info, chartTooltipBehavior);
+
+			Assert.Equal(info.Background, backgroundColor);
+			Assert.Equal(info.TextColor, textColor);
+			Assert.Equal(info.FontSize, fontSize);
+		}
+
+		[Fact]
+		public void UpdateTooltipAppearance_TestWithCartesianChartValues()
+		{
+			var backgroundColor = Colors.Red;
+			var textColor = Colors.Blue;
+			var fontSize = 12.0f;
+
+			var chartTooltipBehavior = new ChartTooltipBehavior();
+			var sfCartesianChart = new SfCartesianChart();
+
+			sfCartesianChart.TooltipBackground = backgroundColor;
+			sfCartesianChart.TooltipTextColor = textColor;
+			sfCartesianChart.TooltipFontSize = fontSize;
+
+			var columnSeries = new ColumnSeries();
+			columnSeries.Chart = sfCartesianChart;
+			TooltipInfo info = new TooltipInfo(columnSeries);
+
+			columnSeries.UpdateTooltipAppearance(info, chartTooltipBehavior);
+
+			Assert.Equal(info.Background, backgroundColor);
+			Assert.Equal(info.TextColor, textColor);
+			Assert.Equal(info.FontSize, fontSize);
 		}
 
 		[Fact]
 		public void CreateChartArea_InitializesWithCurrentInstance()
 		{
-
 			var sfCartesianChart = new SfCartesianChart();
 			var result = sfCartesianChart.CreateChartArea();
 			Assert.NotNull(result);
-
 		}
 
 		[Fact]

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Chart/Features/SegmentUnitTests.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Chart/Features/SegmentUnitTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.Data;
 using Syncfusion.Maui.Toolkit.Charts;
 
-namespace Syncfusion.Maui.Toolkit.UnitTest
+namespace Syncfusion.Maui.Toolkit.UnitTest.Charts
 {
 	public class SegmentUnitTests : BaseUnitTest
 	{


### PR DESCRIPTION
### Description

When setting the AppThemeBinding to tooltipBehavior background color, the tooltip background was not updated when the theme was changed.

https://github.com/syncfusion/maui-toolkit/issues/159 

### Root Cause of the Issue

To set the internal property values to the behavior background property, the binding property was overridden to the value property, so the appthemebinding values were not dynamically updated. 

### Changes description

Set the Behavior background property value to tooltipinfo. If it is null means to set the tooltip background that was applied in the resource key, and if it is also null means to set the default values for the tooltip background.

### Test cases ###

1. Test with Appthemebinding for Background property and change the theme dynamically and load time.
3. Test with Resource key for Tooltipbackground property and change the theme dynamically and load time.
4. Test the Both AppThemeBidning and TooltipBackground resource key.
5. Test without both AppthemeBinding and TooltipBackground resource key.

Test this cases for Caresian, Circular, Funnel, Pyramid and Polar chart.

### Screenshots

#### Before:

https://github.com/user-attachments/assets/e89c116c-4df2-4cfd-a111-043dca67ad25


#### After:

https://github.com/user-attachments/assets/abbbc20b-2bfd-45e9-9412-d4a63a1d2b95

