### PR TITLE
Resolved the ValueChanged event issue in SfOtpInput.

### DIFF
--- a/maui/src/OtpInput/SfOtpInput.cs
+++ b/maui/src/OtpInput/SfOtpInput.cs
@@ -862,12 +862,28 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 					return;
 				}
 
-                if (otpInput.ValueChanged != null)
-                {
-                    RaiseValueChangedEvent(otpInput, oldValue?.ToString() ?? string.Empty, newValue?.ToString() ?? string.Empty);
+				string newValueStr = newValue?.ToString() ?? string.Empty;
+				string oldValueStr = oldValue?.ToString() ?? string.Empty;
+
+				if (otpInput.Type == OtpInputType.Number)
+				{
+					newValueStr = new string(newValueStr.Where(c => !char.IsControl(c)).ToArray());
+					oldValueStr = new string(oldValueStr.Where(c => !char.IsControl(c)).ToArray());
 				}
-                
-                otpInput.UpdateValue(bindable, newValue?? string.Empty);
+
+				if (otpInput.ValueChanged != null)
+				{
+					if (otpInput.Type == OtpInputType.Number)
+					{
+						RaiseValueChangedEvent(otpInput, oldValueStr, newValueStr);
+					}
+					else
+					{
+						RaiseValueChangedEvent(otpInput, oldValue?.ToString() ?? string.Empty, newValue?.ToString() ?? string.Empty);
+					}
+				}
+
+				otpInput.UpdateValue(bindable, newValue?? string.Empty);
             }
         }
 


### PR DESCRIPTION
### Root Cause of the Issue

In the SfOtpInput control, the `GetPlaceHolder()` method appends `\0` (null) characters to pad the placeholder text to the required Length. These null characters unintentionally propagate into the `Value` property, particularly when Type is set to Number.

This behavior causes:

Value being polluted with `\0` characters (e.g., "1\0\0" for Length=3)

Incorrect entry behavior: Deleting the first character shifts the second entry's value to the first, breaking the position-to-box integrity.

### Description of Change

**Input Type Fix (Number):** Modified internal logic to prevent `\0` padding from affecting the actual Value property.

**Backspace Handling:** Enforced a strict one-to-one mapping between value positions and UI boxes, preventing value shifting on deletion.

**Value Sanitization (Optional Enhancement):** Updated the Value getter to strip `\0` characters before returning, ensuring a clean string representation.

### Issues Fixed

Fix : https://github.com/syncfusion/maui-toolkit/issues/183
Prevent character shifting by maintaining strict position-to-box mapping, especially on backspace and numeric validation logic. Value Getter Enhancement (Optional): Ensure internal logic accessing Value strips \0.

### Screenshots

#### Before:
![OTPInputValueChangedIssue](https://github.com/user-attachments/assets/a93c9ea8-00e8-4e0a-8ff2-ea7f234e095f)

#### After:


https://github.com/user-attachments/assets/76769297-12f5-4bbb-a5b3-520d5755dee2



