### PR TITLE
fix: make SfPicker respect HorizontalOptions and VerticalOptions for adjustable layout

### DIFF
--- a/maui/src/Picker/PickerBase.cs
+++ b/maui/src/Picker/PickerBase.cs
@@ -240,6 +240,8 @@ namespace Syncfusion.Maui.Toolkit.Picker
         void AddChildren()
         {
             _pickerStackLayout = new PickerStackLayout(this);
+            _pickerStackLayout.HorizontalOptions = this.HorizontalOptions;
+            _pickerStackLayout.VerticalOptions = this.VerticalOptions;
             AddOrRemoveHeaderLayout();
             _pickerContainer = new PickerContainer(this);
             _pickerStackLayout.Children.Add(_pickerContainer);


### PR DESCRIPTION
This PR updates the internal PickerStackLayout in SfPicker to respect the HorizontalOptions and VerticalOptions properties set on the picker control. This allows the picker to be sized and aligned according to these layout options, fixing the issue where the picker did not adjust its size or alignment as expected.

- Sets HorizontalOptions and VerticalOptions on PickerStackLayout in PickerBase.
- No breaking changes; only layout behavior is improved.