### PR TITLE
Feature/otp size bindable properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 bin
 obj
 .vs/
+.vshistory/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 bin
 obj
+.vs/

--- a/maui/src/OtpInput/SfOtpInput.cs
+++ b/maui/src/OtpInput/SfOtpInput.cs
@@ -1,10 +1,10 @@
-﻿using Syncfusion.Maui.Toolkit.Internals;
-using Syncfusion.Maui.Toolkit.Graphics.Internals;
-using Rect = Microsoft.Maui.Graphics.Rect; // Alias for Maui's Rect
-using TextAlignment = Microsoft.Maui.TextAlignment; // Alias for Maui's TextAlignment
-using ResourceDictionary = Microsoft.Maui.Controls.ResourceDictionary; // Alias for Maui's ResourceDictionary
+﻿using Syncfusion.Maui.Toolkit.Graphics.Internals;
 using Syncfusion.Maui.Toolkit.Helper;
+using Syncfusion.Maui.Toolkit.Internals;
 using Syncfusion.Maui.Toolkit.Themes;
+using Rect = Microsoft.Maui.Graphics.Rect;
+using ResourceDictionary = Microsoft.Maui.Controls.ResourceDictionary;
+using TextAlignment = Microsoft.Maui.TextAlignment;
 using System.Globalization;
 #if WINDOWS
 using Microsoft.UI.Xaml;
@@ -1057,10 +1057,10 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 				if ((bool)newValue)
 				{
 #if !(MACCATALYST || IOS)
-                    otpInput.Loaded += (s, e) =>
-                    {
-                        otpInput._otpEntries[0].Focus();
-                    };
+					otpInput.Loaded += (s, e) =>
+					{
+						otpInput._otpEntries[0].Focus();
+					};
 #else
 					Task.Run(() =>
 					{
@@ -1154,7 +1154,7 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 		}
 
 		/// <summary>
-		/// Add this property changed handler
+		/// Updates all OTP entry dimensions when BoxWidth or BoxHeight changes.
 		/// </summary>
 		static void OnBoxSizePropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
@@ -1166,10 +1166,7 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 				{
 					foreach (var entry in otpInput._otpEntries)
 					{
-						entry.MinimumWidthRequest = otpInput._entryWidth;
-						entry.MinimumHeightRequest = otpInput._entryHeight;
-						entry.WidthRequest = otpInput._entryWidth;
-						entry.HeightRequest = otpInput._entryHeight;
+						otpInput.ApplyEntrySize(entry);
 					}
 				}
 				otpInput.InvalidateMeasure();
@@ -1411,21 +1408,29 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 		{
 			OTPEntry otpEntry = new OTPEntry
 			{
-				MinimumWidthRequest = _entryWidth,
-				MinimumHeightRequest = _entryHeight,
-				WidthRequest = _entryWidth,
-				HeightRequest = _entryHeight,
 				FontSize = 16,
 				HorizontalTextAlignment = TextAlignment.Center,
 				VerticalTextAlignment = TextAlignment.Center,
 				Keyboard = Type is OtpInputType.Number ? Keyboard.Numeric : Keyboard.Text,
 			};
 
+			ApplyEntrySize(otpEntry);
 			otpEntry.BindingContext = this;
 			otpEntry.SetBinding(OTPEntry.PlaceholderColorProperty, BindingHelper.CreateBinding(nameof(PlaceholderColor), getter: static (SfOtpInput otpInput) => otpInput.PlaceholderColor));
 			otpEntry.SetBinding(OTPEntry.TextColorProperty, BindingHelper.CreateBinding(nameof(TextColor), getter: static (SfOtpInput otpInput) => otpInput.TextColor));
 
 			return otpEntry;
+		}
+
+		/// <summary>
+		/// Applies the current entry size to the given OTPEntry.
+		/// </summary>
+		void ApplyEntrySize(OTPEntry entry)
+		{
+			entry.MinimumWidthRequest = _entryWidth;
+			entry.MinimumHeightRequest = _entryHeight;
+			entry.WidthRequest = _entryWidth;
+			entry.HeightRequest = _entryHeight;
 		}
 
 		/// <summary>
@@ -1533,19 +1538,19 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 				});
 			}
 #else
+			{
+				if (Type is OtpInputType.Password && e.NewTextValue is not "")
 				{
-					if (Type is OtpInputType.Password && e.NewTextValue is not "")
-					{
-						_otpEntries[index].Text = MaskCharacter.ToString();
-					}
-
-					if (isValidText)
-					{
-						Value = new string(valueArray);
-					}
-
-					HandleFocus(index, hasText);
+					_otpEntries[index].Text = MaskCharacter.ToString();
 				}
+
+				if (isValidText)
+				{
+					Value = new string(valueArray);
+				}
+
+				HandleFocus(index, hasText);
+			}
 #endif
 
 #if ANDROID || WINDOWS

--- a/maui/src/OtpInput/SfOtpInput.cs
+++ b/maui/src/OtpInput/SfOtpInput.cs
@@ -2028,7 +2028,7 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
         /// Handles key down events for OTP input fields.
         /// </summary>
         /// <param name="sender">The object that triggered the event.</param>
-        /// <param { get; set; }="e">Event arguments containing key information.</param>
+        /// <param name="e">Event arguments containing key information.</param>
         void OnKeyDown(object sender, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
         {
             if (_otpEntries is null)
@@ -2315,7 +2315,7 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 		/// Sets up platform-specific event handlers for key input validation and handling.
 		/// </summary>
 		/// <param name="sender">The OTPEntry control whose handler has changed.</param>
-		/// <param { get; set; }="e">Event arguments containing details of the change.</param>
+		/// <param name="e">Event arguments containing details of the change.</param>
 		void OnHandlerChanged(object? sender, EventArgs e)
 		{
 			if (sender is OTPEntry textBox)

--- a/maui/src/OtpInput/SfOtpInput.cs
+++ b/maui/src/OtpInput/SfOtpInput.cs
@@ -1,11 +1,11 @@
-﻿using Syncfusion.Maui.Toolkit.Graphics.Internals;
+﻿using System.Globalization;
+using Syncfusion.Maui.Toolkit.Graphics.Internals;
 using Syncfusion.Maui.Toolkit.Helper;
 using Syncfusion.Maui.Toolkit.Internals;
 using Syncfusion.Maui.Toolkit.Themes;
 using Rect = Microsoft.Maui.Graphics.Rect;
 using ResourceDictionary = Microsoft.Maui.Controls.ResourceDictionary;
 using TextAlignment = Microsoft.Maui.TextAlignment;
-using System.Globalization;
 #if WINDOWS
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Input;
@@ -85,11 +85,6 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 		/// Space between each OTP input field.
 		/// </summary>
 		float _spacing;
-
-		/// <summary>
-		/// Length of a decorative line element within the OTP control.
-		/// </summary>
-		float _lineLength = 40;
 
 #if WINDOWS
 		/// <summary>
@@ -1682,9 +1677,8 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 				? (float)(this.Width - _entryWidth - baseXPos)
 				: baseXPos;
 
-			// Update base line points
-			_startPoint = new PointF(xPos, _lineLength + _extraSpacing + yPadding);
-			_endPoint = new PointF(xPos + _entryWidth, _lineLength + _extraSpacing + yPadding);
+			_startPoint = new PointF(xPos, _entryHeight + _extraSpacing + yPadding);
+			_endPoint = new PointF(xPos + _entryWidth, _entryHeight + _extraSpacing + yPadding);
 
 			// Update outline rectangle
 			_outlineRectF = new RectF(xPos, _extraSpacing + yPadding, _entryWidth, _entryHeight);

--- a/maui/src/OtpInput/SfOtpInput.cs
+++ b/maui/src/OtpInput/SfOtpInput.cs
@@ -57,12 +57,12 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
         /// <summary>
         /// Width of each OTP input field.
         /// </summary>
-        float _entryWidth = 40;
+        float _entryWidth;
 
         /// <summary>
         /// Height of each OTP input field.
         /// </summary>
-        float _entryHeight = 40;
+        float _entryHeight;
 
         /// <summary>
         /// Corner radius for the rounded edges of OTP input fields.
@@ -155,6 +155,18 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 		/// </summary>
 		bool _isPasteHandled = false;
 #endif
+
+        /// <summary>
+        /// Identifies the BoxWidth bindable property.
+        /// </summary>
+        public static readonly BindableProperty BoxWidthProperty =
+            BindableProperty.Create(nameof(BoxWidth), typeof(double), typeof(SfOtpInput), 40.0, BindingMode.TwoWay, propertyChanged: OnBoxSizePropertyChanged);
+
+        /// <summary>
+        /// Identifies the BoxHeight bindable property.
+        /// </summary>
+        public static readonly BindableProperty BoxHeightProperty =
+            BindableProperty.Create(nameof(BoxHeight), typeof(double), typeof(SfOtpInput), 40.0, BindingMode.TwoWay, propertyChanged: OnBoxSizePropertyChanged);
 		#endregion
 		#region BindableProperties
 
@@ -303,6 +315,8 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
         {
             ThemeElement.InitializeThemeResources(this, "SfOtpInputTheme");
             DrawingOrder = DrawingOrder.BelowContent;
+            _entryWidth = (float)BoxWidth;
+            _entryHeight = (float)BoxHeight;
             InitializeFields();
 #if IOS
             this.IgnoreSafeArea = true;
@@ -737,6 +751,24 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 		{
 			get { return (Color)GetValue(InputBackgroundProperty); }
 			set { SetValue(InputBackgroundProperty, value); }
+			}
+
+		/// <summary>
+		/// Gets or sets the width of each OTP input box.
+		/// </summary>
+		public double BoxWidth
+		{
+			get => (double)GetValue(BoxWidthProperty);
+			set => SetValue(BoxWidthProperty, value);
+		}
+
+		/// <summary>
+		/// Gets or sets the height of each OTP input box.
+		/// </summary>
+		public double BoxHeight
+		{
+			get => (double)GetValue(BoxHeightProperty);
+			set => SetValue(BoxHeightProperty, value);
 		}
 
 		#endregion
@@ -1118,6 +1150,20 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 			if (bindable is SfOtpInput otpInput)
 			{
 				otpInput?.InvalidateDrawable();
+			}
+		}
+
+		/// <summary>
+		/// Add this property changed handler
+		/// </summary>
+		static void OnBoxSizePropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (bindable is SfOtpInput otpInput)
+			{
+				otpInput._entryWidth = (float)otpInput.BoxWidth;
+				otpInput._entryHeight = (float)otpInput.BoxHeight;
+				otpInput.InvalidateMeasure();
+				otpInput.InvalidateDrawable();
 			}
 		}
 
@@ -1970,7 +2016,7 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
         /// Handles key down events for OTP input fields.
         /// </summary>
         /// <param name="sender">The object that triggered the event.</param>
-        /// <param name="e">Event arguments containing key information.</param>
+        /// <param { get; set; }="e">Event arguments containing key information.</param>
         void OnKeyDown(object sender, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
         {
             if (_otpEntries is null)
@@ -2257,7 +2303,7 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
         /// Sets up platform-specific event handlers for key input validation and handling.
         /// </summary>
         /// <param name="sender">The OTPEntry control whose handler has changed.</param>
-        /// <param name="e">Event arguments containing details of the change.</param>
+        /// <param { get; set; }="e">Event arguments containing details of the change.</param>
         void OnHandlerChanged(object? sender, EventArgs e)
         {
             if (sender is OTPEntry textBox)

--- a/maui/src/OtpInput/SfOtpInput.cs
+++ b/maui/src/OtpInput/SfOtpInput.cs
@@ -16,58 +16,58 @@ using Foundation;
 
 namespace Syncfusion.Maui.Toolkit.OtpInput
 {
-    /// <summary>
-    /// The <see cref="SfOtpInput"/> control is used to enter and verify one-time passwords (OTP) easily and securely.
-    /// </summary>
-    public class SfOtpInput : SfView, IKeyboardListener, IParentThemeElement
+	/// <summary>
+	/// The <see cref="SfOtpInput"/> control is used to enter and verify one-time passwords (OTP) easily and securely.
+	/// </summary>
+	public class SfOtpInput : SfView, IKeyboardListener, IParentThemeElement
 	{
 
-        #region Fields
+		#region Fields
 
-        /// <summary>
-        /// Array of OTP entry controls, each representing an OTP input field.
-        /// </summary>
-        OTPEntry[]? _otpEntries;
+		/// <summary>
+		/// Array of OTP entry controls, each representing an OTP input field.
+		/// </summary>
+		OTPEntry[]? _otpEntries;
 
-        /// <summary>
-        /// Array of bounds defining the position and size of each OTP input field.
-        /// </summary>
-        RectF[] _entryBounds = new RectF[4];
+		/// <summary>
+		/// Array of bounds defining the position and size of each OTP input field.
+		/// </summary>
+		RectF[] _entryBounds = new RectF[4];
 
-        /// <summary>
-        /// Index of the currently focused OTP input field.
-        /// </summary>
-        int _focusedIndex = 0;
+		/// <summary>
+		/// Index of the currently focused OTP input field.
+		/// </summary>
+		int _focusedIndex = 0;
 
-        /// <summary>
-        /// Rectangle used to outline the bounds of each OTP input field for drawing purposes.
-        /// </summary>
-        RectF _outlineRectF = new();
+		/// <summary>
+		/// Rectangle used to outline the bounds of each OTP input field for drawing purposes.
+		/// </summary>
+		RectF _outlineRectF = new();
 
-        /// <summary>
-        /// Starting point of a drawable element line within the OTP control.
-        /// </summary>
-        PointF _startPoint = new();
+		/// <summary>
+		/// Starting point of a drawable element line within the OTP control.
+		/// </summary>
+		PointF _startPoint = new();
 
-        /// <summary>
-        /// Ending point of a drawable element line within the OTP control.
-        /// </summary>
-        PointF _endPoint = new();
+		/// <summary>
+		/// Ending point of a drawable element line within the OTP control.
+		/// </summary>
+		PointF _endPoint = new();
 
-        /// <summary>
-        /// Width of each OTP input field.
-        /// </summary>
-        float _entryWidth;
+		/// <summary>
+		/// Width of each OTP input field.
+		/// </summary>
+		float _entryWidth;
 
-        /// <summary>
-        /// Height of each OTP input field.
-        /// </summary>
-        float _entryHeight;
+		/// <summary>
+		/// Height of each OTP input field.
+		/// </summary>
+		float _entryHeight;
 
-        /// <summary>
-        /// Corner radius for the rounded edges of OTP input fields.
-        /// </summary>
-        const float _cornerRadius = 4;
+		/// <summary>
+		/// Corner radius for the rounded edges of OTP input fields.
+		/// </summary>
+		const float _cornerRadius = 4;
 
 		/// <summary>
 		/// This helps in adjusting the alignment or layout of the elements.
@@ -81,15 +81,15 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 		float _platformSpecificPadding  = 6;
 #endif
 
-        /// <summary>
-        /// Space between each OTP input field.
-        /// </summary>
-        float _spacing;
+		/// <summary>
+		/// Space between each OTP input field.
+		/// </summary>
+		float _spacing;
 
-        /// <summary>
-        /// Length of a decorative line element within the OTP control.
-        /// </summary>
-        float _lineLength = 40;
+		/// <summary>
+		/// Length of a decorative line element within the OTP control.
+		/// </summary>
+		float _lineLength = 40;
 
 #if WINDOWS
 		/// <summary>
@@ -98,30 +98,30 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 		bool _isCapsOn = false;
 #endif
 
-        /// <summary>
-        /// Array of separator labels placed between the OTP input fields.
-        /// </summary>
-        SfLabel[] _separators = new SfLabel[3];
+		/// <summary>
+		/// Array of separator labels placed between the OTP input fields.
+		/// </summary>
+		SfLabel[] _separators = new SfLabel[3];
 
-        /// <summary>
-        /// Width of the separator between OTP input fields.
-        /// </summary>
-        float _separatorWidth;
+		/// <summary>
+		/// Width of the separator between OTP input fields.
+		/// </summary>
+		float _separatorWidth;
 
-        /// <summary>
-        /// Height of the separator between OTP input fields.
-        /// </summary>
-        float _separatorHeight;
+		/// <summary>
+		/// Height of the separator between OTP input fields.
+		/// </summary>
+		float _separatorHeight;
 
-        /// <summary>
-        /// Font size of the separator text between OTP input fields.
-        /// </summary>
-        const double _separatorTextSize = 14;
+		/// <summary>
+		/// Font size of the separator text between OTP input fields.
+		/// </summary>
+		const double _separatorTextSize = 14;
 
-        /// <summary>
-        /// Represents the previous value of the OTP input.
-        /// </summary>
-        string? _oldValue;
+		/// <summary>
+		/// Represents the previous value of the OTP input.
+		/// </summary>
+		string? _oldValue;
 
 #if IOS || MACCATALYST
 		/// <summary>
@@ -156,84 +156,84 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 		bool _isPasteHandled = false;
 #endif
 
-        /// <summary>
-        /// Identifies the BoxWidth bindable property.
-        /// </summary>
-        public static readonly BindableProperty BoxWidthProperty =
-            BindableProperty.Create(nameof(BoxWidth), typeof(double), typeof(SfOtpInput), 40.0, BindingMode.TwoWay, propertyChanged: OnBoxSizePropertyChanged);
+		/// <summary>
+		/// Identifies the BoxWidth bindable property.
+		/// </summary>
+		public static readonly BindableProperty BoxWidthProperty =
+			BindableProperty.Create(nameof(BoxWidth), typeof(double), typeof(SfOtpInput), 40.0, BindingMode.TwoWay, propertyChanged: OnBoxSizePropertyChanged);
 
-        /// <summary>
-        /// Identifies the BoxHeight bindable property.
-        /// </summary>
-        public static readonly BindableProperty BoxHeightProperty =
-            BindableProperty.Create(nameof(BoxHeight), typeof(double), typeof(SfOtpInput), 40.0, BindingMode.TwoWay, propertyChanged: OnBoxSizePropertyChanged);
+		/// <summary>
+		/// Identifies the BoxHeight bindable property.
+		/// </summary>
+		public static readonly BindableProperty BoxHeightProperty =
+			BindableProperty.Create(nameof(BoxHeight), typeof(double), typeof(SfOtpInput), 40.0, BindingMode.TwoWay, propertyChanged: OnBoxSizePropertyChanged);
 		#endregion
 		#region BindableProperties
 
 		/// <summary>
-		/// Identifies the <see cref="Value"/> bindable property. 
+		/// Identifies the <see cref="Value"/> bindable property.
 		/// </summary>
 		public static readonly BindableProperty ValueProperty =
-           BindableProperty.Create(nameof(Value), typeof(string), typeof(SfOtpInput), null, BindingMode.TwoWay, propertyChanged: OnValuePropertyChanged);
+		   BindableProperty.Create(nameof(Value), typeof(string), typeof(SfOtpInput), null, BindingMode.TwoWay, propertyChanged: OnValuePropertyChanged);
 
-        /// <summary>
-        /// Identifies the <see cref="Length"/> bindable property.
-        /// </summary>
-        public static readonly BindableProperty LengthProperty =
-            BindableProperty.Create(nameof(Length), typeof(double), typeof(SfOtpInput), 4.0, BindingMode.TwoWay, propertyChanged: OnLengthPropertyChanged);
+		/// <summary>
+		/// Identifies the <see cref="Length"/> bindable property.
+		/// </summary>
+		public static readonly BindableProperty LengthProperty =
+			BindableProperty.Create(nameof(Length), typeof(double), typeof(SfOtpInput), 4.0, BindingMode.TwoWay, propertyChanged: OnLengthPropertyChanged);
 
-        /// <summary>
-        /// Identifies the <see cref="StylingMode"/> bindable property.
-        /// </summary>
-        public static readonly BindableProperty StylingModeProperty =
-            BindableProperty.Create(nameof(StylingMode), typeof(OtpInputStyle), typeof(SfOtpInput), OtpInputStyle.Outlined, BindingMode.TwoWay, propertyChanged: OnStylingModePropertyChanged);
+		/// <summary>
+		/// Identifies the <see cref="StylingMode"/> bindable property.
+		/// </summary>
+		public static readonly BindableProperty StylingModeProperty =
+			BindableProperty.Create(nameof(StylingMode), typeof(OtpInputStyle), typeof(SfOtpInput), OtpInputStyle.Outlined, BindingMode.TwoWay, propertyChanged: OnStylingModePropertyChanged);
 
-        /// <summary>
-        /// Identifies the <see cref="Placeholder"/> bindable property.
-        /// </summary>
-        public static readonly BindableProperty PlaceholderProperty =
-          BindableProperty.Create(nameof(Placeholder), typeof(string), typeof(SfOtpInput), null, BindingMode.TwoWay, propertyChanged: OnPlaceholderPropertyChanged);
+		/// <summary>
+		/// Identifies the <see cref="Placeholder"/> bindable property.
+		/// </summary>
+		public static readonly BindableProperty PlaceholderProperty =
+		  BindableProperty.Create(nameof(Placeholder), typeof(string), typeof(SfOtpInput), null, BindingMode.TwoWay, propertyChanged: OnPlaceholderPropertyChanged);
 
-        /// <summary>
-        /// Identifies the <see cref="Type"/> bindable property.
-        /// </summary>
-        public static readonly BindableProperty TypeProperty =
-            BindableProperty.Create(nameof(Type), typeof(OtpInputType), typeof(SfOtpInput), OtpInputType.Number, BindingMode.TwoWay, propertyChanged: OnTypePropertyChanged);
+		/// <summary>
+		/// Identifies the <see cref="Type"/> bindable property.
+		/// </summary>
+		public static readonly BindableProperty TypeProperty =
+			BindableProperty.Create(nameof(Type), typeof(OtpInputType), typeof(SfOtpInput), OtpInputType.Number, BindingMode.TwoWay, propertyChanged: OnTypePropertyChanged);
 
-        ///<summary>
-        /// Identifies the <see cref="Separator"/> bindable property.
-        /// </summary>
-        public static readonly BindableProperty SeparatorProperty =
-          BindableProperty.Create(nameof(Separator), typeof(string), typeof(SfOtpInput), string.Empty, BindingMode.TwoWay, propertyChanged: OnSeparatorpropertyChanged);
+		///<summary>
+		/// Identifies the <see cref="Separator"/> bindable property.
+		/// </summary>
+		public static readonly BindableProperty SeparatorProperty =
+		  BindableProperty.Create(nameof(Separator), typeof(string), typeof(SfOtpInput), string.Empty, BindingMode.TwoWay, propertyChanged: OnSeparatorpropertyChanged);
 
-        ///<summary>
-        /// Identifies the <see cref="IsEnabled"/> bindable property.
-        /// </summary>
-        public static new readonly BindableProperty IsEnabledProperty =
-          BindableProperty.Create(nameof(IsEnabled), typeof(bool), typeof(SfOtpInput), true, BindingMode.TwoWay, propertyChanged: OnIsEnabledpropertyChanged);
+		///<summary>
+		/// Identifies the <see cref="IsEnabled"/> bindable property.
+		/// </summary>
+		public static new readonly BindableProperty IsEnabledProperty =
+		  BindableProperty.Create(nameof(IsEnabled), typeof(bool), typeof(SfOtpInput), true, BindingMode.TwoWay, propertyChanged: OnIsEnabledpropertyChanged);
 
-        /// <summary>
-        /// Identifies the <see cref="AutoFocus"/> bindable property.
-        /// </summary>
-        public static readonly BindableProperty AutoFocusProperty =
-            BindableProperty.Create(nameof(AutoFocus), typeof(bool), typeof(SfOtpInput), false, BindingMode.TwoWay, propertyChanged: OnAutoFocusPropertyChanged);
+		/// <summary>
+		/// Identifies the <see cref="AutoFocus"/> bindable property.
+		/// </summary>
+		public static readonly BindableProperty AutoFocusProperty =
+			BindableProperty.Create(nameof(AutoFocus), typeof(bool), typeof(SfOtpInput), false, BindingMode.TwoWay, propertyChanged: OnAutoFocusPropertyChanged);
 
-        /// <summary>
-        /// Identifies the <see cref="MaskCharacter"/> bindable property.
-        /// </summary>
-        public static readonly BindableProperty MaskCharacterProperty =
-            BindableProperty.Create(nameof(MaskCharacter), typeof(char), typeof(SfOtpInput), '●', BindingMode.TwoWay, propertyChanged: OnMaskCharacterPropertyChanged);
+		/// <summary>
+		/// Identifies the <see cref="MaskCharacter"/> bindable property.
+		/// </summary>
+		public static readonly BindableProperty MaskCharacterProperty =
+			BindableProperty.Create(nameof(MaskCharacter), typeof(char), typeof(SfOtpInput), '●', BindingMode.TwoWay, propertyChanged: OnMaskCharacterPropertyChanged);
 
-        /// <summary>
-        /// Identifies the <see cref="InputState"/> bindable property.
-        /// </summary>
-        public static readonly BindableProperty InputStateProperty =
-            BindableProperty.Create(nameof(InputState), typeof(OtpInputState), typeof(SfOtpInput), OtpInputState.Default, BindingMode.TwoWay, propertyChanged: OnInputStatePropertyChanged);
+		/// <summary>
+		/// Identifies the <see cref="InputState"/> bindable property.
+		/// </summary>
+		public static readonly BindableProperty InputStateProperty =
+			BindableProperty.Create(nameof(InputState), typeof(OtpInputState), typeof(SfOtpInput), OtpInputState.Default, BindingMode.TwoWay, propertyChanged: OnInputStatePropertyChanged);
 
 		/// <summary>
 		/// Identifies the <see cref="TextColor"/> bindable property.
 		/// </summary>
-		public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(SfOtpInput), Color.FromArgb("#1C1B1F"), BindingMode.TwoWay,propertyChanged:OnPropertyChanged);
+		public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(SfOtpInput), Color.FromArgb("#1C1B1F"), BindingMode.TwoWay, propertyChanged: OnPropertyChanged);
 
 		/// <summary>
 		/// Identifies the <see cref="Stroke"/> bindable property.
@@ -298,7 +298,7 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 		/// Identifies the <see cref="ErrorStroke"/> bindable property.
 		/// </summary>
 		internal static readonly BindableProperty ErrorStrokeProperty = BindableProperty.Create(nameof(ErrorStroke), typeof(Color), typeof(SfOtpInput), Color.FromArgb("#B3261E"), BindingMode.TwoWay, propertyChanged: OnPropertyChanged);
-		
+
 		/// <summary>
 		/// Identifies the <see cref="DisabledTextColor"/> bindable property.
 		/// </summary>
@@ -312,17 +312,17 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 		/// Initializes a new instance of the <see cref="SfOtpInput"/> class.
 		/// </summary>
 		public SfOtpInput()
-        {
-            ThemeElement.InitializeThemeResources(this, "SfOtpInputTheme");
-            DrawingOrder = DrawingOrder.BelowContent;
-            _entryWidth = (float)BoxWidth;
-            _entryHeight = (float)BoxHeight;
-            InitializeFields();
+		{
+			ThemeElement.InitializeThemeResources(this, "SfOtpInputTheme");
+			DrawingOrder = DrawingOrder.BelowContent;
+			_entryWidth = (float)BoxWidth;
+			_entryHeight = (float)BoxHeight;
+			InitializeFields();
 #if IOS
-            this.IgnoreSafeArea = true;
+			this.IgnoreSafeArea = true;
 #endif
-            this.AddKeyboardListener(this);
-            HookEvents();
+			this.AddKeyboardListener(this);
+			HookEvents();
 			this.SetDynamicResource(FilledHoveredBackgroundProperty, "SfOtpInputHoveredBackground");
 			this.SetDynamicResource(FilledDisableBackgroundProperty, "SfOtpInputBackgroundDisabled");
 			this.SetDynamicResource(FocusedStrokeProperty, "SfOtpInputBorderPressed");
@@ -338,27 +338,27 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 
 		#region Properties
 
-		/// <summary> 
-		/// Gets or sets a value for the OTP input in SfOtpInput control. 
-		/// </summary> 
-		/// <value> 
+		/// <summary>
+		/// Gets or sets a value for the OTP input in SfOtpInput control.
+		/// </summary>
+		/// <value>
 		/// It accepts string values.
-		/// </value> 
+		/// </value>
 		/// <example>
 		/// Below is an example of how to configure the <see cref="Value"/> property using XAML and C#:
-		/// 
+		///
 		/// # [XAML](#tab/tabid-1)
 		/// <code Lang="XAML"><![CDATA[
 		/// <otpInput:SfOtpInput x:Name="otpInput" Value="1234"/>
 		/// ]]></code>
-		/// 
+		///
 		/// # [C#](#tab/tabid-2)
 		/// <code Lang="C#"><![CDATA[
 		/// SfOtpInput otpInput = new SfOtpInput();
 		/// otpInput.Value = "1234";
 		/// this.Content = otpInput;
 		/// ]]></code>
-		/// 
+		///
 		/// ***
 		/// </example>
 		public string Value
@@ -367,27 +367,27 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 			set { SetValue(ValueProperty, value); }
 		}
 
-		/// <summary> 
-		/// Gets or sets a value that can be used to specify the length of the input fields in SfOtpInput control. 
-		/// </summary> 
-		/// <value> 
+		/// <summary>
+		/// Gets or sets a value that can be used to specify the length of the input fields in SfOtpInput control.
+		/// </summary>
+		/// <value>
 		/// It accepts double values and the default value is 4.
 		/// </value>
 		/// <example>
 		/// Below is an example of how to configure the <see cref="Length"/> property using XAML and C#:
-		/// 
+		///
 		/// # [XAML](#tab/tabid-1)
 		/// <code Lang="XAML"><![CDATA[
 		/// <otpInput:SfOtpInput x:Name="otpInput" Length="5" />
 		/// ]]></code>
-		/// 
+		///
 		/// # [C#](#tab/tabid-2)
 		/// <code Lang="C#"><![CDATA[
 		/// SfOtpInput otpInput = new SfOtpInput();
 		/// otpInput.Length = 5;
 		/// this.Content = otpInput;
 		/// ]]></code>
-		/// 
+		///
 		/// ***
 		/// </example>
 		public double Length
@@ -396,27 +396,27 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 			set { SetValue(LengthProperty, value); }
 		}
 
-		/// <summary>  
+		/// <summary>
 		/// Gets or sets a value that can be used to customize the OTP  input fields in SfOtpInput.
-		/// </summary>  
-		/// <value>  
+		/// </summary>
+		/// <value>
 		/// A <see cref="OtpInputStyle"/> value. The default is <see cref="OtpInputStyle.Outlined"/>.
 		/// </value>
 		/// <example>
 		/// Below is an example of how to configure the <see cref="StylingMode"/> property using XAML and C#:
-		/// 
+		///
 		/// # [XAML](#tab/tabid-1)
 		/// <code Lang="XAML"><![CDATA[
 		/// <otpInput:SfOtpInput x:Name="otpInput" StylingMode="Filled" />
 		/// ]]></code>
-		/// 
+		///
 		/// # [C#](#tab/tabid-2)
 		/// <code Lang="C#"><![CDATA[
 		/// SfOtpInput otpInput = new SfOtpInput();
 		/// otpInput.StylingMode = OtpInputStyle.Filled;
 		/// this.Content = otpInput;
 		/// ]]></code>
-		/// 
+		///
 		/// ***
 		/// </example>
 		public OtpInputStyle StylingMode
@@ -425,27 +425,27 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 			set { SetValue(StylingModeProperty, value); }
 		}
 
-		/// <summary>  
+		/// <summary>
 		/// Gets or sets a value that can be used to shown as a hint/placeholder until the user focuses on or enters a value in SfOtpInput.
-		/// </summary>  
-		/// <value>  
+		/// </summary>
+		/// <value>
 		/// It accepts string values.
 		/// </value>
 		/// <example>
 		/// Below is an example of how to configure the <see cref="Placeholder"/> property using XAML and C#:
-		/// 
+		///
 		/// # [XAML](#tab/tabid-1)
 		/// <code Lang="XAML"><![CDATA[
 		/// <otpInput:SfOtpInput x:Name="otpInput" Placeholder="X" />
 		/// ]]></code>
-		/// 
+		///
 		/// # [C#](#tab/tabid-2)
 		/// <code Lang="C#"><![CDATA[
 		/// SfOtpInput otpInput = new SfOtpInput();
 		/// otpInput.Placeholder = "X";
 		/// this.Content = otpInput;
 		/// ]]></code>
-		/// 
+		///
 		/// ***
 		/// </example>
 		public string Placeholder
@@ -454,27 +454,27 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 			set { SetValue(PlaceholderProperty, value); }
 		}
 
-		/// <summary>  
+		/// <summary>
 		/// Gets or sets a value that can be used to specify the input values for the OTP input fields in SfOtpInput.
-		/// </summary>  
-		/// <value>  
+		/// </summary>
+		/// <value>
 		/// It accepts the <see cref="OtpInputType"/> values and the default is <see cref="OtpInputType.Number"/>.
 		/// </value>
 		/// <example>
 		/// Below is an example of how to configure the <see cref="Type"/> property using XAML and C#:
-		/// 
+		///
 		/// # [XAML](#tab/tabid-1)
 		/// <code Lang="XAML"><![CDATA[
 		/// <otpInput:SfOtpInput x:Name="otpInput" Type="Password" />
 		/// ]]></code>
-		/// 
+		///
 		/// # [C#](#tab/tabid-2)
 		/// <code Lang="C#"><![CDATA[
 		/// SfOtpInput otpInput = new SfOtpInput();
 		/// otpInput.Type = OtpInputType.Password;
 		/// this.Content = otpInput;
 		/// ]]></code>
-		/// 
+		///
 		/// ***
 		/// </example>
 		public OtpInputType Type
@@ -485,25 +485,25 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 
 		///<summary>
 		/// Gets or sets a value that can be add a unique characters between the OTP input fields in SfOtpInput.
-		/// </summary>  
-		/// <value>  
+		/// </summary>
+		/// <value>
 		/// It accepts string values and the default value is an empty string.
 		/// </value>
 		/// <example>
 		/// Below is an example of how to configure the <see cref="Separator"/> property using XAML and C#:
-		/// 
+		///
 		/// # [XAML](#tab/tabid-1)
 		/// <code Lang="XAML"><![CDATA[
 		/// <otpInput:SfOtpInput x:Name="otpInput" Separator="|" />
 		/// ]]></code>
-		/// 
+		///
 		/// # [C#](#tab/tabid-2)
 		/// <code Lang="C#"><![CDATA[
 		/// SfOtpInput otpInput = new SfOtpInput();
 		/// otpInput.Separator = "|";
 		/// this.Content = otpInput;
 		/// ]]></code>
-		/// 
+		///
 		/// ***
 		/// </example>
 		public string Separator
@@ -512,27 +512,27 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 			set { SetValue(SeparatorProperty, value); }
 		}
 
-		/// <summary>  
-		/// Gets or sets a value indicating whether to enable or disable the SfOtpInput control.  
-		/// </summary>  
-		/// <value>  
+		/// <summary>
+		/// Gets or sets a value indicating whether to enable or disable the SfOtpInput control.
+		/// </summary>
+		/// <value>
 		/// It accepts Boolean values and the default value is true.
 		/// </value>
 		/// <example>
 		/// Below is an example of how to configure the <see cref="IsEnabled"/> property using XAML and C#:
-		/// 
+		///
 		/// # [XAML](#tab/tabid-1)
 		/// <code Lang="XAML"><![CDATA[
 		/// <otpInput:SfOtpInput x:Name="otpInput" IsEnabled="False" />
 		/// ]]></code>
-		/// 
+		///
 		/// # [C#](#tab/tabid-2)
 		/// <code Lang="C#"><![CDATA[
 		/// SfOtpInput otpInput = new SfOtpInput();
 		/// otpInput.IsEnabled = false;
 		/// this.Content = otpInput;
 		/// ]]></code>
-		/// 
+		///
 		/// ***
 		/// </example>
 		public new bool IsEnabled
@@ -541,27 +541,27 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 			set { SetValue(IsEnabledProperty, value); }
 		}
 
-		/// <summary>  
-		/// Gets or sets a value indicating whether the SfOtpInput field should automatically receive focus when the component is rendered. 
-		/// </summary>  
-		/// <value>  
+		/// <summary>
+		/// Gets or sets a value indicating whether the SfOtpInput field should automatically receive focus when the component is rendered.
+		/// </summary>
+		/// <value>
 		/// It accepts the Boolean values and the default value is false.
 		/// </value>
 		/// <example>
 		/// Below is an example of how to configure the <see cref="AutoFocus"/> property using XAML and C#:
-		/// 
+		///
 		/// # [XAML](#tab/tabid-1)
 		/// <code Lang="XAML"><![CDATA[
 		/// <otpInput:SfOtpInput x:Name="otpInput" AutoFocus="True" />
 		/// ]]></code>
-		/// 
+		///
 		/// # [C#](#tab/tabid-2)
 		/// <code Lang="C#"><![CDATA[
 		/// SfOtpInput otpInput = new SfOtpInput();
 		/// otpInput.AutoFocus = true;
 		/// this.Content = otpInput;
 		/// ]]></code>
-		/// 
+		///
 		/// ***
 		/// </example>
 		public bool AutoFocus
@@ -570,20 +570,20 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 			set { SetValue(AutoFocusProperty, value); }
 		}
 
-		/// <summary>  
+		/// <summary>
 		/// Gets or sets a character value that can be used to mask the OTP input values in password mode.
-		/// </summary>  
-		/// <value>  
+		/// </summary>
+		/// <value>
 		/// It accepts the character values, and the default value is a dot ('●').
 		/// </value>
 		/// <example>
 		/// Below is an example of how to configure the <see cref="MaskCharacter"/> property using XAML and C#:
-		/// 
+		///
 		/// # [XAML](#tab/tabid-1)
 		/// <code Lang="XAML"><![CDATA[
 		/// <otpInput:SfOtpInput x:Name="otpInput" Type="Password" MaskCharacter="*" />
 		/// ]]></code>
-		/// 
+		///
 		/// # [C#](#tab/tabid-2)
 		/// <code Lang="C#"><![CDATA[
 		/// SfOtpInput otpInput = new SfOtpInput();
@@ -591,39 +591,39 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 		/// otpInput.MaskCharacter = '*';
 		/// this.Content = otpInput;
 		/// ]]></code>
-		/// 
+		///
 		/// ***
 		/// </example>
 		public char MaskCharacter
 		{
 			get { return (char)GetValue(MaskCharacterProperty); }
-		    set { SetValue(MaskCharacterProperty, value); }
+			set { SetValue(MaskCharacterProperty, value); }
 		}
 
-		/// <summary>  
+		/// <summary>
 		/// Gets or sets a value that can be used to customize the visual state of the SfOtpInput control.
-		/// </summary>  
-		/// <value>  
+		/// </summary>
+		/// <value>
 		/// It accepts the OtpInputState values, and the default value is Default.
 		/// </value>
 		/// <remarks>
-		/// This property is useful for scenarios where sensitive information needs to be hidden from view, such as when entering a password or PIN. 
+		/// This property is useful for scenarios where sensitive information needs to be hidden from view, such as when entering a password or PIN.
 		/// </remarks>
 		/// <example>
 		/// Below is an example of how to configure the <see cref="InputState"/> property using XAML and C#:
-		/// 
+		///
 		/// # [XAML](#tab/tabid-1)
 		/// <code Lang="XAML"><![CDATA[
 		/// <otpInput:SfOtpInput x:Name="otpInput" InputState="Success" />
 		/// ]]></code>
-		/// 
+		///
 		/// # [C#](#tab/tabid-2)
 		/// <code Lang="C#"><![CDATA[
 		/// SfOtpInput otpInput = new SfOtpInput();
 		/// otpInput.InputState = OtpInputState.Success;
 		/// this.Content = otpInput;
 		/// ]]></code>
-		/// 
+		///
 		/// ***
 		/// </example>
 		public OtpInputState InputState
@@ -640,19 +640,19 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 		/// </value>
 		/// <example>
 		/// Below is an example of how to configure the <see cref="TextColor"/> property using XAML and C#:
-		/// 
+		///
 		/// # [XAML](#tab/tabid-1)
 		/// <code Lang="XAML"><![CDATA[
 		/// <otpInput:SfOtpInput x:Name="otpInput" TextColor="Green" />
 		/// ]]></code>
-		/// 
+		///
 		/// # [C#](#tab/tabid-2)
 		/// <code Lang="C#"><![CDATA[
 		/// SfOtpInput otpInput = new SfOtpInput();
 		/// otpInput.TextColor = Colors.Green;
 		/// this.Content = otpInput;
 		/// ]]></code>
-		/// 
+		///
 		/// ***
 		/// </example>
 		public Color TextColor
@@ -669,19 +669,19 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 		/// </value>
 		/// <example>
 		/// Below is an example of how to configure the <see cref="Stroke"/> property using XAML and C#:
-		/// 
+		///
 		/// # [XAML](#tab/tabid-1)
 		/// <code Lang="XAML"><![CDATA[
 		/// <otpInput:SfOtpInput x:Name="otpInput" Stroke="Blue" />
 		/// ]]></code>
-		/// 
+		///
 		/// # [C#](#tab/tabid-2)
 		/// <code Lang="C#"><![CDATA[
 		/// SfOtpInput otpInput = new SfOtpInput();
 		/// otpInput.Stroke = Colors.Blue;
 		/// this.Content = otpInput;
 		/// ]]></code>
-		/// 
+		///
 		/// ***
 		/// </example>
 		public Color Stroke
@@ -698,12 +698,12 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 		/// </value>
 		/// <example>
 		/// Below is an example of how to configure the <see cref="PlaceholderColor"/> property using XAML and C#:
-		/// 
+		///
 		/// # [XAML](#tab/tabid-1)
 		/// <code Lang="XAML"><![CDATA[
 		/// <otpInput:SfOtpInput x:Name="otpInput" Placeholder="X" PlaceholderColor="Orange" />
 		/// ]]></code>
-		/// 
+		///
 		/// # [C#](#tab/tabid-2)
 		/// <code Lang="C#"><![CDATA[
 		/// SfOtpInput otpInput = new SfOtpInput();
@@ -711,7 +711,7 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 		/// otpInput.PlaceholderColor = Colors.Orange;
 		/// this.Content = otpInput;
 		/// ]]></code>
-		/// 
+		///
 		/// ***
 		/// </example>
 		public Color PlaceholderColor
@@ -731,12 +731,12 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 		/// </value>
 		/// <example>
 		/// Below is an example of how to configure the <see cref="InputBackground"/> property using XAML and C#:
-		/// 
+		///
 		/// # [XAML](#tab/tabid-1)
 		/// <code Lang="XAML"><![CDATA[
 		/// <otpInput:SfOtpInput x:Name="otpInput" StylingMode="Filled" InputBackground="LightBlue" />
 		/// ]]></code>
-		/// 
+		///
 		/// # [C#](#tab/tabid-2)
 		/// <code Lang="C#"><![CDATA[
 		/// SfOtpInput otpInput = new SfOtpInput();
@@ -744,14 +744,14 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 		/// otpInput.InputBackground = Colors.LightBlue;
 		/// this.Content = otpInput;
 		/// ]]></code>
-		/// 
+		///
 		/// ***
 		/// </example>
 		public Color InputBackground
 		{
 			get { return (Color)GetValue(InputBackgroundProperty); }
 			set { SetValue(InputBackgroundProperty, value); }
-			}
+		}
 
 		/// <summary>
 		/// Gets or sets the width of each OTP input box.
@@ -773,7 +773,7 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 
 		#endregion
 
-		#region Event 
+		#region Event
 
 		/// <summary>
 		/// Invoke the event when the value of <see cref="SfOtpInput"/> is changed.
@@ -784,14 +784,14 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 
 		#region Internal Properties
 
-        /// <summary>
-        /// Gets or sets the color used for separators between OTP input fields.
-        /// </summary>
-        internal Color SeparatorColor
-        {
-            get { return (Color)GetValue(SeparatorColorProperty); }
-            set { SetValue(SeparatorColorProperty, value); }
-        }
+		/// <summary>
+		/// Gets or sets the color used for separators between OTP input fields.
+		/// </summary>
+		internal Color SeparatorColor
+		{
+			get { return (Color)GetValue(SeparatorColorProperty); }
+			set { SetValue(SeparatorColorProperty, value); }
+		}
 
 		/// <summary>
 		/// Gets or sets the hovered stroke color of the Input.
@@ -885,10 +885,10 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 		/// <param name="oldValue">The old value of the Value property.</param>
 		/// <param name="newValue">The new value of the Value property.</param>
 		static void OnValuePropertyChanged(BindableObject bindable, object oldValue, object newValue)
-        {
-            if (bindable is SfOtpInput otpInput)
-            {
-				if(oldValue is not null && newValue is not null && newValue.ToString()?.Length > (int)otpInput.Length)
+		{
+			if (bindable is SfOtpInput otpInput)
+			{
+				if (oldValue is not null && newValue is not null && newValue.ToString()?.Length > (int)otpInput.Length)
 				{
 					otpInput.TrimValueToLength((int)otpInput.Length);
 					return;
@@ -915,20 +915,20 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 					}
 				}
 
-				otpInput.UpdateValue(bindable, newValue?? string.Empty);
-            }
-        }
+				otpInput.UpdateValue(bindable, newValue ?? string.Empty);
+			}
+		}
 
-        /// <summary>
-        /// Property changed method for Length property.
-        /// </summary>
-        /// <param name="bindable">The bindable object should be SfOtpInput.</param>
-        /// <param name="oldValue">The old value of the Length property.</param>
-        /// <param name="newValue">The new value of the Length property.</param>
-        static void OnLengthPropertyChanged(BindableObject bindable, object oldValue, object newValue)
-        {
-            if (bindable is SfOtpInput otpInput && newValue is double newLength && oldValue is double oldLength)
-            {
+		/// <summary>
+		/// Property changed method for Length property.
+		/// </summary>
+		/// <param name="bindable">The bindable object should be SfOtpInput.</param>
+		/// <param name="oldValue">The old value of the Length property.</param>
+		/// <param name="newValue">The new value of the Length property.</param>
+		static void OnLengthPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (bindable is SfOtpInput otpInput && newValue is double newLength && oldValue is double oldLength)
+			{
 
 				if (newLength <= 0)
 				{
@@ -936,73 +936,73 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 					otpInput.Length = oldLength;
 					return;
 				}
-				else if(oldLength <= 0)
+				else if (oldLength <= 0)
 				{
 					oldLength = newLength;
 				}
 
 				otpInput.UpdateEntriesLength((int)oldLength, (int)newLength);
-                otpInput.UpdateValue(bindable, otpInput.Value);
-                otpInput.HookEvents();
-                otpInput.UpdatePlaceholderText();
-                OnIsEnabledpropertyChanged(bindable, otpInput.IsEnabled, otpInput.IsEnabled);
-                otpInput.InvalidateDrawable();
-            }
-        }
+				otpInput.UpdateValue(bindable, otpInput.Value);
+				otpInput.HookEvents();
+				otpInput.UpdatePlaceholderText();
+				OnIsEnabledpropertyChanged(bindable, otpInput.IsEnabled, otpInput.IsEnabled);
+				otpInput.InvalidateDrawable();
+			}
+		}
 
-        /// <summary>
-        /// Property changed method for StylingMode property.
-        /// </summary>
-        /// <param name="bindable">The bindable object should be SfOtpInput.</param>
-        /// <param name="oldValue">The old value of the StylingMode property.</param>
-        /// <param name="newValue">The new value of the StylingMode property.</param>
-        static void OnStylingModePropertyChanged(BindableObject bindable, object oldValue, object newValue)
-        {
-            if (bindable is SfOtpInput otpInput)
-            {
-                otpInput.InvalidateDrawable();
-            }
-        }
+		/// <summary>
+		/// Property changed method for StylingMode property.
+		/// </summary>
+		/// <param name="bindable">The bindable object should be SfOtpInput.</param>
+		/// <param name="oldValue">The old value of the StylingMode property.</param>
+		/// <param name="newValue">The new value of the StylingMode property.</param>
+		static void OnStylingModePropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (bindable is SfOtpInput otpInput)
+			{
+				otpInput.InvalidateDrawable();
+			}
+		}
 
-        /// <summary>
-        /// Property changed method for Placeholder property.
-        /// </summary>
-        /// <param name="bindable">The bindable object should be SfOtpInput.</param>
-        /// <param name="oldValue">The old value of the Placeholder property.</param>
-        /// <param name="newValue">The new value of the Placeholder property.</param>
-        static void OnPlaceholderPropertyChanged(BindableObject bindable, object oldValue, object newValue)
-        {
-            if (bindable is SfOtpInput otpInput)
-            {
-                otpInput.UpdatePlaceholderText();
-                otpInput.InvalidateDrawable();
-            }
-        }
+		/// <summary>
+		/// Property changed method for Placeholder property.
+		/// </summary>
+		/// <param name="bindable">The bindable object should be SfOtpInput.</param>
+		/// <param name="oldValue">The old value of the Placeholder property.</param>
+		/// <param name="newValue">The new value of the Placeholder property.</param>
+		static void OnPlaceholderPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (bindable is SfOtpInput otpInput)
+			{
+				otpInput.UpdatePlaceholderText();
+				otpInput.InvalidateDrawable();
+			}
+		}
 
-        /// <summary>
-        /// Property changed method for Separator property.
-        /// </summary>
-        /// <param name="bindable">The bindable object should be SfOtpInput.</param>
-        /// <param name="oldValue">The old value of the Separator property.</param>
-        /// <param name="newValue">The new value of the Separator property.</param>
-        static void OnSeparatorpropertyChanged(BindableObject bindable, object oldValue, object newValue)
-        {
-            if (bindable is SfOtpInput otpInput)
-            {
-                otpInput.InvalidateMeasure();
-            }
-        }
+		/// <summary>
+		/// Property changed method for Separator property.
+		/// </summary>
+		/// <param name="bindable">The bindable object should be SfOtpInput.</param>
+		/// <param name="oldValue">The old value of the Separator property.</param>
+		/// <param name="newValue">The new value of the Separator property.</param>
+		static void OnSeparatorpropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (bindable is SfOtpInput otpInput)
+			{
+				otpInput.InvalidateMeasure();
+			}
+		}
 
-        /// <summary>
-        /// Property changed method for Type property.
-        /// </summary>
-        /// <param name="bindable">The bindable object should be SfOtpInput.</param>
-        /// <param name="oldValue">The old value of the Type property.</param>
-        /// <param name="newValue">The new value of the Type property.</param>
-        static void OnTypePropertyChanged(BindableObject bindable, object oldValue, object newValue)
-        {
-            if (bindable is SfOtpInput otpInput)
-            {
+		/// <summary>
+		/// Property changed method for Type property.
+		/// </summary>
+		/// <param name="bindable">The bindable object should be SfOtpInput.</param>
+		/// <param name="oldValue">The old value of the Type property.</param>
+		/// <param name="newValue">The new value of the Type property.</param>
+		static void OnTypePropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (bindable is SfOtpInput otpInput)
+			{
 				if (otpInput.Type is OtpInputType.Number && otpInput.Value is not null && otpInput.Value.Any(char.IsLetter))
 				{
 					otpInput._oldValue = otpInput.Value;
@@ -1013,116 +1013,116 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 				}
 				otpInput.UpdateTypeProperty();
 				otpInput.UpdateKeyboardType();
-                otpInput.UpdateMaskCharacter();
+				otpInput.UpdateMaskCharacter();
 				if (otpInput.Value is not null)
 				{
 					otpInput.UpdateValue(bindable, otpInput.Value);
 				}
-                otpInput.InvalidateDrawable();
-            }
-        }
+				otpInput.InvalidateDrawable();
+			}
+		}
 
-        /// <summary>
-        /// Property changed method for IsEnabled property.
-        /// </summary>
-        /// <param name="bindable">The bindable object should be SfOtpInput.</param>
-        /// <param name="oldValue">The old value of the IsEnabled property.</param>
-        /// <param name="newValue">The new value of the IsEnabled property.</param>
-        static void OnIsEnabledpropertyChanged(BindableObject bindable, object oldValue, object newValue)
-        {
-            if (bindable is SfOtpInput otpInput)
-            {
-                if (otpInput._otpEntries is not null)
-                {
-                    foreach (var field in otpInput._otpEntries)
-                    {
-                        field.IsEnabled = (bool)newValue;
-                    }
+		/// <summary>
+		/// Property changed method for IsEnabled property.
+		/// </summary>
+		/// <param name="bindable">The bindable object should be SfOtpInput.</param>
+		/// <param name="oldValue">The old value of the IsEnabled property.</param>
+		/// <param name="newValue">The new value of the IsEnabled property.</param>
+		static void OnIsEnabledpropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (bindable is SfOtpInput otpInput)
+			{
+				if (otpInput._otpEntries is not null)
+				{
+					foreach (var field in otpInput._otpEntries)
+					{
+						field.IsEnabled = (bool)newValue;
+					}
 
-                    otpInput.InvalidateDrawable();
-                }
-            }
-        }
+					otpInput.InvalidateDrawable();
+				}
+			}
+		}
 
-        /// <summary>
-        /// Property changed method for AutoFocus property.
-        /// </summary>
-        /// <param name="bindable">The bindable object should be SfOtpInput.</param>
-        /// <param name="oldValue">The old value of the AutoFocus property.</param>
-        /// <param name="newValue">The new value of the AutoFocus property.</param>
-        static void OnAutoFocusPropertyChanged(BindableObject bindable, object oldValue, object newValue)
-        {
-            if (bindable is SfOtpInput otpInput && otpInput._otpEntries is not null)
-            {
-                if ((bool)newValue)
-                {
+		/// <summary>
+		/// Property changed method for AutoFocus property.
+		/// </summary>
+		/// <param name="bindable">The bindable object should be SfOtpInput.</param>
+		/// <param name="oldValue">The old value of the AutoFocus property.</param>
+		/// <param name="newValue">The new value of the AutoFocus property.</param>
+		static void OnAutoFocusPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (bindable is SfOtpInput otpInput && otpInput._otpEntries is not null)
+			{
+				if ((bool)newValue)
+				{
 #if !(MACCATALYST || IOS)
                     otpInput.Loaded += (s, e) =>
                     {
                         otpInput._otpEntries[0].Focus();
                     };
 #else
-                    Task.Run(() =>
-                    {
-                        MainThread.BeginInvokeOnMainThread(() =>
-                        {
-                            otpInput._otpEntries[0].Focus();
-                        });
-                    });
+					Task.Run(() =>
+					{
+						MainThread.BeginInvokeOnMainThread(() =>
+						{
+							otpInput._otpEntries[0].Focus();
+						});
+					});
 #endif
-                }
-                else
-                {
-                    otpInput._otpEntries[0].Unfocus();
-                }
+				}
+				else
+				{
+					otpInput._otpEntries[0].Unfocus();
+				}
 
-                otpInput.InvalidateDrawable();
-            }
-        }
+				otpInput.InvalidateDrawable();
+			}
+		}
 
-        /// <summary>
-        /// Invoked when the MaskCharacter property is changed.
-        /// </summary>
-        /// <param name="bindable">The bindable object should be SfOtpInput.</param>
-        /// <param name="oldValue">The old value of the MaskCharacter property.</param>
-        /// <param name="newValue">The new value of the MaskCharacter property.</param>
-        static void OnMaskCharacterPropertyChanged(BindableObject bindable, object oldValue, object newValue)
-        {
-            if (bindable is SfOtpInput otpInput)
-            {
-				if(newValue is char maskChar && maskChar is ' ')
+		/// <summary>
+		/// Invoked when the MaskCharacter property is changed.
+		/// </summary>
+		/// <param name="bindable">The bindable object should be SfOtpInput.</param>
+		/// <param name="oldValue">The old value of the MaskCharacter property.</param>
+		/// <param name="newValue">The new value of the MaskCharacter property.</param>
+		static void OnMaskCharacterPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (bindable is SfOtpInput otpInput)
+			{
+				if (newValue is char maskChar && maskChar is ' ')
 				{
 					otpInput.MaskCharacter = '●';
 				}
-                otpInput.UpdateMaskCharacter();
-            }
-        }
+				otpInput.UpdateMaskCharacter();
+			}
+		}
 
-        /// <summary>
-        /// Invoked when the InputState property is changed.Invalidates and redraws the OTP input fields to reflect the updated state.
-        /// </summary>
-        /// <param name="bindable">The bindable object should be SfOtpInput.</param>
-        /// <param name="oldValue">The old value of the InputState property.</param>
-        /// <param name="newValue">The new value of the InputState property.</param>
-        static void OnInputStatePropertyChanged(BindableObject bindable, object oldValue, object newValue)
-        {
-            if (bindable is SfOtpInput otpInput)
-            {
-                otpInput.InvalidateDrawable();
-            }
-        }
+		/// <summary>
+		/// Invoked when the InputState property is changed.Invalidates and redraws the OTP input fields to reflect the updated state.
+		/// </summary>
+		/// <param name="bindable">The bindable object should be SfOtpInput.</param>
+		/// <param name="oldValue">The old value of the InputState property.</param>
+		/// <param name="newValue">The new value of the InputState property.</param>
+		static void OnInputStatePropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (bindable is SfOtpInput otpInput)
+			{
+				otpInput.InvalidateDrawable();
+			}
+		}
 
-        /// <summary>
-        /// Raises the ValueChanged event for the SfOtpInput control.
-        /// </summary>
-        /// <param name="otpInput">The SfOtpInput control.</param>
-        /// <param name="oldValue">The previous value.</param>
-        /// <param name="newValue">The new value.</param>
-        static void RaiseValueChangedEvent(SfOtpInput otpInput, string? oldValue, string? newValue)
-        {
-            var valueChangedEventArgs = new OtpInputValueChangedEventArgs(newValue, oldValue);
-            otpInput.ValueChanged?.Invoke(otpInput, valueChangedEventArgs);
-        }
+		/// <summary>
+		/// Raises the ValueChanged event for the SfOtpInput control.
+		/// </summary>
+		/// <param name="otpInput">The SfOtpInput control.</param>
+		/// <param name="oldValue">The previous value.</param>
+		/// <param name="newValue">The new value.</param>
+		static void RaiseValueChangedEvent(SfOtpInput otpInput, string? oldValue, string? newValue)
+		{
+			var valueChangedEventArgs = new OtpInputValueChangedEventArgs(newValue, oldValue);
+			otpInput.ValueChanged?.Invoke(otpInput, valueChangedEventArgs);
+		}
 
 		/// <summary>
 		/// Invoked when the background property of the control is changed.
@@ -1162,6 +1162,16 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 			{
 				otpInput._entryWidth = (float)otpInput.BoxWidth;
 				otpInput._entryHeight = (float)otpInput.BoxHeight;
+				if (otpInput._otpEntries is not null)
+				{
+					foreach (var entry in otpInput._otpEntries)
+					{
+						entry.MinimumWidthRequest = otpInput._entryWidth;
+						entry.MinimumHeightRequest = otpInput._entryHeight;
+						entry.WidthRequest = otpInput._entryWidth;
+						entry.HeightRequest = otpInput._entryHeight;
+					}
+				}
 				otpInput.InvalidateMeasure();
 				otpInput.InvalidateDrawable();
 			}
@@ -1177,100 +1187,100 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 		/// <param name="canvas">The canvas on which the rectangles will be drawn.</param>
 		/// <param name="rectF">The bounds defining the size and position of the rectangles.</param>
 		public void DrawUI(ICanvas canvas, RectF rectF)
-        {
-            if (_otpEntries is not null)
-            {
-                for (int i = 0; i < Length; i++)
-                {
-                    UpdateDrawingParameters(i);
-                    canvas.StrokeSize = GetStrokeThickness(i);
-                    _otpEntries[i].UpdateParameters(StylingMode, _cornerRadius, _startPoint, _endPoint, this, IsEnabled, InputState,Stroke,InputBackground ,TextColor, DisabledTextColor);
-                    _otpEntries[i].Draw(canvas, _outlineRectF);
+		{
+			if (_otpEntries is not null)
+			{
+				for (int i = 0; i < Length; i++)
+				{
+					UpdateDrawingParameters(i);
+					canvas.StrokeSize = GetStrokeThickness(i);
+					_otpEntries[i].UpdateParameters(StylingMode, _cornerRadius, _startPoint, _endPoint, this, IsEnabled, InputState, Stroke, InputBackground, TextColor, DisabledTextColor);
+					_otpEntries[i].Draw(canvas, _outlineRectF);
 
-                }
-            }
-        }
+				}
+			}
+		}
 
 		#endregion
 
 		#region Private Methods
 
-        /// <summary>
-        /// This method handles navigation and focus changes based on keyboard input.
-        /// </summary>
-        void HandleKeyPress(string key)
-        {
-            if (_otpEntries is null)
-            {
-                return;
-            }
+		/// <summary>
+		/// This method handles navigation and focus changes based on keyboard input.
+		/// </summary>
+		void HandleKeyPress(string key)
+		{
+			if (_otpEntries is null)
+			{
+				return;
+			}
 
-            int newIndex;
+			int newIndex;
 
-            switch (key)
-            {
-                case "Left":
-                    newIndex = _focusedIndex - 1;
+			switch (key)
+			{
+				case "Left":
+					newIndex = _focusedIndex - 1;
 
-                    if (newIndex >= 0)
-                    {
-                        FocusEntry(newIndex, true);
-                    }
+					if (newIndex >= 0)
+					{
+						FocusEntry(newIndex, true);
+					}
 
-                    break;
+					break;
 
-                case "Right":
-                    newIndex = _focusedIndex + 1;
+				case "Right":
+					newIndex = _focusedIndex + 1;
 
-                    if (newIndex < _otpEntries.Length)
-                    {
-                        FocusEntry(newIndex, true);
-                    }
-                    
-                    break;
+					if (newIndex < _otpEntries.Length)
+					{
+						FocusEntry(newIndex, true);
+					}
 
-                case "Back":
-                    _oldValue = string.Empty;
-                    if ((!string.IsNullOrEmpty(_otpEntries[_focusedIndex].Text)) & _otpEntries[_focusedIndex].Text is not "\0")
-                    {
-                        _otpEntries[_focusedIndex].Text = string.Empty;
-                    }
-                    else if (_focusedIndex > 0)
-                    {
-                        newIndex = _focusedIndex - 1;
-                        _otpEntries[newIndex].Text = string.Empty;
-                        FocusEntry(newIndex, false);
-                    }
+					break;
 
-                    break;
+				case "Back":
+					_oldValue = string.Empty;
+					if ((!string.IsNullOrEmpty(_otpEntries[_focusedIndex].Text)) & _otpEntries[_focusedIndex].Text is not "\0")
+					{
+						_otpEntries[_focusedIndex].Text = string.Empty;
+					}
+					else if (_focusedIndex > 0)
+					{
+						newIndex = _focusedIndex - 1;
+						_otpEntries[newIndex].Text = string.Empty;
+						FocusEntry(newIndex, false);
+					}
 
-                case "Tab":
-                    newIndex = _focusedIndex + (_isShiftOn ? -1 : 1);
-                    if (newIndex >= 0 && newIndex < _otpEntries.Length)
-                    {
-                        FocusEntry(newIndex, true);
-                    }
+					break;
+
+				case "Tab":
+					newIndex = _focusedIndex + (_isShiftOn ? -1 : 1);
+					if (newIndex >= 0 && newIndex < _otpEntries.Length)
+					{
+						FocusEntry(newIndex, true);
+					}
 					else
 					{
 						MoveFocusToNextElement(_isShiftOn);
 					}
 
-                    break;
+					break;
 
-                default:
+				default:
 					_oldValue = string.Empty;
-                    char input = key.Last();
-                    bool isValidInput = ((Type == OtpInputType.Number && char.IsDigit(input)) || (Type != OtpInputType.Number) );
-                    if (isValidInput)
-                    {
-                        UpdateEntryValue(input.ToString());
-                    }
+					char input = key.Last();
+					bool isValidInput = ((Type == OtpInputType.Number && char.IsDigit(input)) || (Type != OtpInputType.Number));
+					if (isValidInput)
+					{
+						UpdateEntryValue(input.ToString());
+					}
 
-                    break;
-            }
-        }
+					break;
+			}
+		}
 
-        /// <summary>
+		/// <summary>
 		/// Moves the focus to the next or previous focusable element within the parent visual tree.
 		/// </summary>
 		/// <param name="moveBackward"></param>
@@ -1295,7 +1305,7 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 					var previousElement = focusableElements[currentIndex - 1];
 					if (previousElement is SfOtpInput otpInput && otpInput._otpEntries is not null)
 					{
-						otpInput._otpEntries[^1]?.Focus(); 
+						otpInput._otpEntries[^1]?.Focus();
 					}
 					else
 					{
@@ -1310,7 +1320,7 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 					var nextElement = focusableElements[currentIndex + 1];
 					if (nextElement is SfOtpInput otpInput && otpInput._otpEntries is not null)
 					{
-						otpInput._otpEntries[0]?.Focus(); 
+						otpInput._otpEntries[0]?.Focus();
 					}
 					else
 					{
@@ -1323,24 +1333,24 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 
 
 		/// <summary>
-        /// Initializes the OTP input fields, separators, and their layout.This method dynamically creates the required number of input fields and separators based on the specified length and positions them within the layout.
-        /// </summary>
-        void InitializeFields()
-        {
-            _otpEntries = new OTPEntry[(int)Length];
-            _entryBounds = new RectF[(int)Length];
-            _separators = new SfLabel[(int)Length - 1];
+		/// Initializes the OTP input fields, separators, and their layout.This method dynamically creates the required number of input fields and separators based on the specified length and positions them within the layout.
+		/// </summary>
+		void InitializeFields()
+		{
+			_otpEntries = new OTPEntry[(int)Length];
+			_entryBounds = new RectF[(int)Length];
+			_separators = new SfLabel[(int)Length - 1];
 
-            var layout = new AbsoluteLayout();
+			var layout = new AbsoluteLayout();
 #if IOS
-            layout.IgnoreSafeArea = true;
+			layout.IgnoreSafeArea = true;
 #endif
 			layout.BindingContext = this;
 #if WINDOWS || ANDROID
 			layout.SetBinding(AbsoluteLayout.FlowDirectionProperty, BindingHelper.CreateBinding(nameof(FlowDirection), getter: static (SfOtpInput otpInput) => otpInput.FlowDirection));
 
 #elif MACCATALYST || IOS
-			layout.SetBinding(AbsoluteLayout.FlowDirectionProperty,BindingHelper.CreateBinding(nameof(FlowDirection),getter: static (SfOtpInput otpInput) =>
+			layout.SetBinding(AbsoluteLayout.FlowDirectionProperty, BindingHelper.CreateBinding(nameof(FlowDirection), getter: static (SfOtpInput otpInput) =>
 			{
 				VisualElement? parent = otpInput.Parent as VisualElement;
 
@@ -1352,79 +1362,81 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 				return otpInput.FlowDirection == FlowDirection.MatchParent
 					? (parent?.FlowDirection ?? FlowDirection.LeftToRight)
 					: otpInput.FlowDirection;
-				}
+			}
 				)
 			);
 #endif
 
 			for (int i = 0; i < Length; i++)
-            {
-                OTPEntry otpEntry = InitializeEntry();
-                _otpEntries[i] = otpEntry;
-                layout.Children.Add(otpEntry);
+			{
+				OTPEntry otpEntry = InitializeEntry();
+				_otpEntries[i] = otpEntry;
+				layout.Children.Add(otpEntry);
 
-                // Add separator only if it's not the last entry.
-                if (i < Length - 1)
-                {
-                    SfLabel separatorlabel = InitializeSeparator();
-                    _separators[i] = separatorlabel;
-                    layout.Children.Add(separatorlabel);
-                }
-            }
+				// Add separator only if it's not the last entry.
+				if (i < Length - 1)
+				{
+					SfLabel separatorlabel = InitializeSeparator();
+					_separators[i] = separatorlabel;
+					layout.Children.Add(separatorlabel);
+				}
+			}
 
-            Children.Clear();
-            Children.Add(layout);
-        }
+			Children.Clear();
+			Children.Add(layout);
+		}
 
-        /// <summary>
-        /// Initializes a separator label to be placed between OTP input fields.
-        /// </summary>
-        /// <returns>A new instance of the <see cref="SfLabel"/> configured as a separator.</returns>
-        SfLabel InitializeSeparator()
-        {
-            return new SfLabel
-            {
-                Text = Separator,
-                FontSize = _separatorTextSize,
-                HorizontalTextAlignment = TextAlignment.Center,
-				VerticalTextAlignment = TextAlignment.Center,
-                LineBreakMode = LineBreakMode.NoWrap,
-                TextColor = SeparatorColor
-            };
-        }
-
-        /// <summary>
-        /// Initializes an OTP input entry field at the specified index.
-        /// </summary>
-        /// <returns>A new instance of the <see cref="OTPEntry"/> configured for OTP input.</returns>
-        OTPEntry InitializeEntry()
-        {
-            OTPEntry otpEntry = new OTPEntry
-            {
-                MinimumWidthRequest = _entryWidth,
-                MinimumHeightRequest = _entryHeight,
-                FontSize = 16,
+		/// <summary>
+		/// Initializes a separator label to be placed between OTP input fields.
+		/// </summary>
+		/// <returns>A new instance of the <see cref="SfLabel"/> configured as a separator.</returns>
+		SfLabel InitializeSeparator()
+		{
+			return new SfLabel
+			{
+				Text = Separator,
+				FontSize = _separatorTextSize,
 				HorizontalTextAlignment = TextAlignment.Center,
-                VerticalTextAlignment = TextAlignment.Center,
-                Keyboard = Type is OtpInputType.Number ? Keyboard.Numeric : Keyboard.Text,
-            };
+				VerticalTextAlignment = TextAlignment.Center,
+				LineBreakMode = LineBreakMode.NoWrap,
+				TextColor = SeparatorColor
+			};
+		}
+
+		/// <summary>
+		/// Initializes an OTP input entry field at the specified index.
+		/// </summary>
+		/// <returns>A new instance of the <see cref="OTPEntry"/> configured for OTP input.</returns>
+		OTPEntry InitializeEntry()
+		{
+			OTPEntry otpEntry = new OTPEntry
+			{
+				MinimumWidthRequest = _entryWidth,
+				MinimumHeightRequest = _entryHeight,
+				WidthRequest = _entryWidth,
+				HeightRequest = _entryHeight,
+				FontSize = 16,
+				HorizontalTextAlignment = TextAlignment.Center,
+				VerticalTextAlignment = TextAlignment.Center,
+				Keyboard = Type is OtpInputType.Number ? Keyboard.Numeric : Keyboard.Text,
+			};
 
 			otpEntry.BindingContext = this;
-			otpEntry.SetBinding(OTPEntry.PlaceholderColorProperty, BindingHelper.CreateBinding(nameof(PlaceholderColor),getter: static (SfOtpInput otpInput) => otpInput.PlaceholderColor));
+			otpEntry.SetBinding(OTPEntry.PlaceholderColorProperty, BindingHelper.CreateBinding(nameof(PlaceholderColor), getter: static (SfOtpInput otpInput) => otpInput.PlaceholderColor));
 			otpEntry.SetBinding(OTPEntry.TextColorProperty, BindingHelper.CreateBinding(nameof(TextColor), getter: static (SfOtpInput otpInput) => otpInput.TextColor));
 
 			return otpEntry;
-        }
+		}
 
-        /// <summary>
-        /// Handles the event when an OTP input field receives focus.
-        /// Updates the focused index and redraws the control.
-        /// </summary>
-        /// <param name="sender">The source of the focus event.</param>
-        /// <param name="e">The event data for the focus event.</param>
-        void FocusAsync(object? sender, FocusEventArgs e)
-        {
-            _focusedIndex = Array.IndexOf(_otpEntries!, sender);
+		/// <summary>
+		/// Handles the event when an OTP input field receives focus.
+		/// Updates the focused index and redraws the control.
+		/// </summary>
+		/// <param name="sender">The source of the focus event.</param>
+		/// <param name="e">The event data for the focus event.</param>
+		void FocusAsync(object? sender, FocusEventArgs e)
+		{
+			_focusedIndex = Array.IndexOf(_otpEntries!, sender);
 			if (sender is Entry entry)
 			{
 				entry.CursorPosition = 0;
@@ -1437,40 +1449,40 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 					if (_otpEntries[_focusedIndex].Text is not "" && text[0] is not '\0')
 					{
 						_otpEntries[_focusedIndex].Unfocus();
-						
+
 					}
 				}
 #endif
 			}
 
 			InvalidateDrawable();
-        }
+		}
 
-        /// <summary>
-        /// Handles the event when an OTP input field loses focus.
-        /// Redraws the control to update the visual state.
-        /// </summary>
-        /// <param name="sender">The source of the unfocus event.</param>
-        /// <param name="e">The event data for the unfocus event.</param>
-        void FocusOutAsync(object? sender, FocusEventArgs e)
-        {
-            InvalidateDrawable();
-        }
+		/// <summary>
+		/// Handles the event when an OTP input field loses focus.
+		/// Redraws the control to update the visual state.
+		/// </summary>
+		/// <param name="sender">The source of the unfocus event.</param>
+		/// <param name="e">The event data for the unfocus event.</param>
+		void FocusOutAsync(object? sender, FocusEventArgs e)
+		{
+			InvalidateDrawable();
+		}
 
-        /// <summary>
-        /// Focuses the OTP entry at the specified index and sets the cursor position.
-        /// </summary>
-        /// <param name="index">The index of the OTP entry to focus.</param>
-        /// <param name="setCursorToStart">If true, the cursor is set to the start; otherwise, it is set to position 1.</param>
-        void FocusEntry(int index, bool setCursorToStart)
-        {
-            if (_otpEntries is not null)
-            {
-                _focusedIndex = index;
-                _otpEntries[_focusedIndex].Focus();
-                _otpEntries[_focusedIndex].CursorPosition = setCursorToStart ? 0 : 1;
-            }
-        }
+		/// <summary>
+		/// Focuses the OTP entry at the specified index and sets the cursor position.
+		/// </summary>
+		/// <param name="index">The index of the OTP entry to focus.</param>
+		/// <param name="setCursorToStart">If true, the cursor is set to the start; otherwise, it is set to position 1.</param>
+		void FocusEntry(int index, bool setCursorToStart)
+		{
+			if (_otpEntries is not null)
+			{
+				_focusedIndex = index;
+				_otpEntries[_focusedIndex].Focus();
+				_otpEntries[_focusedIndex].CursorPosition = setCursorToStart ? 0 : 1;
+			}
+		}
 
 		/// <summary>
 		/// Handles the text change event for the OTP entry fields.
@@ -1493,12 +1505,12 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 			if (e.NewTextValue.Length <= 1)
 			{
 #endif
-				string currentValue = Value?.PadRight((int)Length, '\0') ?? new string('\0', (int)Length);
-				char[] valueArray = currentValue.ToCharArray();
+			string currentValue = Value?.PadRight((int)Length, '\0') ?? new string('\0', (int)Length);
+			char[] valueArray = currentValue.ToCharArray();
 
-				bool hasText = !string.IsNullOrEmpty(e.NewTextValue) && e.NewTextValue is not "\0";
-				bool isValidText = (string.IsNullOrEmpty(e.NewTextValue) || e.NewTextValue is "\0" || char.IsLetterOrDigit(char.Parse(e.NewTextValue))) && (!string.IsNullOrEmpty(MaskCharacter.ToString()));
-				valueArray[index] = hasText ? e.NewTextValue[0] : '\0';
+			bool hasText = !string.IsNullOrEmpty(e.NewTextValue) && e.NewTextValue is not "\0";
+			bool isValidText = (string.IsNullOrEmpty(e.NewTextValue) || e.NewTextValue is "\0" || char.IsLetterOrDigit(char.Parse(e.NewTextValue))) && (!string.IsNullOrEmpty(MaskCharacter.ToString()));
+			valueArray[index] = hasText ? e.NewTextValue[0] : '\0';
 
 #if (MACCATALYST || IOS)
 			{
@@ -1585,11 +1597,11 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 		/// <param name="index">The current index of the OTP input field that triggered the focus change.</param>
 		/// <param name="hasText">A boolean indicating whether the current field contains text.</param>
 		void HandleFocus(int index, bool hasText)
-        {
-            if (_otpEntries is not null)
-            {
-                if (hasText)
-                {
+		{
+			if (_otpEntries is not null)
+			{
+				if (hasText)
+				{
 #if ANDROID || WINDOWS
 					if(_isPasteHandled && _isPaste)
 					{
@@ -1610,14 +1622,14 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 					}
 #endif
 					if (index < Length - 1)
-                    {
-                        _otpEntries[index + 1].Focus();
-                    }
-                    else if (index == Length - 1)
-                    {
+					{
+						_otpEntries[index + 1].Focus();
+					}
+					else if (index == Length - 1)
+					{
 						_otpEntries[index].Unfocus();
-                    }
-                }
+					}
+				}
 #if IOS || MACCATALYST
 				else
 				{
@@ -1630,15 +1642,15 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 			}
 		}
 
-        /// <summary>
-        /// Determines the stroke size of the OTP entry based on focus state.
-        /// </summary>
-        /// <param name="index">The index of the OTP entry.</param>
-        /// <returns>Returns the stroke size for the OTP entry.</returns>
-        float GetStrokeThickness(int index)
-        {
-            return _otpEntries is not null && _otpEntries[index].IsFocused ? 2 : 1;
-        }
+		/// <summary>
+		/// Determines the stroke size of the OTP entry based on focus state.
+		/// </summary>
+		/// <param name="index">The index of the OTP entry.</param>
+		/// <returns>Returns the stroke size for the OTP entry.</returns>
+		float GetStrokeThickness(int index)
+		{
+			return _otpEntries is not null && _otpEntries[index].IsFocused ? 2 : 1;
+		}
 
 		/// <summary>
 		/// Updates the drawing parameters such as line points and rectangle boundaries for an OTP entry.
@@ -1679,65 +1691,65 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 		/// <param name="bindable">The bindable object associated with this method.</param>
 		/// <param name="value">The new value to update the OTP fields with.</param>
 		void UpdateValue(BindableObject bindable, object value)
-        {
-            var otpInput = bindable as SfOtpInput;
-            string? newValue = value as string;
+		{
+			var otpInput = bindable as SfOtpInput;
+			string? newValue = value as string;
 
-            if (otpInput?._otpEntries is not null && newValue is not null)
-            {
-                newValue = !string.IsNullOrEmpty(_oldValue) ? _oldValue : newValue;
+			if (otpInput?._otpEntries is not null && newValue is not null)
+			{
+				newValue = !string.IsNullOrEmpty(_oldValue) ? _oldValue : newValue;
 
-                for (int i = 0; i < otpInput._otpEntries.Length; i++)
-                {
-                    if (i < newValue.Length)
-                    {
-                        char enteredCharacter = newValue[i];
-                        if (Type != OtpInputType.Password)
-                        {
-                            if (!char.IsLetterOrDigit(enteredCharacter) || (Type is OtpInputType.Number && !char.IsDigit(enteredCharacter)))
-                            {
-                                otpInput._otpEntries[i].Text = string.Empty;
-                            }
-                            else
-                            {
-                                otpInput._otpEntries[i].Text = enteredCharacter.ToString();
-                            }
-                        }
-						else if(char.IsLetterOrDigit(enteredCharacter))
+				for (int i = 0; i < otpInput._otpEntries.Length; i++)
+				{
+					if (i < newValue.Length)
+					{
+						char enteredCharacter = newValue[i];
+						if (Type != OtpInputType.Password)
+						{
+							if (!char.IsLetterOrDigit(enteredCharacter) || (Type is OtpInputType.Number && !char.IsDigit(enteredCharacter)))
+							{
+								otpInput._otpEntries[i].Text = string.Empty;
+							}
+							else
+							{
+								otpInput._otpEntries[i].Text = enteredCharacter.ToString();
+							}
+						}
+						else if (char.IsLetterOrDigit(enteredCharacter))
 						{
 							otpInput._otpEntries[i].Text = MaskCharacter.ToString();
 						}
-                    }
-                    else
-                    {
-                        otpInput._otpEntries[i].Text = string.Empty;
-                    }
-                }
-            }
+					}
+					else
+					{
+						otpInput._otpEntries[i].Text = string.Empty;
+					}
+				}
+			}
 		}
 
-        /// <summary>
-        /// Updates the length of OTP input fields when the length property changes.
-        /// </summary>
-        /// <param name="oldLength">The previous number of OTP input fields.</param>
-        /// <param name="newLength">The new desired number of OTP input fields.</param>
-        void UpdateEntriesLength(int oldLength, int newLength)
-        {
-            if (_otpEntries is null) 
-            { 
-                return;
-            }
+		/// <summary>
+		/// Updates the length of OTP input fields when the length property changes.
+		/// </summary>
+		/// <param name="oldLength">The previous number of OTP input fields.</param>
+		/// <param name="newLength">The new desired number of OTP input fields.</param>
+		void UpdateEntriesLength(int oldLength, int newLength)
+		{
+			if (_otpEntries is null)
+			{
+				return;
+			}
 
 			var layout = Children[0] as AbsoluteLayout;
-            if (newLength > oldLength)
-            {
-                AddEntry(oldLength, newLength, layout);
-            }
-            else if (newLength < oldLength)
-            {
-                RemoveEntry(oldLength, newLength, layout);
-            }
-        }
+			if (newLength > oldLength)
+			{
+				AddEntry(oldLength, newLength, layout);
+			}
+			else if (newLength < oldLength)
+			{
+				RemoveEntry(oldLength, newLength, layout);
+			}
+		}
 
 		/// <summary>
 		/// Trims the value to the specified length if it exceeds the given length.
@@ -1745,37 +1757,37 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 		/// <param name="length">Length of the OTPInput</param>
 		void TrimValueToLength(int length)
 		{
-			if(!string.IsNullOrEmpty(Value) && Value.Length > length)
+			if (!string.IsNullOrEmpty(Value) && Value.Length > length)
 			{
 				Value = Value.Substring(0, length);
 			}
 		}
 
-        /// <summary>
-        /// Removes OTP entry fields and separators when the length is reduced.
-        /// </summary>
-        /// <param name="oldLength">The previous number of OTP input fields.</param>
-        /// <param name="newLength">The desired new number of OTP input fields.</param>
-        /// <param name="layout">The AbsoluteLayout container holding the OTP input fields.</param>
-        void RemoveEntry(int oldLength, int newLength, AbsoluteLayout? layout)
-        {
-            if (_otpEntries is not null)
-            {
-                for (int i = oldLength - 1; i >= newLength; i--)
-                {
-                    layout?.Children.Remove(_otpEntries[i]);
-                    DetachEventsForEntry(i);
-                    if (i >= newLength && i is not 0)
-                    {
-                        layout?.Children.Remove(_separators[i - 1]);
-                    }
-                }
+		/// <summary>
+		/// Removes OTP entry fields and separators when the length is reduced.
+		/// </summary>
+		/// <param name="oldLength">The previous number of OTP input fields.</param>
+		/// <param name="newLength">The desired new number of OTP input fields.</param>
+		/// <param name="layout">The AbsoluteLayout container holding the OTP input fields.</param>
+		void RemoveEntry(int oldLength, int newLength, AbsoluteLayout? layout)
+		{
+			if (_otpEntries is not null)
+			{
+				for (int i = oldLength - 1; i >= newLength; i--)
+				{
+					layout?.Children.Remove(_otpEntries[i]);
+					DetachEventsForEntry(i);
+					if (i >= newLength && i is not 0)
+					{
+						layout?.Children.Remove(_separators[i - 1]);
+					}
+				}
 
-                _otpEntries =_otpEntries.Take(newLength).ToArray();
-                _entryBounds = _entryBounds.Take(newLength).ToArray();
-                _separators = _separators.Take(newLength - 1).ToArray();
-            }
-        }
+				_otpEntries = _otpEntries.Take(newLength).ToArray();
+				_entryBounds = _entryBounds.Take(newLength).ToArray();
+				_separators = _separators.Take(newLength - 1).ToArray();
+			}
+		}
 
 		/// <summary>
 		/// Adds new OTP entry fields and separators when the length is increased.
@@ -1801,7 +1813,7 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 
 				OTPEntry otpEntry = InitializeEntry();
 				AttachEvents(otpEntry);
-                _otpEntries = _otpEntries.Concat(new[] { otpEntry }).ToArray();
+				_otpEntries = _otpEntries.Concat(new[] { otpEntry }).ToArray();
 				SetInputFieldPosition(i, otpEntry);
 				layout?.Children.Add(otpEntry);
 			}
@@ -1829,7 +1841,7 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 			AbsoluteLayout.SetLayoutBounds(otpEntry, new Rect(rect.X, rect.Y, rect.Width, rect.Height));
 
 			float entryX = ((_entryWidth + _spacing) * i) + _extraSpacing;
-			float entryY = _extraSpacing ;
+			float entryY = _extraSpacing;
 			_entryBounds[i] = new RectF(entryX, entryY, _entryWidth, _entryHeight);
 			AbsoluteLayout.SetLayoutBounds(otpEntry, new Rect(_entryBounds[i].X, _entryBounds[i].Y, _entryBounds[i].Width, _entryBounds[i].Height));
 		}
@@ -1856,55 +1868,55 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 		/// A formatted string based on the placeholder value. If the placeholder length is less than the total OTP input field length, it appends empty characters.
 		/// </returns>
 		string GetPlaceHolder()
-        {
-            if (string.IsNullOrEmpty(Placeholder))
-            {
-                return string.Empty;
-            }
+		{
+			if (string.IsNullOrEmpty(Placeholder))
+			{
+				return string.Empty;
+			}
 
-            if (Placeholder.Length is 1)
-            {
-                return new string(Placeholder[0], _otpEntries?.Length ?? 0);
-            }
+			if (Placeholder.Length is 1)
+			{
+				return new string(Placeholder[0], _otpEntries?.Length ?? 0);
+			}
 
-            if (_otpEntries is not null)
-            {
-                if (Placeholder.Length < _otpEntries.Length)
-                {
-                    return Placeholder + new string('\0', _otpEntries.Length - Placeholder.Length);
-                }
-            }
+			if (_otpEntries is not null)
+			{
+				if (Placeholder.Length < _otpEntries.Length)
+				{
+					return Placeholder + new string('\0', _otpEntries.Length - Placeholder.Length);
+				}
+			}
 
-            return Placeholder;
-        }
+			return Placeholder;
+		}
 
-        /// <summary>
-        /// Updates the placeholder text for all OTP input fields based on the Placeholder property.
-        /// </summary>
-        void UpdatePlaceholderText()
-        {
-            if (_otpEntries is null || Placeholder is null)
-            {
-                return;
-            }
+		/// <summary>
+		/// Updates the placeholder text for all OTP input fields based on the Placeholder property.
+		/// </summary>
+		void UpdatePlaceholderText()
+		{
+			if (_otpEntries is null || Placeholder is null)
+			{
+				return;
+			}
 
-            string actualPlaceholder = GetPlaceHolder();
-            for (int i = 0; i < _otpEntries.Length; i++)
-            {
-                _otpEntries[i].Placeholder = actualPlaceholder.Length > i ? actualPlaceholder[i].ToString() : string.Empty;
-            }
-        }
+			string actualPlaceholder = GetPlaceHolder();
+			for (int i = 0; i < _otpEntries.Length; i++)
+			{
+				_otpEntries[i].Placeholder = actualPlaceholder.Length > i ? actualPlaceholder[i].ToString() : string.Empty;
+			}
+		}
 
-        /// <summary>
-        /// Updates the text value of the currently focused OTP entry field based on the key pressed.
-        /// </summary>
-        /// <param name="key">The key input value to be assigned to the OTP entry.</param>
-        void UpdateEntryValue(string key)
-        {
-            if (_otpEntries is not null)
-            {
+		/// <summary>
+		/// Updates the text value of the currently focused OTP entry field based on the key pressed.
+		/// </summary>
+		/// <param name="key">The key input value to be assigned to the OTP entry.</param>
+		void UpdateEntryValue(string key)
+		{
+			if (_otpEntries is not null)
+			{
 				char input = key[key.Length - 1];
-#if WINDOWS 
+#if WINDOWS
 				if (_isCapsOn || _isShiftOn)
 				{
 					_otpEntries[_focusedIndex].Text = input.ToString().ToUpper(CultureInfo.CurrentCulture);
@@ -1917,75 +1929,75 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 				_otpEntries[_focusedIndex].Text = input.ToString();
 #endif
 			}
-        }
+		}
 
-        /// <summary>
-        /// Updates the properties of OTP input fields when the Type property is changed.
-        /// This includes enabling/disabling password masking and clearing invalid text.
-        /// </summary>
-        void UpdateTypeProperty()
-        {
-            if (_focusedIndex < 0 || _otpEntries is null || Length == 0)
-            {
-                return;
-            }
+		/// <summary>
+		/// Updates the properties of OTP input fields when the Type property is changed.
+		/// This includes enabling/disabling password masking and clearing invalid text.
+		/// </summary>
+		void UpdateTypeProperty()
+		{
+			if (_focusedIndex < 0 || _otpEntries is null || Length == 0)
+			{
+				return;
+			}
 
-            if (_otpEntries[_focusedIndex].Text is not "")
-            {
-                for (int i = 0; i < _otpEntries.Length; i++)
-                {
-                    if (Type == OtpInputType.Password && _otpEntries[i].Text is not "")
-                    {
-                        _otpEntries[i].Text = MaskCharacter.ToString();
-                    }
-                    else if (Type == OtpInputType.Number && _otpEntries[i].Text.Any(char.IsLetter))
-                    {
-                        _otpEntries[i].Text = string.Empty;
-                    }
-                }
-            }
-        }
+			if (_otpEntries[_focusedIndex].Text is not "")
+			{
+				for (int i = 0; i < _otpEntries.Length; i++)
+				{
+					if (Type == OtpInputType.Password && _otpEntries[i].Text is not "")
+					{
+						_otpEntries[i].Text = MaskCharacter.ToString();
+					}
+					else if (Type == OtpInputType.Number && _otpEntries[i].Text.Any(char.IsLetter))
+					{
+						_otpEntries[i].Text = string.Empty;
+					}
+				}
+			}
+		}
 
-        /// <summary>
-        /// Helps to wire the event handlers to the OTP entry fields.
-        /// </summary>
-        void HookEvents()
-        {
-            UnHookEvents();
-            if (_otpEntries is not null)
-            {
-                foreach (var otpEntry in _otpEntries)
+		/// <summary>
+		/// Helps to wire the event handlers to the OTP entry fields.
+		/// </summary>
+		void HookEvents()
+		{
+			UnHookEvents();
+			if (_otpEntries is not null)
+			{
+				foreach (var otpEntry in _otpEntries)
 				{
 					AttachEvents(otpEntry);
 				}
 			}
-        }
+		}
 
 		/// <summary>
 		/// Helps to Unwire the event handlers to the OTP entry fields.
 		/// </summary>
 		void UnHookEvents()
-        {
-            if (_otpEntries is not null)
-            {
-                foreach (var otpEntry in _otpEntries)
-                {
-                    DetachEvents(otpEntry);
-                }
-            }
-        }
+		{
+			if (_otpEntries is not null)
+			{
+				foreach (var otpEntry in _otpEntries)
+				{
+					DetachEvents(otpEntry);
+				}
+			}
+		}
 
-        /// <summary>
-        /// Detaches event handlers from a specific OTP entry field when its length is changed.
-        /// </summary>
-        /// <param name="i">The index of the OTP input field to remove event handlers from.</param>
-        void DetachEventsForEntry(int i)
-        {
-            if (_otpEntries is not null)
-            {
-                 DetachEvents(_otpEntries[i]);
-            }
-        }
+		/// <summary>
+		/// Detaches event handlers from a specific OTP entry field when its length is changed.
+		/// </summary>
+		/// <param name="i">The index of the OTP input field to remove event handlers from.</param>
+		void DetachEventsForEntry(int i)
+		{
+			if (_otpEntries is not null)
+			{
+				DetachEvents(_otpEntries[i]);
+			}
+		}
 
 		/// <summary>
 		/// Attaches event handlers to a specified OTP entry field.
@@ -2129,7 +2141,7 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
             {
 				return;
             }
-		    
+
 			switch (e.KeyCode)
             {
                 case Android.Views.Keycode.Del:
@@ -2161,7 +2173,7 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
                     }
                     break;
             }
-            
+
         }
 #endif
 
@@ -2169,34 +2181,34 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 		/// Updates the size of the separator text based on its content and font size.
 		/// </summary>
 		void UpdateSeparatorSize()
-        {
-            var size = TextMeasurer.CreateTextMeasurer().MeasureText(Separator, (float)_separatorTextSize);
-            _separatorHeight = (float)size.Height;
-            _separatorWidth = (float)size.Width + Separator.Length;
-        }
+		{
+			var size = TextMeasurer.CreateTextMeasurer().MeasureText(Separator, (float)_separatorTextSize);
+			_separatorHeight = (float)size.Height;
+			_separatorWidth = (float)size.Width + Separator.Length;
+		}
 
 #if MACCATALYST || IOS
-        /// <summary>
-        /// Validates the input text for the OTP entry field, handling backspace and alphanumeric input.
-        /// </summary>
-        /// <param name="textField">The UITextField where the input is occurring.</param>
-        /// <param name="range">The range of the text to be replaced.</param>
-        /// <param name="inputText">The new string being entered.</param>
-        /// <returns>
-        /// Returns <c>true</c> if the input should proceed; otherwise, <c>false</c> to prevent input.
-        /// </returns>
-        bool ValidateText(UITextField textField, NSRange range, string inputText)
-        {
-            if (_otpEntries is null)
-            {
-                return true;
-            }
+		/// <summary>
+		/// Validates the input text for the OTP entry field, handling backspace and alphanumeric input.
+		/// </summary>
+		/// <param name="textField">The UITextField where the input is occurring.</param>
+		/// <param name="range">The range of the text to be replaced.</param>
+		/// <param name="inputText">The new string being entered.</param>
+		/// <returns>
+		/// Returns <c>true</c> if the input should proceed; otherwise, <c>false</c> to prevent input.
+		/// </returns>
+		bool ValidateText(UITextField textField, NSRange range, string inputText)
+		{
+			if (_otpEntries is null)
+			{
+				return true;
+			}
 
-            if (string.IsNullOrEmpty(inputText))
-            {
-                HandleKeyPress("Back");
-                return true;
-            }
+			if (string.IsNullOrEmpty(inputText))
+			{
+				HandleKeyPress("Back");
+				return true;
+			}
 
 			if (inputText.Length > 1)
 			{
@@ -2205,35 +2217,35 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 			}
 
 			char enteredText = inputText[0];
-            if (char.IsLetterOrDigit(enteredText))
-            {
-                HandleKeyPress(enteredText.ToString());
-                return false;
-            }
+			if (char.IsLetterOrDigit(enteredText))
+			{
+				HandleKeyPress(enteredText.ToString());
+				return false;
+			}
 
-            return false;
-        }
+			return false;
+		}
 #endif
 
-        /// <summary>
-        /// Handles the key-down event for the OTP input field and invokes the <c>OnPreviewKeyDown</c> method.
-        /// </summary>
-        /// <param name="args">The key event arguments associated with the key-down event.</param>
-        void IKeyboardListener.OnKeyDown(KeyEventArgs args)
-        {
+		/// <summary>
+		/// Handles the key-down event for the OTP input field and invokes the <c>OnPreviewKeyDown</c> method.
+		/// </summary>
+		/// <param name="args">The key event arguments associated with the key-down event.</param>
+		void IKeyboardListener.OnKeyDown(KeyEventArgs args)
+		{
 #if MACCATALYST || IOS
-            OnPreviewKeyDown(args);
+			OnPreviewKeyDown(args);
 #endif
-        }
+		}
 
-        /// <summary>
-        /// Handles the key-up event for the OTP input field.
-        /// </summary>
-        /// <param name="args">The key event arguments associated with the key-up event.</param>
-        void IKeyboardListener.OnKeyUp(KeyEventArgs args)
-        {
+		/// <summary>
+		/// Handles the key-up event for the OTP input field.
+		/// </summary>
+		/// <param name="args">The key event arguments associated with the key-up event.</param>
+		void IKeyboardListener.OnKeyUp(KeyEventArgs args)
+		{
 #if MACCATALYST || IOS
-			if(!args.IsShiftKeyPressed)
+			if (!args.IsShiftKeyPressed)
 			{
 				_isShiftOn = false;
 			}
@@ -2241,73 +2253,73 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 		}
 
 #if MACCATALYST || IOS
-        /// <summary>
-        /// Processes key-down events for OTP input fields.
-        /// Handles navigation keys, backspace, delete, caps lock, and alphanumeric input.
-        /// </summary>
-        /// <param name="e">The key event arguments containing the key pressed.</param>
-        void OnPreviewKeyDown(KeyEventArgs e)
-        {
-            if (_otpEntries is null)
-            {
-                return;
-            }
+		/// <summary>
+		/// Processes key-down events for OTP input fields.
+		/// Handles navigation keys, backspace, delete, caps lock, and alphanumeric input.
+		/// </summary>
+		/// <param name="e">The key event arguments containing the key pressed.</param>
+		void OnPreviewKeyDown(KeyEventArgs e)
+		{
+			if (_otpEntries is null)
+			{
+				return;
+			}
 
-            string text = e.Key.ToString();
-            switch (e.Key)
-            {
-                case KeyboardKey.Left:
-                    HandleKeyPress("Left");
-                    e.Handled = true;
-                    break;
+			string text = e.Key.ToString();
+			switch (e.Key)
+			{
+				case KeyboardKey.Left:
+					HandleKeyPress("Left");
+					e.Handled = true;
+					break;
 
-                case KeyboardKey.Right:
-                    HandleKeyPress("Right");
-                    e.Handled = true;
-                    break;
+				case KeyboardKey.Right:
+					HandleKeyPress("Right");
+					e.Handled = true;
+					break;
 
-                case KeyboardKey.Back:
-                    HandleKeyPress("Back");
-                    e.Handled = true;
-                    break;
+				case KeyboardKey.Back:
+					HandleKeyPress("Back");
+					e.Handled = true;
+					break;
 
-                case KeyboardKey.Delete:
-                    HandleKeyPress("Back");
-                    e.Handled = true;
-                    break;
+				case KeyboardKey.Delete:
+					HandleKeyPress("Back");
+					e.Handled = true;
+					break;
 
-                case KeyboardKey.Tab:
+				case KeyboardKey.Tab:
 					_isShiftOn = e.IsShiftKeyPressed;
-                    HandleKeyPress("Tab");
-                    e.Handled = true;
-                    break;
+					HandleKeyPress("Tab");
+					e.Handled = true;
+					break;
 
-                case KeyboardKey.Shift:
-                    _isShiftOn = true;
-                    break;
+				case KeyboardKey.Shift:
+					_isShiftOn = true;
+					break;
 
-                default:
-                    if ((e.Key >= KeyboardKey.A && e.Key <= KeyboardKey.Z) ||
-                        (e.Key >= KeyboardKey.Num0 && e.Key <= KeyboardKey.Num9))
-                    {
-                        HandleKeyPress(text);
-                    }
-                    e.Handled = true;
-                    break;
-            }
-        }
+				default:
+					if ((e.Key >= KeyboardKey.A && e.Key <= KeyboardKey.Z) ||
+						(e.Key >= KeyboardKey.Num0 && e.Key <= KeyboardKey.Num9))
+					{
+						HandleKeyPress(text);
+					}
+					e.Handled = true;
+					break;
+			}
+		}
 #endif
 
-        /// <summary>
-        /// Handles the handler change event for OTP entry fields.
-        /// Sets up platform-specific event handlers for key input validation and handling.
-        /// </summary>
-        /// <param name="sender">The OTPEntry control whose handler has changed.</param>
-        /// <param { get; set; }="e">Event arguments containing details of the change.</param>
-        void OnHandlerChanged(object? sender, EventArgs e)
-        {
-            if (sender is OTPEntry textBox)
-            {
+		/// <summary>
+		/// Handles the handler change event for OTP entry fields.
+		/// Sets up platform-specific event handlers for key input validation and handling.
+		/// </summary>
+		/// <param name="sender">The OTPEntry control whose handler has changed.</param>
+		/// <param { get; set; }="e">Event arguments containing details of the change.</param>
+		void OnHandlerChanged(object? sender, EventArgs e)
+		{
+			if (sender is OTPEntry textBox)
+			{
 #if MACCATALYST || IOS
 				// Unhook from previous handler if exists
 				if (_lastPlatformView is not null)
@@ -2333,8 +2345,8 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 
 #elif MACCATALYST || IOS
 				if ((sender as OTPEntry)?.Handler is not null && (sender as OTPEntry)?.Handler?.PlatformView is UIKit.UITextField platformView)
-                {
-                    platformView.ShouldChangeCharacters += ValidateText;
+				{
+					platformView.ShouldChangeCharacters += ValidateText;
 					_lastPlatformView = platformView;
 				}
 #endif
@@ -2379,20 +2391,20 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 		/// Updates the text of all OTP input fields with the masked character if the input type is set to Password.
 		/// </summary>
 		void UpdateMaskCharacter()
-        {
-            if (_otpEntries is null || Value is null || Type is not OtpInputType.Password)
-            {
-                return;
-            }
-            
-            foreach (var otpEntry in _otpEntries)
-            {
+		{
+			if (_otpEntries is null || Value is null || Type is not OtpInputType.Password)
+			{
+				return;
+			}
+
+			foreach (var otpEntry in _otpEntries)
+			{
 				if (otpEntry.Text is not "")
 				{
 					otpEntry.Text = MaskCharacter.ToString();
 				}
-            }
-        }
+			}
+		}
 
 		/// <summary>
 		/// Handles the paste operation when triggered. This method processes the clipboard content and performs necessary actions depending on the content type or context.
@@ -2411,7 +2423,7 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 				copiedText = await Microsoft.Maui.ApplicationModel.DataTransfer.Clipboard.GetTextAsync();
 			}
 #elif WINDOWS
-			if (Clipboard.Default.HasText) 
+			if (Clipboard.Default.HasText)
 			{
 				copiedText = await Clipboard.Default.GetTextAsync();
 				_isCtrlPressed = false;
@@ -2427,30 +2439,30 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 				Value = new string(copiedText);
 			}
 		}
-		
-        /// <summary>
-        /// Updates the keyboard type for each OTP entry based on the input type of the control.
-        /// </summary>
-        void UpdateKeyboardType()
-        {
-            if (_otpEntries is not null)
-            {
-                for (int i = 0; i < _otpEntries.Length; i++)
-                {
-                    if (Type == OtpInputType.Password || Type == OtpInputType.Text)
-                    {
-                        _otpEntries[i].Keyboard = Keyboard.Text;
-                    }
-                    else
-                    {
-                        _otpEntries[i].Keyboard = Keyboard.Numeric;
-                    }
-                }
-            }
-        }
+
+		/// <summary>
+		/// Updates the keyboard type for each OTP entry based on the input type of the control.
+		/// </summary>
+		void UpdateKeyboardType()
+		{
+			if (_otpEntries is not null)
+			{
+				for (int i = 0; i < _otpEntries.Length; i++)
+				{
+					if (Type == OtpInputType.Password || Type == OtpInputType.Text)
+					{
+						_otpEntries[i].Keyboard = Keyboard.Text;
+					}
+					else
+					{
+						_otpEntries[i].Keyboard = Keyboard.Numeric;
+					}
+				}
+			}
+		}
 		#endregion
 
-    	#region Override methods
+		#region Override methods
 
 		/// <summary>
 		/// Arranges the layout and positions of OTP input fields and separators within the specified bounds, dynamically calculating positions to ensure proper alignment and spacing.
@@ -2493,7 +2505,7 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 					separatorLabel.Text = Separator;
 					float separatorX = entryX + _entryWidth + ((_spacing - _separatorWidth) / 2);
 
-					AbsoluteLayout.SetLayoutBounds(separatorLabel, new Rect(separatorX,entryY-(_extraSpacing/2), _separatorWidth, _entryHeight+_extraSpacing));
+					AbsoluteLayout.SetLayoutBounds(separatorLabel, new Rect(separatorX, entryY - (_extraSpacing / 2), _separatorWidth, _entryHeight + _extraSpacing));
 				}
 			}
 
@@ -2514,7 +2526,7 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 			DrawUI(canvas, dirtyRect);
 		}
 
-#endregion
+		#endregion
 
 		#region Interface Implementation
 

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Editors/SfOtpInputUnitTests.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Editors/SfOtpInputUnitTests.cs
@@ -292,7 +292,7 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 			Assert.Equal(expected, actual);
 		}
 
-		
+
 
 		[Theory]
 		[InlineData(40)]
@@ -313,7 +313,7 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 			}
 		}
 
-		
+
 
 		[Theory]
 		[InlineData(40)]
@@ -657,16 +657,15 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 
 
 		[Theory]
-		[InlineData(0, 30f, 40f, 5f, 3f, 50f, false, 300f)]
-		[InlineData(1, 35f, 45f, 10f, 5f, 60f, false, 300f)]
-		public void UpdateDrawingParameters(int index, float entryWidth, float entryHeight, float spacing, float extraSpacing, float lineLength, bool isRTL, float controlWidth)
+		[InlineData(0, 30f, 40f, 5f, 3f, false, 300f)]
+		[InlineData(1, 35f, 45f, 10f, 5f, false, 300f)]
+		public void UpdateDrawingParameters(int index, float entryWidth, float entryHeight, float spacing, float extraSpacing, bool isRTL, float controlWidth)
 		{
 			var otpInput = new SfOtpInput();
 			SetPrivateField(otpInput, "_entryWidth", entryWidth);
 			SetPrivateField(otpInput, "_entryHeight", entryHeight);
 			SetPrivateField(otpInput, "_spacing", spacing);
 			SetPrivateField(otpInput, "_extraSpacing", extraSpacing);
-			SetPrivateField(otpInput, "_lineLength", lineLength);
 			otpInput.WidthRequest = controlWidth;
 
 			var flowDirection = isRTL ? EffectiveFlowDirection.RightToLeft : 0;
@@ -689,11 +688,11 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 
 			// Assert start point
 			Assert.Equal(xPos, startPoint.X);
-			Assert.Equal(lineLength + extraSpacing + yPadding, startPoint.Y);
+			Assert.Equal(entryHeight + extraSpacing + yPadding, startPoint.Y);
 
 			// Assert end point
 			Assert.Equal(xPos + entryWidth, endPoint.X);
-			Assert.Equal(lineLength + extraSpacing + yPadding, endPoint.Y);
+			Assert.Equal(entryHeight + extraSpacing + yPadding, endPoint.Y);
 
 			// Assert outline rectangle
 			Assert.Equal(xPos, outlineRectF.X);

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Editors/SfOtpInputUnitTests.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Editors/SfOtpInputUnitTests.cs
@@ -120,7 +120,7 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 		[InlineData(OtpInputStyle.Outlined, 13, false, OtpInputState.Error, "#008000", "#FF0000", "#1C1B1F", "#611c1b1f")]
 		public void UpdateParameters(OtpInputStyle otpInputStyle, double cornerRadius, bool isEnabled, OtpInputState otpInputState, string stroke, string background, string textColor, string disabledTextColor)
 		{
-			OTPEntry otpEntry = new OTPEntry();			
+			OTPEntry otpEntry = new OTPEntry();
 			otpEntry.UpdateParameters(otpInputStyle, cornerRadius, new PointF(10, 10), new PointF(30, 30), new SfOtpInput(),isEnabled, otpInputState, Color.FromArgb(stroke), Color.FromArgb(background), Color.FromArgb(textColor), Color.FromArgb(disabledTextColor));
 			OtpInputStyle? resultInputStyle = (OtpInputStyle?)GetPrivateField(otpEntry, "_styleMode");
 			double? resultCornerRadius = (double?)GetPrivateField(otpEntry, "_cornerRadius");
@@ -290,6 +290,48 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 			otpInput.InputBackground = input;
 			var actual = otpInput.InputBackground;
 			Assert.Equal(expected, actual);
+		}
+
+		
+
+		[Theory]
+		[InlineData(40)]
+		[InlineData(60)]
+		[InlineData(100)]
+		public void BoxWidth_UpdatesEntryDimensions(double newWidth)
+		{
+			var otpInput = new SfOtpInput();
+			otpInput.BoxWidth = newWidth;
+			var _otpEntries = (OTPEntry[]?)GetPrivateField(otpInput, "_otpEntries");
+			if (_otpEntries != null)
+			{
+				foreach (var entry in _otpEntries)
+				{
+					Assert.Equal(newWidth, entry.MinimumWidthRequest);
+					Assert.Equal(newWidth, entry.WidthRequest);
+				}
+			}
+		}
+
+		
+
+		[Theory]
+		[InlineData(40)]
+		[InlineData(55)]
+		[InlineData(80)]
+		public void BoxHeight_UpdatesEntryDimensions(double newHeight)
+		{
+			var otpInput = new SfOtpInput();
+			otpInput.BoxHeight = newHeight;
+			var _otpEntries = (OTPEntry[]?)GetPrivateField(otpInput, "_otpEntries");
+			if (_otpEntries != null)
+			{
+				foreach (var entry in _otpEntries)
+				{
+					Assert.Equal(newHeight, entry.MinimumHeightRequest);
+					Assert.Equal(newHeight, entry.HeightRequest);
+				}
+			}
 		}
 
 		#endregion
@@ -548,11 +590,11 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 			var otpInput = new SfOtpInput();
 			OTPEntry[]? otpEntries = (OTPEntry[]?)GetPrivateField(otpInput, "_otpEntries");
 			SetPrivateField(otpInput, "_otpEntries", otpEntries);
-			var sender = otpEntries?[2]; 
+			var sender = otpEntries?[2];
 			var focusEventArgs = new FocusEventArgs(otpInput,true);
 			InvokePrivateMethod(otpInput, "FocusAsync", sender, focusEventArgs);
 			var focusedIndex = (int?)GetPrivateField(otpInput, "_focusedIndex");
-			Assert.Equal(2, focusedIndex); 
+			Assert.Equal(2, focusedIndex);
 		}
 
 
@@ -567,14 +609,14 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 		}
 
 		[Theory]
-		[InlineData(0, true, 0)]  
+		[InlineData(0, true, 0)]
 		[InlineData(1, false, 1)]
 		public void FocusEntry(int index, bool setCursorToStart, int expectedCursorPosition)
 		{
 			var otpInput = new SfOtpInput();
 			OTPEntry[]? otpEntries = (OTPEntry[]?)GetPrivateField(otpInput, "_otpEntries");
 			SetPrivateField(otpInput, "_otpEntries", otpEntries);
-			SetPrivateField(otpInput, "_focusedIndex", 0); 
+			SetPrivateField(otpInput, "_focusedIndex", 0);
 			otpEntries?[0].Focus();
 			InvokePrivateMethod(otpInput, "FocusEntry", index, setCursorToStart);
 			int? resultFocusedIndex = (int?)GetPrivateField(otpInput, "_focusedIndex");
@@ -584,9 +626,9 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 		}
 
 		[Theory]
-		[InlineData(3, true, 3)] 
+		[InlineData(3, true, 3)]
 		[InlineData(0, false, 0)]
-		[InlineData(3, false, 3)] 
+		[InlineData(3, false, 3)]
 		public void HandleFocus(int index, bool hasText, int expectedFocusIndex)
 		{
 			var otpInput = new SfOtpInput ();
@@ -596,26 +638,26 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 			SetPrivateField(otpInput, "_focusedIndex", index);
 			InvokePrivateMethod(otpInput,"HandleFocus", index, hasText);
 			focusedIndex = GetPrivateField(otpInput, "_focusedIndex");
-			Assert.Equal(expectedFocusIndex, focusedIndex); 
+			Assert.Equal(expectedFocusIndex, focusedIndex);
 		}
 
 		[Theory]
-		[InlineData(0, 1)] 
+		[InlineData(0, 1)]
 		[InlineData(1, 1)]
-		[InlineData(2,1)] 
-		[InlineData(3, 1)] 
+		[InlineData(2,1)]
+		[InlineData(3, 1)]
 		public void GetStrokeThickness(int index, float expectedStrokeThickness)
 		{
 			var otpInput = new SfOtpInput();
 			OTPEntry[]? otpEntries = (OTPEntry[]?)GetPrivateField(otpInput, "_otpEntries");
 			SetPrivateField(otpInput,"_otpEntries", otpEntries);
 			float? strokeThickness =(float?) InvokePrivateMethod(otpInput, "GetStrokeThickness", index);
-			Assert.Equal(expectedStrokeThickness, strokeThickness); 
+			Assert.Equal(expectedStrokeThickness, strokeThickness);
 		}
 
 
 		[Theory]
-		[InlineData(0, 30f, 40f, 5f, 3f, 50f, false, 300f)] 
+		[InlineData(0, 30f, 40f, 5f, 3f, 50f, false, 300f)]
 		[InlineData(1, 35f, 45f, 10f, 5f, 60f, false, 300f)]
 		public void UpdateDrawingParameters(int index, float entryWidth, float entryHeight, float spacing, float extraSpacing, float lineLength, bool isRTL, float controlWidth)
 		{
@@ -667,14 +709,14 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 			var otpInput = new SfOtpInput();
 			OTPEntry[]? _otpEntries = (OTPEntry[]?)GetPrivateField(otpInput, "_otpEntries");
 
-			string invalidInput = "12A4"; 
-			InvokePrivateMethod(otpInput, "UpdateValue", otpInput, invalidInput); 
+			string invalidInput = "12A4";
+			InvokePrivateMethod(otpInput, "UpdateValue", otpInput, invalidInput);
 			Assert.Equal("1", _otpEntries?[0].Text);
 			Assert.Equal("2", _otpEntries?[1].Text);
-			Assert.Equal("", _otpEntries?[2].Text); 
+			Assert.Equal("", _otpEntries?[2].Text);
 			Assert.Equal("4", _otpEntries?[3].Text);
 
-			otpInput.Type = OtpInputType.Password; 
+			otpInput.Type = OtpInputType.Password;
 			string passwordInput = "1234";
 			InvokePrivateMethod(otpInput, "UpdateValue", otpInput, passwordInput);
 			if (_otpEntries != null)
@@ -696,7 +738,7 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 			InvokePrivateMethod(otpInput, "UpdateEntriesLength", initialLength, newLength);
 			OTPEntry[]? _otpEntries = (OTPEntry[]?)GetPrivateField(otpInput, "_otpEntries");
 			SetPrivateField(otpInput, "_otpEntries", _otpEntries);
-			Assert.Equal(newLength, _otpEntries?.Length); 
+			Assert.Equal(newLength, _otpEntries?.Length);
 		}
 
 		[Theory]
@@ -753,14 +795,14 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 			int expectedSeparatorCount = newLength - 1;
 			int actualSeparatorCount = layout.Children.OfType<SfLabel>().Count();
 			Assert.Equal(expectedSeparatorCount, actualSeparatorCount);
-			int expectedTotalChildren = newLength + expectedSeparatorCount; 
+			int expectedTotalChildren = newLength + expectedSeparatorCount;
 			Assert.Equal(expectedTotalChildren, layout.Children.Count);
 		}
 
 
 		[Theory]
-		[InlineData(0, 50f, 30f, 5f, 5f)]  
-		[InlineData(0, 60f, 40f, 10f, 10f)]  
+		[InlineData(0, 50f, 30f, 5f, 5f)]
+		[InlineData(0, 60f, 40f, 10f, 10f)]
 		public void SetInputFieldPosition(int index, float entryWidth, float entryHeight, float spacing, float extraSpacing)
 		{
 
@@ -777,22 +819,22 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 			InvokePrivateMethod(otpInput, "SetInputFieldPosition", index, otpEntry);
 
 			RectF[]? entryBounds = (RectF[]?)GetPrivateField(otpInput, "_entryBounds");
-			Assert.Equal(index + 1, entryBounds?.Length);  
+			Assert.Equal(index + 1, entryBounds?.Length);
 
 			var layoutBounds = AbsoluteLayout.GetLayoutBounds(otpEntry);
 
 			float expectedX =  (entryWidth + spacing) * index + extraSpacing;
 			float expectedY =  extraSpacing;
 
-			Assert.Equal(expectedX, layoutBounds.X);  
+			Assert.Equal(expectedX, layoutBounds.X);
 			Assert.Equal(expectedY, layoutBounds.Y);
 			Assert.Equal(entryWidth, layoutBounds.Width);
-			Assert.Equal(entryHeight, layoutBounds.Height); 
+			Assert.Equal(entryHeight, layoutBounds.Height);
 		}
 
 		[Theory]
-		[InlineData(0, 50f, 30f, 5f, 5f)] 
-		[InlineData(1, 60f, 40f, 10f, 10f)] 
+		[InlineData(0, 50f, 30f, 5f, 5f)]
+		[InlineData(1, 60f, 40f, 10f, 10f)]
 		public void SetSeparatorPosition(int index, float entryWidth, float entryHeight, float spacing, float separatorWidth)
 		{
 			var otpInput = new SfOtpInput();


### PR DESCRIPTION
### Description of Change

This pull request introduces new bindable properties for customizable dimensions in the `SfOtpInput` class.

- `SfOtpInput.cs`: Added `BoxWidth` and `BoxHeight` properties for customizable input box dimensions.
- `.gitignore`: Updated to include the `.vs/` directory for Visual Studio temporary files.

Addresses: https://github.com/syncfusion/maui-toolkit/issues/186

### Screenshots

#### Before:

Default BoxSize

![image](https://github.com/user-attachments/assets/80c6358c-8641-4e17-bfa7-0012778d6846)

#### After:

Variable Box Width and Height

![image](https://github.com/user-attachments/assets/2ff0c5d5-efe7-414c-bf41-b8a811cbb925)
