### PR TITLE
Resolved the Tab key navigation issue in TextInputLayout

### DIFF
--- a/maui/src/TextInputLayout/SfTextInputLayout.Properties.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.Properties.cs
@@ -2197,13 +2197,12 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
         {
             if (bindable is SfTextInputLayout inputLayout && newValue is bool value)
             {
-                double minOpacity = DeviceInfo.Platform.ToString() switch
-                {
-                    nameof(DevicePlatform.MacCatalyst) => 0.011,
-                    nameof(DevicePlatform.iOS) => 0.00001,
-                    nameof(DevicePlatform.Android) => 0.00001,
-                    _ => 0 
-                };
+				double minOpacity = 0;
+#if ANDROID || IOS
+				minOpacity  = 0.00001;
+#elif MACCATALYST
+				minOpacity  = 0.011;
+#endif
 
                 double targetOpacity = value ? 1 : minOpacity;
 

--- a/maui/src/TextInputLayout/SfTextInputLayout.Properties.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.Properties.cs
@@ -2193,24 +2193,33 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 			}
 		}
 
-		static void OnIsHintFloatedPropertyChanged(BindableObject bindable, object oldValue, object newValue)
-		{
-			if (bindable is SfTextInputLayout inputLayout && newValue is bool value)
-			{
-				if (inputLayout.Content is InputView || inputLayout.Content is Microsoft.Maui.Controls.Picker)
-				{
-					inputLayout.Content.Opacity = value ? 1 : (DeviceInfo.Platform == DevicePlatform.iOS ? 0.00001 : 0);
-				}
-				else if (inputLayout != null && inputLayout.Content is SfView numericEntry && numericEntry.Children.Count > 0)
-				{
-					if (numericEntry.Children[0] is Entry numericInputView)
-					{
-						numericInputView.Opacity = value ? 1 : (DeviceInfo.Platform == DevicePlatform.iOS ? 0.00001 : 0);
-					}
-				}
-			}
-			
-		}
+        static void OnIsHintFloatedPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            if (bindable is SfTextInputLayout inputLayout && newValue is bool value)
+            {
+                double minOpacity = DeviceInfo.Platform.ToString() switch
+                {
+                    nameof(DevicePlatform.MacCatalyst) => 0.011,
+                    nameof(DevicePlatform.iOS) => 0.00001,
+                    nameof(DevicePlatform.Android) => 0.00001,
+                    _ => 0 
+                };
+
+                double targetOpacity = value ? 1 : minOpacity;
+
+                if (inputLayout.Content is InputView || inputLayout.Content is Microsoft.Maui.Controls.Picker)
+                {
+                    inputLayout.Content.Opacity = targetOpacity;
+                }
+                else if (inputLayout.Content is SfView numericEntry && numericEntry.Children.Count > 0)
+                {
+                    if (numericEntry.Children[0] is Entry numericInputView)
+                    {
+                        numericInputView.Opacity = targetOpacity;
+                    }
+                }
+            }
+        }
 
 		static void OnInputViewPaddingPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{

--- a/maui/src/TextInputLayout/SfTextInputLayout.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.cs
@@ -842,13 +842,13 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
             {
                 UpdateContentMargin(view);
             }
-			double minOpacity = DeviceInfo.Platform.ToString() switch
-			{
-				nameof(DevicePlatform.MacCatalyst) => 0.011,
-				nameof(DevicePlatform.iOS) => 0.00001,
-				nameof(DevicePlatform.Android) => 0.00001,
-				_ => 0
-			};
+
+			double minOpacity = 0;
+#if ANDROID || IOS
+			minOpacity  = 0.00001;
+#elif MACCATALYST
+			minOpacity  = 0.011;
+#endif
 
 			//For placeholder overlap issue here handled the opacity value for controls.
 			if (newValue is InputView entryEditorContent)

--- a/maui/src/TextInputLayout/SfTextInputLayout.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.cs
@@ -842,33 +842,32 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
             {
                 UpdateContentMargin(view);
             }
+			double minOpacity = DeviceInfo.Platform.ToString() switch
+			{
+				nameof(DevicePlatform.MacCatalyst) => 0.011,
+				nameof(DevicePlatform.iOS) => 0.00001,
+				nameof(DevicePlatform.Android) => 0.00001,
+				_ => 0
+			};
 
 			//For placeholder overlap issue here handled the opacity value for controls.
 			if (newValue is InputView entryEditorContent)
             {
-#if ANDROID || IOS
-				entryEditorContent.Opacity = IsHintFloated ? 1 : 0.00001;
-#else
-				entryEditorContent.Opacity = IsHintFloated ? 1 : 0;
-#endif
+				entryEditorContent.Opacity = IsHintFloated ? 1 : minOpacity;
 				_initialContentDescription = SemanticProperties.GetDescription(entryEditorContent);
 			}
             else if (newValue is SfView numericEntryContent && numericEntryContent.Children.Count > 0)
             {
                 if (numericEntryContent.Children[0] is Entry numericInputView)
                 {
-#if ANDROID || IOS
-					numericInputView.Opacity = IsHintFloated ? 1 : 0.00001;
-#else
-					numericInputView.Opacity = IsHintFloated ? 1 : 0;
-#endif
+					numericInputView.Opacity = IsHintFloated ? 1 : minOpacity;
 				}
             }
             else if (newValue is Microsoft.Maui.Controls.Picker picker)
             {
                 if (DeviceInfo.Platform != DevicePlatform.WinUI)
                 {
-					picker.Opacity = IsHintFloated ? 1 : (DeviceInfo.Platform == DevicePlatform.iOS ? 0.00001 : 0);
+					picker.Opacity = IsHintFloated ? 1 : minOpacity;
 				}
 			}
 


### PR DESCRIPTION
### Root Cause of the Issue

The use of Opacity = 0 for certain UI elements excluded them from the Tab key navigation hierarchy, as the system did not consider them visible or focusable.

### Description of Change

To address this, we introduced a minimal saturation opacity value that keeps elements visually hidden but logically present for accessibility and keyboard navigation. This update ensures the TextInputLayout is included in the focus traversal order via Tab key navigation. The fix applies consistently across supported platforms including macOS (via MacCatalyst), Windows, Android, and iOS, ensuring unified behavior

### Issues Fixed


Fixes https://github.com/syncfusion/maui-toolkit/issues/178




### Screenshots

#### Before:

https://github.com/user-attachments/assets/4f21e5f4-facb-4a7e-bb27-3bb4673e9e0d


#### After:

https://github.com/user-attachments/assets/a4777761-8738-4d00-bbf3-3fb5df610595

