### PR TITLE
964655- Fix for MAUI Segmented control right side cropped when the stroke thickness is 0

### DIFF
--- a/maui/src/SegmentedControl/Helper/SegmentViewHelper.cs
+++ b/maui/src/SegmentedControl/Helper/SegmentViewHelper.cs
@@ -63,7 +63,7 @@ namespace Syncfusion.Maui.Toolkit.SegmentedControl
 			// Calculated width based on widthRequest and maxWidth.
 			if (widthRequest < 0)
 			{
-				return totalWidth > maxWidth ? maxWidth - keyFocusedViewPadding : totalWidth;
+				return totalWidth + keyFocusedViewPadding > maxWidth ? maxWidth - keyFocusedViewPadding : totalWidth;
 			}
 
 			// Left and right of the keyboard layout in order to avoid the control crop issue while given the heightrequest.

--- a/maui/src/SegmentedControl/Views/SegmentItemView.cs
+++ b/maui/src/SegmentedControl/Views/SegmentItemView.cs
@@ -246,7 +246,6 @@ namespace Syncfusion.Maui.Toolkit.SegmentedControl
 			canvas.Antialias = true;
 			float strokeRadius = (float)itemInfo.StrokeThickness / 2f;
 			CornerRadius cornerRadius = itemInfo.SegmentCornerRadius;
-
 			// Calculate corner radius values, subtracting stroke radius when there's stroke thickness
 			float cornerRadiusTopLeft = itemInfo.StrokeThickness > 0 ? (float)cornerRadius.TopLeft - strokeRadius : (float)cornerRadius.TopLeft;
 			float cornerRadiusTopRight = itemInfo.StrokeThickness > 0 ? (float)cornerRadius.TopRight - strokeRadius : (float)cornerRadius.TopRight;
@@ -258,14 +257,6 @@ namespace Syncfusion.Maui.Toolkit.SegmentedControl
 			Brush background = isEnabled ? SegmentViewHelper.GetSegmentBackground(itemInfo, _segmentItem) : itemInfo.DisabledSegmentBackground;
 			canvas.FillColor = SegmentViewHelper.BrushToColorConverter(background);
 			canvas.FillRoundedRectangle(dirtyRect.Left, dirtyRect.Top, dirtyRect.Width, dirtyRect.Height, cornerRadiusTopLeft, cornerRadiusTopRight, cornerRadiusBottomRight, cornerRadiusBottomLeft);
-
-			// Only draw stroke if stroke thickness is greater than 0
-			if (itemInfo.StrokeThickness > 0)
-			{
-				canvas.StrokeSize = (float)itemInfo.StrokeThickness;
-				canvas.StrokeColor = SegmentViewHelper.BrushToColorConverter(itemInfo.Stroke);
-			}
-
 			canvas.CanvasRestoreState();
 		}
 

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Buttons/SfSegmentedControlUnitTests.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Buttons/SfSegmentedControlUnitTests.cs
@@ -896,6 +896,78 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 		}
 
 		[Theory]
+		[InlineData(100.0, 50.0, 200.0, LayoutAlignment.Fill, 94.0)]
+		[InlineData(-100.0, 50.0, 200.0, LayoutAlignment.Fill, 194.0)]
+		[InlineData(100.0, 50.0, 100.0, LayoutAlignment.Start, 94.0)]
+		[InlineData(-100.0, 50.0, 200.0, LayoutAlignment.Start, 50.0)]
+		
+		public void GetActualSegmentWidth_ReturnsExpectedWidth_WithStrokethicknessZero(double widthRequest, double minWidth, double maxWidth, LayoutAlignment alignment, double expectedResult)
+		{
+			var segmentInfo = new SfSegmentedControl
+			{
+				_items = [new SfSegmentItem { }, new SfSegmentItem { }],
+				VisibleSegmentsCount = 2,
+				StrokeThickness = 0
+			};
+			var resultWidth = SegmentViewHelper.GetActualSegmentWidth(segmentInfo, widthRequest, minWidth, maxWidth, alignment);
+			Assert.Equal(expectedResult, resultWidth);
+		}
+
+		[Theory]
+		[InlineData(100.0, 50.0, 200.0, LayoutAlignment.Fill, 94.0)]
+		[InlineData(-100.0, 50.0, 200.0, LayoutAlignment.Fill, 194.0)]
+		[InlineData(100.0, 50.0, 100.0, LayoutAlignment.Start, 94.0)]
+		[InlineData(-100.0, 50.0, 200.0, LayoutAlignment.Start, 50.0)]
+
+		public void GetActualSegmentWidth_DifferentCount_ReturnsExpectedWidth_WithStrokethicknessZero(double widthRequest, double minWidth, double maxWidth, LayoutAlignment alignment, double expectedResult)
+		{
+			var segmentInfo = new SfSegmentedControl
+			{
+				_items = [new SfSegmentItem { }, new SfSegmentItem { }],
+				VisibleSegmentsCount = 1,
+				StrokeThickness = 0
+			};
+			var resultWidth = SegmentViewHelper.GetActualSegmentWidth(segmentInfo, widthRequest, minWidth, maxWidth, alignment);
+			Assert.Equal(expectedResult, resultWidth);
+		}
+
+		[Theory]
+		[InlineData(100.0, 50.0, 200.0, LayoutAlignment.Fill, 94.0)]
+		[InlineData(-100.0, 50.0, 200.0, LayoutAlignment.Fill, 194.0)]
+		[InlineData(100.0, 50.0, 100.0, LayoutAlignment.Start, 94.0)]
+		[InlineData(-100.0, 50.0, 200.0, LayoutAlignment.Start, 194.0)]
+
+		public void GetActualSegmentWidth_NegativeCount_ReturnsExpectedWidth_WithStrokethicknessZero(double widthRequest, double minWidth, double maxWidth, LayoutAlignment alignment, double expectedResult)
+		{
+			var segmentInfo = new SfSegmentedControl
+			{
+				_items = [new SfSegmentItem { }, new SfSegmentItem { }],
+				VisibleSegmentsCount = -1,
+				StrokeThickness = 0
+			};
+			var resultWidth = SegmentViewHelper.GetActualSegmentWidth(segmentInfo, widthRequest, minWidth, maxWidth, alignment);
+			Assert.Equal(expectedResult, resultWidth);
+		}
+
+		[Theory]
+		[InlineData(100.0, 50.0, 200.0, LayoutAlignment.Fill, 94.0)]
+		[InlineData(-100.0, 50.0, 200.0, LayoutAlignment.Fill, 194.0)]
+		[InlineData(100.0, 50.0, 100.0, LayoutAlignment.Start, 94.0)]
+		[InlineData(-100.0, 50.0, 200.0, LayoutAlignment.Start, 194.0)]
+
+		public void GetActualSegmentWidth_NegativeCount_ReturnsExpectedWidth_WithStrokethickness(double widthRequest, double minWidth, double maxWidth, LayoutAlignment alignment, double expectedResult)
+		{
+			var segmentInfo = new SfSegmentedControl
+			{
+				_items = [new SfSegmentItem { }, new SfSegmentItem { }],
+				VisibleSegmentsCount = -1,
+				StrokeThickness = 1
+			};
+			var resultWidth = SegmentViewHelper.GetActualSegmentWidth(segmentInfo, widthRequest, minWidth, maxWidth, alignment);
+			Assert.Equal(expectedResult, resultWidth);
+		}
+
+		[Theory]
 		[InlineData(LayoutAlignment.Fill)]
 		[InlineData(LayoutAlignment.Start)]
 		public void GetActualSegmentWidth_ReturnsTotalWidth_WhenVisibleSegmentsCountIsGreaterThanZero(LayoutAlignment alignment)


### PR DESCRIPTION
## Root Cause of the Issue ##
When StrokeThickness is zero, the totalwidth is equal to maxWidth. So the keyFocusedViewPadding is not reduced from the maxWidth. This causes the segmented control to get cut.

This behavior causes:
Value is added with the keypadding causing the control to get cropped.

## Description of Change ##
Added the keypadding to the totalwidth before comparing with the max width.

### Issues Fixed ###
Fix : [Pr 1190](https://gitea.syncfusion.com/essential-studio/maui-toolkit/pulls/1190)
Prevents the extra padding and renders within the given width

### Output screenshots:
### Before changes:
**Windows**

![Windowsissue](https://github.com/user-attachments/assets/1bcf723f-947d-4599-a88b-271d0d347556)


**Android**
![androidissue](https://github.com/user-attachments/assets/6353a25d-51d9-4764-8dbd-2256850c6b44)


**Mac**
![macissue](https://github.com/user-attachments/assets/f7b09735-e5e6-487b-8baf-820884fccc8c)


**iOS**
![iosissue](https://github.com/user-attachments/assets/bd5f3373-09ff-4b40-afd7-0d8f2f644a18)


### After changes:

**Windows**
![windowsfix](https://github.com/user-attachments/assets/6de2244c-e45e-4199-9e0b-9a7c506ef2b6)


**Android**
![androidfix](https://github.com/user-attachments/assets/6c21da4d-5afe-4c54-a9f0-e5cb7421b5b3)


**Mac**
![macfix](https://github.com/user-attachments/assets/d583db5a-5fa9-497f-a9b2-02538b16a2d9)


**iOS**
![iosfix](https://github.com/user-attachments/assets/ab32f5b9-12cf-4fb0-a050-495c33b2182b)
