### PR TITLE
Resolve Animation Inconsistencies in Carousel Control on Android Platform

### DIFF
--- a/maui/src/Carousel/Platform/Android/PlatformCarousel.Android.cs
+++ b/maui/src/Carousel/Platform/Android/PlatformCarousel.Android.cs
@@ -3126,7 +3126,6 @@ namespace Syncfusion.Maui.Toolkit.Carousel
 						_tempList?.Add(carouselItem);
 					}
 				}
-				ArrangeItemsBasedOnVirtualization();
 			}
 		}
 


### PR DESCRIPTION
### Description
The Carousel control exhibits inconsistent animation behavior on the Android platform. Only the first item animates correctly; subsequent items either lack animation or render improperly while swiping.

### Root Cause of the Issue
While swiping, the carousel item is added to the view and then arranged by item position. During this process, the animation is set to false, so the animation does not occur in the carousel control.

### Description of Change
An investigation into the item arrangement revealed that positioning the items at that point in the code was unnecessary, so it was removed.

### Issues Fixed
Swiping animation is fixed on the Android platform.

### Screenshots

#### Before:

https://github.com/user-attachments/assets/f623fab6-d07f-4eaf-881c-866850639fb7


#### After:

https://github.com/user-attachments/assets/4836d792-2b77-4e7e-89b8-9b1988ba5eac

