### PR TITLE
Resolved the button text does not wrap without explicit Widthrequest

### DIFF
--- a/maui/src/Button/SfButton.Methods.cs
+++ b/maui/src/Button/SfButton.Methods.cs
@@ -540,15 +540,20 @@ namespace Syncfusion.Maui.Toolkit.Buttons
 		{
 			if (widthConstraint == double.PositiveInfinity || widthConstraint < 0 || WidthRequest < 0)
 			{
+				double buttonContentWidth = 0;
 				if (ShowIcon && ImageSource != null)
 				{
-					return ImageAlignment == Alignment.Top || ImageAlignment == Alignment.Bottom
+					buttonContentWidth = ImageAlignment == Alignment.Top || ImageAlignment == Alignment.Bottom
 						? Math.Max(ImageSize, TextSize.Width) + Padding.Left + Padding.Right + StrokeThickness + (_leftPadding * 2) + (_rightPadding * 2)
 						: ImageSize + TextSize.Width + StrokeThickness + Padding.Left + Padding.Right + (_leftPadding * 2) + (_rightPadding * 2);
 				}
 				else
 				{
-					return TextSize.Width + Padding.Left + Padding.Right + StrokeThickness + (_leftPadding * 2) + (_rightPadding * 2);
+					buttonContentWidth = TextSize.Width + Padding.Left + Padding.Right + StrokeThickness + (_leftPadding * 2) + (_rightPadding * 2);
+				}
+				if (buttonContentWidth <= widthConstraint)
+				{
+					return buttonContentWidth;
 				}
 			}
 			return widthConstraint;
@@ -564,6 +569,7 @@ namespace Syncfusion.Maui.Toolkit.Buttons
 		{
 			if (heightConstraint == double.PositiveInfinity || heightConstraint < 0 || VerticalOptions != LayoutOptions.Fill)
 			{
+				width = CalculateAvailableTextWidth(width);
 				if (LineBreakMode == LineBreakMode.WordWrap || LineBreakMode == LineBreakMode.CharacterWrap)
 					{
 						_numberOfLines = StringExtensions.GetLinesCount(Text, (float)width, this, LineBreakMode, out _);
@@ -585,6 +591,46 @@ namespace Syncfusion.Maui.Toolkit.Buttons
 				}
 			}
 			return heightConstraint;
+		}
+
+		/// <summary>
+		/// Calculates the available width for the text area within the button.
+		/// </summary>
+		/// <param name="width"></param>
+		/// <returns></returns>
+		double CalculateAvailableTextWidth(double width)
+		{
+			if (ShowIcon && ImageSource != null)
+			{
+				if (ImageAlignment == Alignment.Start || ImageAlignment == Alignment.Left)
+				{
+					width = (ImageAlignment == Alignment.Start && _isRightToLeft) ? Math.Abs((float)(width - _textRectF.X - ImageSize - (_leftIconPadding * 2) - _textAreaPadding - (StrokeThickness / 2) - Padding.Right))
+										: Math.Abs((float)(width - _textRectF.X - (StrokeThickness / 2) - _textAreaPadding - Padding.Right));
+
+				}
+				else if (ImageAlignment == Alignment.End || ImageAlignment == Alignment.Right)
+				{
+					width = (ImageAlignment == Alignment.End && _isRightToLeft) ? Math.Abs((float)(width - _textRectF.X - (StrokeThickness / 2) - _textAreaPadding - Padding.Right))
+										: Math.Abs((float)(width - _textRectF.X - ImageSize - _leftIconPadding - _leftIconPadding - _textAreaPadding - (StrokeThickness / 2) - Padding.Right));
+				}
+				else if (ImageAlignment == Alignment.Top)
+				{
+					width = Math.Abs((float)(width - _textAreaPadding - Padding.Left - Padding.Right - _textAreaPadding - (StrokeThickness / 2) - (StrokeThickness / 2)));
+				}
+				else if (ImageAlignment == Alignment.Bottom)
+				{
+					width = Math.Abs((float)(width - _textAreaPadding - Padding.Left - Padding.Right - _textAreaPadding - (StrokeThickness / 2) - (StrokeThickness / 2)));
+				}
+				else
+				{
+					width =  Math.Abs((float)(width - _textRectF.X - (StrokeThickness / 2) - _textAreaPadding - Padding.Right));
+				}
+			}
+			else
+			{
+				width = Math.Abs((float)(width - _textAreaPadding - Padding.Left - Padding.Right - _textAreaPadding - StrokeThickness));
+			}
+			return width;
 		}
 
 		/// <summary>
@@ -735,7 +781,10 @@ namespace Syncfusion.Maui.Toolkit.Buttons
 			canvas.SaveState();
 			float availableWidth = _textRectF.Width;
 #if ANDROID
-			availableWidth-=AndroidTextMargin;
+			if (LineBreakMode != LineBreakMode.WordWrap)
+			{
+				availableWidth -= AndroidTextMargin;
+			}
 #endif
 			var trimmedText = _isFontIconText ? Text : StringExtensions.GetTextBasedOnLineBreakMode(ApplyTextTransform(Text), this, availableWidth, _textRectF.Height, LineBreakMode);
 			if (_textRectF.Width > 0 && _textRectF.Height > 0)

--- a/maui/src/Core/Extensions/StringExtensions.cs
+++ b/maui/src/Core/Extensions/StringExtensions.cs
@@ -47,13 +47,15 @@ namespace Syncfusion.Maui.Toolkit.Graphics.Internals
 		/// </summary>
 		/// Note: It can be used from chart and sunbrust chart datalabels implement. 
 		public static string TrimTextToFit(this string inputText, ITextElement textElement, double availableWidth)
-		{
-			while (inputText.Measure(textElement).Width > availableWidth && inputText.Length > 0)
-			{
-				inputText = inputText.Substring(0, inputText.Length - 1);
-			}
-			return inputText;
-		}
+        {
+            string trimmedText = inputText.TrimEnd();
+            while (trimmedText.Measure(textElement).Width >= availableWidth && trimmedText.Length > 0)
+            {
+                trimmedText = trimmedText.Substring(0, trimmedText.Length - 1);
+                trimmedText = trimmedText.TrimEnd();
+            }
+            return trimmedText;
+        }
 
 		/// <summary>
 		/// This method is utilized to get the total number of lines count from the text to fit within the available width.
@@ -171,13 +173,24 @@ namespace Syncfusion.Maui.Toolkit.Graphics.Internals
 					var leftTrimmedTextSize = leftTrimmedText.Measure((ITextElement)textElement);
 					int leftLength = 0;
 
-					while (leftTrimmedTextSize.Width > charsToKeep && leftTrimmedText.Length > 0)
+					while (leftTrimmedTextSize.Width >= charsToKeep && leftTrimmedText.Length > 0)
 					{
 						leftTrimmedText = leftTrimmedText.Substring(0, leftTrimmedText.Length - 1);
 						leftTrimmedTextSize = leftTrimmedText.Measure((ITextElement)textElement);
 						leftLength++;
 					}
 					string rightText = text.Substring(leftLength);
+
+					leftTrimmedText = leftTrimmedText.TrimEnd();
+					rightText = rightText.TrimStart();
+
+					var rightTrimmedTextSize = rightText.Measure((ITextElement)textElement);
+					while (rightTrimmedTextSize.Width >= charsToKeep && rightText.Length > 0)
+					{
+						leftLength++;
+						rightText = text.Substring(leftLength).TrimStart();
+						rightTrimmedTextSize = rightText.Measure((ITextElement)textElement);
+					}
 					string trimmedText = leftTrimmedText + "..." + rightText;
 					return trimmedText;
 

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Buttons/SfButtonUnitTests.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Buttons/SfButtonUnitTests.cs
@@ -700,6 +700,32 @@ namespace Syncfusion.Maui.Toolkit.UnitTest.Buttons
 		}
 
 		[Theory]
+		[InlineData(150, 142, "SampleImage1.png", Alignment.Left)]
+		[InlineData(150, 108, "SampleImage1.png", Alignment.Right)]
+		[InlineData(180, 164, "SampleImage1.png", Alignment.Top)]
+		[InlineData(250, 234, "SampleImage1.png", Alignment.Bottom)]
+		[InlineData(200, 184, "SampleImage1.png", null)]
+		public void CalculateAvailableTextWidth_ShouldReturnExpectedWidth(double width, double expectedValue, string imagePath, Alignment? alignment = null)
+		{
+			// Arrange
+			var button = new SfButton();
+			button.ImageSource = ImageSource.FromFile(imagePath);
+
+			if (alignment != null)
+			{
+				button.ShowIcon = true;
+				button.ImageAlignment = (Alignment)alignment;
+			}
+
+			// Set up as needed
+			button.Padding = new Thickness(4, 4, 4, 4);
+
+			var actualValue = InvokePrivateMethod(button, "CalculateAvailableTextWidth", width);
+
+			Assert.Equal(expectedValue, actualValue);
+		}
+
+		[Theory]
 		[InlineData(true, false, false, false, "#000000")] 
 		[InlineData(true, true, false, false, "#FF0000")] 
 		[InlineData(false, false, false, false, "#808080")] 


### PR DESCRIPTION
### Root Cause of the Issue

The issue was in the MeasureContent method where the width calculation for text wrapping didn't consider the available width constraint. When no explicit WidthRequest was set, the method used the button's natural text width (which would be very wide for long text) instead of the available layout width, preventing text wrapping.

### Description of Change

Modified CalculateWidth method to use available width constraint if the measured width higher than width constraint.

### Issues Fixed

Fixes https://github.com/syncfusion/maui-toolkit/issues/190

### Screenshots

#### Before:

<img width="619" height="732" alt="image" src="https://github.com/user-attachments/assets/9812cda0-6d24-4d7e-8560-2bfcff15e1d0" />


<img width="334" height="627" alt="image" src="https://github.com/user-attachments/assets/76222921-4e03-4d5a-9f7e-d568947b6677" />


#### After:

<img width="751" height="724" alt="image" src="https://github.com/user-attachments/assets/2c17dfd2-b96a-484b-868f-16feae5b2e85" />


<img width="332" height="625" alt="image" src="https://github.com/user-attachments/assets/f1375828-0457-4957-a435-588134be3d3d" />

