### PR TITLE
Correct link to PR template md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Follow the coding style guidelines set by the [.NET Foundation](https://github.c
 
 ### Pull Request Requirements
 
-Please refer to our [pull request template](PULL_REQUEST_TEMPLATE.md) for details on how to format your submissions.
+Please refer to our [pull request template](.github/PULL_REQUEST_TEMPLATE.md) for details on how to format your submissions.
 
 * **Allow Edits from Maintainers:** Ensure you check the "Allow edits from maintainers" checkbox on your pull request. This permission allows us to make minor fixes and resolve conflicts quickly.
 


### PR DESCRIPTION
### Root Cause of the Issue

The CONTRIBUTING.md document contained a link to the PR template file which took you to a 404 page.

### Description of Change

Add the correct subfolder prefix so the link works.

### Issues Fixed

Since this is not exactly an issue in the product itself, I didn't file an issue - hope that's ok.