### PR TITLE
Handle un-pressing button when pointer interaction cancelled

### DIFF
--- a/maui/src/Button/SfButton.Methods.cs
+++ b/maui/src/Button/SfButton.Methods.cs
@@ -821,7 +821,9 @@ namespace Syncfusion.Maui.Toolkit.Buttons
 #if ANDROID || IOS
             else if (e.Action == PointerActions.Cancelled)
             {
-                RemoveEffects();
+				_isPressed = false;
+				RemoveEffects();
+				ChangeVisualState();
             }
 #endif
 			else if (e.Action == PointerActions.Exited)


### PR DESCRIPTION
### Root Cause of the Issue

Cancelled interaction was clearing some effects, but wasn't changing the actual button state.

### Description of Change

_isPressed should no longer be true, allowing us to go back to the Normal state

### Issues Fixed

Fixes #228

### Screenshots

#### Before:

https://github.com/user-attachments/assets/bfb46abf-f195-49fb-bef9-784df3f02165

#### After:

https://github.com/user-attachments/assets/72f925ff-56ab-409a-a880-b3d3bca2d655
