### PR TITLE
Fixed the TextInputLayout Helper/Error accessibility issue by modifying label instead of native drawing

### DIFF
--- a/maui/src/TextInputLayout/SfTextInputLayout.Properties.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.Properties.cs
@@ -2394,6 +2394,8 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 			if (bindable is SfTextInputLayout inputLayout && inputLayout._initialLoaded)
 			{
 				inputLayout.UpdateViewBounds();
+				// Update assistive labels when relevant properties change
+				inputLayout.UpdateAssistiveLabels();
 				inputLayout.ResetSemantics();
 			}
 		}


### PR DESCRIPTION
### Root Cause of the Issue
Screen readers like VoiceOver (macOS) and Narrator (Windows) were unable to access HelperText and ErrorText in SfTextInputLayout because they were drawn directly on canvas without semantic information.


### Description of Change

Before this fix, screen readers could only access the Entry field. Now they can navigate to and read both helper text and error text, providing complete accessibility for users with visual impairments.

### Issues Fixed

Fixes https://github.com/syncfusion/maui-toolkit/issues/181


### Screenshots

#### After:

https://github.com/user-attachments/assets/bbdf8308-114e-4a7c-bede-b4fa0ac1dafb


https://github.com/user-attachments/assets/22c409dd-6b8e-4092-ad3a-e31048f09ac8


