### PR TITLE
Resolved the initial layout issue when AllowedState is set to FullExpanded

### DIFF
--- a/maui/src/BottomSheet/SfBottomSheet.cs
+++ b/maui/src/BottomSheet/SfBottomSheet.cs
@@ -2059,7 +2059,7 @@ namespace Syncfusion.Maui.Toolkit.BottomSheet
 		/// <returns>The target Y position for the bottom sheet.</returns>
 		double GetTargetPosition()
 		{
-		    if (State is BottomSheetState.FullExpanded || !_isHalfExpanded)
+		    if ((State is BottomSheetState.FullExpanded || !_isHalfExpanded) && State is not BottomSheetState.Collapsed && AllowedState is not BottomSheetAllowedState.HalfExpanded)
 		    {
 		        return GetFullExpandedPosition();
 		    }
@@ -2078,7 +2078,7 @@ namespace Syncfusion.Maui.Toolkit.BottomSheet
 		/// <returns>The calculated position for the fully expanded state. Currently, it always returns 0.</returns>
 		double GetFullExpandedPosition()
 		{
-		    if (State is BottomSheetState.Hidden)
+		    if (State is BottomSheetState.Hidden || State is not BottomSheetState.FullExpanded)
 		    {
 		        State = BottomSheetState.FullExpanded;
 		    }
@@ -2139,12 +2139,12 @@ namespace Syncfusion.Maui.Toolkit.BottomSheet
 			}
 
 			int animationDuration = this.GetClampedAnimationDuration();
-			const int topPadding = 2;
+		    const int topPadding = 2;
 			_isSheetOpen = true;
 			if (_bottomSheet is not null)
 			{
 				var bottomSheetAnimation = new Animation(d => _bottomSheet.TranslationY = d, _bottomSheet.TranslationY, targetPosition + topPadding);
-				_bottomSheet?.Animate("bottomSheetAnimation", bottomSheetAnimation, length: (uint)animationDuration, easing: Easing.Linear, finished: (v, e) => 
+				_bottomSheet?.Animate("bottomSheetAnimation", bottomSheetAnimation, length: (uint)animationDuration, easing: Easing.Linear, finished: (v, e) =>
 				{
 					UpdateBottomSheetHeight();
 					onFinish?.Invoke();


### PR DESCRIPTION
### Root Cause of the Issue

 When the AllowedState is set to FullExpanded and the State is set to Collapsed during the initial load, the position and height of the bottom sheet behave inconsistently—its position reflects the FullExpanded state, while its height corresponds to the Collapsed state, resulting in unintended behavior.

### Description of Change

 Updated the position based on the current state of the bottom sheet.

### Issues Fixed

 Issue: https://github.com/syncfusion/maui-toolkit/issues/225

### Screenshots

#### Before:

<img width="206" height="446" alt="image" src="https://github.com/user-attachments/assets/5b20014f-a8b2-4e60-9cdc-aa94fdf3b9f0" />


#### After:

<img width="207" height="449" alt="image" src="https://github.com/user-attachments/assets/ea71f913-91a4-48a1-9e8c-bd7bde90696d" />
