### PR TITLE
972079 - Picker Footer Icon Button Issue

### DIFF
--- a/maui/src/Core/Helper/IconButton/SfIconButton.cs
+++ b/maui/src/Core/Helper/IconButton/SfIconButton.cs
@@ -43,6 +43,11 @@ namespace Syncfusion.Maui.Toolkit
         /// </summary>
         readonly bool _isHoveringOnReleased;
 
+        /// <summary>
+        /// Holds the view which is used to clip.
+        /// </summary>
+        Grid clipView;
+
 #if __MACCATALYST__ || (!__ANDROID__ && !__IOS__)
         /// <summary>
         /// Holds the value to denotes the mouse cursor exited.
@@ -66,11 +71,15 @@ namespace Syncfusion.Maui.Toolkit
             _showTouchEffect = showTouchEffect;
             _isSquareSelection = isSquareSelection;
             _isHoveringOnReleased = isHoveringOnReleased;
+            clipView = new Grid();
             EffectsView = new SfEffectsView();
 #if __IOS__
             IgnoreSafeArea = true;
+            clipView.IgnoreSafeArea = true;
             EffectsView.IgnoreSafeArea = true;
 #endif
+            //// - TODO directly clip the parent view cause the crash in the view. So, we add the grid view for the clip purpose.
+            clipView.Add(this.EffectsView);
             Add(EffectsView);
             EffectsView.Content = child;
             EffectsView.ShouldIgnoreTouches = true;
@@ -200,16 +209,15 @@ namespace Syncfusion.Maui.Toolkit
         {
             if (_isSquareSelection || width < 0 || height < 0)
             {
-                EffectsView.Clip = null;
                 return;
             }
 
             double centerX = Math.Min(width, height) / 2;
             EllipseGeometry currentClip = new EllipseGeometry() { Center = new Point(width / 2, height / 2), RadiusX = centerX, RadiusY = centerX };
             EllipseGeometry? previousClip = null;
-            if (EffectsView.Clip != null && EffectsView.Clip is EllipseGeometry)
+            if (clipView.Clip != null && clipView.Clip is EllipseGeometry)
             {
-                previousClip = (EllipseGeometry)EffectsView.Clip;
+                previousClip = (EllipseGeometry)clipView.Clip;
             }
 
             //// If the previous and current clip values are same, then no need to update the effects view clip.
@@ -218,7 +226,7 @@ namespace Syncfusion.Maui.Toolkit
                 return;
             }
 
-            EffectsView.Clip = currentClip;
+            clipView.Clip = currentClip;
         }
 
 #if __MACCATALYST__ || (!__ANDROID__ && !__IOS__)
@@ -237,7 +245,7 @@ namespace Syncfusion.Maui.Toolkit
                 };
 
                 RoundRectangleGeometry? previousClip = null;
-                if (EffectsView.Clip != null && EffectsView.Clip is RoundRectangleGeometry previous)
+                if (clipView.Clip != null && clipView.Clip is RoundRectangleGeometry previous)
                 {
                     previousClip = previous;
                 }
@@ -248,7 +256,7 @@ namespace Syncfusion.Maui.Toolkit
                     return;
                 }
 
-                EffectsView.Clip = currentClip;
+                clipView.Clip = currentClip;
             }
         }
 #endif
@@ -272,6 +280,20 @@ namespace Syncfusion.Maui.Toolkit
             UpdateClip(widthConstraint, heightConstraint);
 #endif
             return size;
+        }
+
+        /// <summary>
+        /// Called when the size of the element is allocated.
+        /// Updates the corner clip for Mac Catalyst and non-Android/iOS platforms.
+        /// </summary>
+        /// <param name="width">The width allocated to the element.</param>
+        /// <param name="height">The height allocated to the element.</param>
+        protected override void OnSizeAllocated(double width, double height)
+        {
+            base.OnSizeAllocated(width, height);
+#if __MACCATALYST__ || (!__ANDROID__ && !__IOS__)
+            this.ApplyCornerClip();
+#endif
         }
 
         #endregion


### PR DESCRIPTION
### Root Cause of the Issue

Following the upgrade to .NET 9, the EffectsView was not applied correctly. This issue stems from directly embedding the EffectsView within the SfIconButton component, which led to improper rendering or behavior.

### Description of Change
The issue was resolved by restructuring the layout specifically, by adding the EffectsView as a child of a Grid control. This allowed the clipping to be handled properly, ensuring the expected visual effects were rendered correctly.

### Issues Fixed

Picker Footer View Button Gets Hidden when clicked.

Fixes #

Added Clip Related changes


### Output

Before

https://github.com/user-attachments/assets/4d469885-4754-4eb4-aa9d-2776653b4b0a



After:



https://github.com/user-attachments/assets/2111b7fc-a9cc-46bb-95b0-7758185b70f5

<img width="1919" height="574" alt="image" src="https://github.com/user-attachments/assets/c8f5d2d7-bb4c-4253-8175-8dfccdbbfd58" />

