### PR TITLE
Fixed the issue of Horizontal axis labels skipped despite available space.

### DIFF
--- a/maui/src/Charts/Axis/ChartAxis.cs
+++ b/maui/src/Charts/Axis/ChartAxis.cs
@@ -239,7 +239,25 @@ namespace Syncfusion.Maui.Toolkit.Charts
 		protected internal double GetActualDesiredIntervalsCount(Size availableSize)
 		{
 			double size = !IsVertical ? availableSize.Width : availableSize.Height;
-			double spacingFactor = GetLabelSpacingFactor();
+
+			double spacingFactor = 1.0; //If the Axis is Vertical
+
+			if (!IsVertical)
+			{
+				// Base factor for horizontal labels
+				double factor = 0.6;
+				// Adjust based on label rotation
+				double rotationRadians = Math.Abs(LabelRotation) * Math.PI / 180;
+
+				if (rotationRadians > 0)
+				{
+					// Rotated labels can be packed more densely
+					factor *= 1.0 + 0.3 * Math.Sin(rotationRadians);
+				}
+
+				spacingFactor = factor;
+			}
+			
 			double adjustedDesiredIntervalsCount = size * spacingFactor * MaximumLabels;
 			return Math.Max(adjustedDesiredIntervalsCount / 100, 1.0);
 		}
@@ -774,25 +792,6 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				VisibleRange = visibleRange;
 				VisibleInterval = EnableAutoIntervalOnZooming ? CalculateNiceInterval(VisibleRange, plotSize) : ActualInterval;
 			}
-		}
-
-		double GetLabelSpacingFactor()
-		{
-			if (IsVertical)
-				return 1.0;
-
-			// Base factor for horizontal labels - more conservative than 0.54
-			double factor = 0.6;
-			// Adjust based on label rotation
-			double rotationRadians = Math.Abs(LabelRotation) * Math.PI / 180;
-
-			if (rotationRadians > 0)
-			{
-				// Rotated labels can be packed more densely
-				factor *= 1.0 + 0.3 * Math.Sin(rotationRadians);
-			}
-
-			return factor;
 		}
 
 		#endregion

--- a/maui/src/Charts/Axis/ChartAxis.cs
+++ b/maui/src/Charts/Axis/ChartAxis.cs
@@ -239,9 +239,9 @@ namespace Syncfusion.Maui.Toolkit.Charts
 		protected internal double GetActualDesiredIntervalsCount(Size availableSize)
 		{
 			double size = !IsVertical ? availableSize.Width : availableSize.Height;
-			double adjustedDesiredIntervalsCount = size * (!IsVertical ? 0.54 : 1.0) * MaximumLabels;
-			var actualDesiredIntervalsCount = Math.Max(adjustedDesiredIntervalsCount / 100, 1.0);
-			return actualDesiredIntervalsCount;
+			double spacingFactor = GetLabelSpacingFactor();
+			double adjustedDesiredIntervalsCount = size * spacingFactor * MaximumLabels;
+			return Math.Max(adjustedDesiredIntervalsCount / 100, 1.0);
 		}
 
 		/// <summary>
@@ -774,6 +774,25 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				VisibleRange = visibleRange;
 				VisibleInterval = EnableAutoIntervalOnZooming ? CalculateNiceInterval(VisibleRange, plotSize) : ActualInterval;
 			}
+		}
+
+		double GetLabelSpacingFactor()
+		{
+			if (IsVertical)
+				return 1.0;
+
+			// Base factor for horizontal labels - more conservative than 0.54
+			double factor = 0.6;
+			// Adjust based on label rotation
+			double rotationRadians = Math.Abs(LabelRotation) * Math.PI / 180;
+
+			if (rotationRadians > 0)
+			{
+				// Rotated labels can be packed more densely
+				factor *= 1.0 + 0.3 * Math.Sin(rotationRadians);
+			}
+
+			return factor;
 		}
 
 		#endregion


### PR DESCRIPTION
### Bug Description

X-axis labels were inconsistently skipped during chart rendering, even when sufficient space was available. This led to a poor user experience, especially in scenarios where label readability was critical.

Bug Report : https://github.com/syncfusion/maui-toolkit/issues/241

### Root Cause of the Issue

The static spacing factor used in the interval count calculation did not account for label rotation. As a result, the algorithm underestimated the number of labels that could be displayed, leading to unnecessary skipping.

### Description of Change

The interval count calculation logic was updated to compute the spacing factor based on the label rotation angle. This ensures that the available space is utilized more effectively, and the correct number of intervals is generated for the X-axis.

### Screenshots

#### Before:

<img width="270" height="602" alt="image" src="https://github.com/user-attachments/assets/2750ec4e-b93c-4a31-8094-9b75b6cbce68" />

<img width="270" height="602" alt="image" src="https://github.com/user-attachments/assets/8d9048a5-4cec-43ef-aaea-baf57789e1b4" />


#### After:

<img width="270" height="602" alt="image" src="https://github.com/user-attachments/assets/5aa3bc2a-3160-49f0-8c83-b4b3ec4ff7a5" />

<img width="270" height="602" alt="image" src="https://github.com/user-attachments/assets/492f63be-b7da-41e8-80c3-e7c28da302b2" />

### Test cases

- Test the axis labels with different LabelRotation values.
- Test using different options for LabelsIntersectAction on the axis.
