### PR TITLE
Resolved the OtpInput value mismatch issue for input types text and password.

### DIFF
--- a/maui/src/OtpInput/SfOtpInput.cs
+++ b/maui/src/OtpInput/SfOtpInput.cs
@@ -939,12 +939,7 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 				string oldValueStr = oldValue?.ToString() ?? string.Empty;
 				newValueStr = new string(newValueStr.Where(c => !char.IsControl(c)).ToArray());
 				oldValueStr = new string(oldValueStr.Where(c => !char.IsControl(c)).ToArray());
-
-				if (otpInput.ValueChanged != null)
-				{
-					RaiseValueChangedEvent(otpInput, oldValueStr, newValueStr);
-				}
-
+				RaiseValueChangedEvent(otpInput, oldValueStr, newValueStr);
 				otpInput.UpdateValue(bindable, newValue ?? string.Empty);
 			}
         }
@@ -959,7 +954,6 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
         {
             if (bindable is SfOtpInput otpInput && newValue is double newLength && oldValue is double oldLength)
             {
-
 				if (newLength <= 0)
 				{
 					newLength = oldLength;

--- a/maui/src/OtpInput/SfOtpInput.cs
+++ b/maui/src/OtpInput/SfOtpInput.cs
@@ -937,27 +937,16 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 
 				string newValueStr = newValue?.ToString() ?? string.Empty;
 				string oldValueStr = oldValue?.ToString() ?? string.Empty;
-
-				if (otpInput.Type == OtpInputType.Number)
-				{
-					newValueStr = new string(newValueStr.Where(c => !char.IsControl(c)).ToArray());
-					oldValueStr = new string(oldValueStr.Where(c => !char.IsControl(c)).ToArray());
-				}
+				newValueStr = new string(newValueStr.Where(c => !char.IsControl(c)).ToArray());
+				oldValueStr = new string(oldValueStr.Where(c => !char.IsControl(c)).ToArray());
 
 				if (otpInput.ValueChanged != null)
-                {
-					if (otpInput.Type == OtpInputType.Number)
-					{
-						RaiseValueChangedEvent(otpInput, oldValueStr, newValueStr);
-					}
-					else
-					{
-						RaiseValueChangedEvent(otpInput, oldValue?.ToString() ?? string.Empty, newValue?.ToString() ?? string.Empty);
-					}
+				{
+					RaiseValueChangedEvent(otpInput, oldValueStr, newValueStr);
 				}
-                
-                otpInput.UpdateValue(bindable, newValue?? string.Empty);
-            }
+
+				otpInput.UpdateValue(bindable, newValue ?? string.Empty);
+			}
         }
 
         /// <summary>

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Editors/SfOtpInputUnitTests.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Editors/SfOtpInputUnitTests.cs
@@ -474,6 +474,37 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 			Assert.True(eventTriggered);
 		}
 
+		[Theory]
+		[InlineData(OtpInputType.Number, "12", "12")]
+		[InlineData(OtpInputType.Text, "ab", "ab")]
+		[InlineData(OtpInputType.Password, "xy", "xy")]
+		public void ValueChangedEvent_WithPartialInput_DoesNotContainNullCharacters(OtpInputType type, string input, string expected)
+		{
+			// Arrange
+			var otpInput = new SfOtpInput
+			{
+				Length = 4,
+				Type = type
+			};
+			string? newValueFromEvent = null;
+			string? oldValueFromEvent = null;
+			otpInput.ValueChanged += (sender, e) =>
+			{
+				newValueFromEvent = e.NewValue;
+				oldValueFromEvent = e.OldValue;
+			};
+			// Act
+			otpInput.Value = input;
+			// Assert
+			Assert.Equal(expected, newValueFromEvent);
+			Assert.Equal(string.Empty, oldValueFromEvent);
+			if (newValueFromEvent != null)
+			{
+				Assert.DoesNotContain('\0', newValueFromEvent!);
+			}
+		}
+
+
 		#endregion
 
 		#region Public Methods


### PR DESCRIPTION
### Root Cause of the Issue

The internal logic for the SfOtpInput component's Value property was including non-printable control characters (specifically, null characters like \0) in its string representation. These characters were likely used as internal placeholders for empty OTP cells. When the ValueChanged event was triggered, these control characters were included in the NewValue and OldValue properties of the event arguments. This caused the reported values to be incorrect (e.g., "1a\0\0" instead of "1a"), leading to a data mismatch and unexpected behavior when consuming the event.

### Description of Change

- To resolve this, the OnValuePropertyChanged method has been updated to sanitize the OTP values before the ValueChanged event is raised.
- The implementation now explicitly filters both the oldValue and newValue strings to remove any control characters. 
- This ensures that the OtpInputValueChangedEventArgs passed to the user contain only the actual visible characters that have been entered. 
- This change guarantees clean and accurate string data in the event, resolving the value mismatch issue for all input types, including Text and Password.


### Issues Fixed

Issue : #184 
