### PR TITLE
Resolved the selectionchanged issue for SfTabView.

### DIFF
--- a/maui/src/TabView/Control/HorizontalContent/SfHorizontalContent.iOS.cs
+++ b/maui/src/TabView/Control/HorizontalContent/SfHorizontalContent.iOS.cs
@@ -69,8 +69,7 @@ namespace Syncfusion.Maui.Toolkit.TabView
 					{
 						this._canProcessTouch = false;
 					}
-				}
-                else if (view is UIKit.UITouch uiTouch)
+					else if (view is UIKit.UITouch uiTouch)
                 {
 				// For SfTextInputLayout or similar views that require precise touch interactions.
                     var touchLocation = uiTouch.LocationInView(uiTouch.View?.Superview);
@@ -104,6 +103,8 @@ namespace Syncfusion.Maui.Toolkit.TabView
 				        }
                     }
 				}
+				}
+                
 			}
 #endif
 		}


### PR DESCRIPTION
### Root Cause of the Issue
The root cause of the issue was an improper handling of touch event propagation within the UI hierarchy of the iOS implementation, specifically in relation to how input views were being tested for touch interactions. By not allowing all relevant views to respond to touches, the user experience was negatively affected.

### Description of Change
The bug was resolved by modifying the conditions properly in the SfHorizontalContent.iOS.cs file. The adjusted implementation returns the root view directly without further checks, ensuring that any view can process touch events effectively. This allows taps to register as intended for item selection.

### Issues Fixed

Fixes:  #251 
