### PR TITLE
Resolved the issue of exception during animation enabled check by applying a default value

### DIFF
--- a/maui/src/Core/Legend/AreaBase.cs
+++ b/maui/src/Core/Legend/AreaBase.cs
@@ -181,16 +181,9 @@ namespace Syncfusion.Maui.Toolkit.Internals
 		{
 			bool isAnimationOn = true;
 #if ANDROID
-			try
-			{
-				var handler = Application.Current?.Handler;
-				float scale = Settings.Global.GetFloat(handler?.MauiContext?.Context?.ApplicationContext?.ContentResolver, Settings.Global.AnimatorDurationScale);
-				isAnimationOn = scale != 0.0f;
-			}
-			catch
-			{
-				isAnimationOn = false;
-			}
+			var handler = Application.Current?.Handler;
+			float scale = Settings.Global.GetFloat(handler?.MauiContext?.Context?.ApplicationContext?.ContentResolver, Settings.Global.AnimatorDurationScale, 0.0f);
+			isAnimationOn = scale != 0.0f;
 #endif
 			return isAnimationOn;
 		}


### PR DESCRIPTION
### Bug Description

Chart rendering throws exceptions on Android devices related to animation settings. This occurs when Developer Options have never been enabled, making animation scale settings inaccessible.

Discussion link: https://github.com/syncfusion/maui-toolkit/discussions/221

### Root Cause of the Issue

The exception was caused by attempting to retrieve the animation scale setting using Settings.Global.GetFloat, which fails if Developer Options were never enabled. This results in a FirstChanceException being logged even though the exception is handled.

### Description of Change

To avoid unnecessary exception logging during chart rendering, we replaced the try-catch block with a direct call to Settings.Global.GetFloat using a default value. This ensures smooth behavior even when Developer Options are disabled. The chart now renders with or without animation based on the retrieved scale value, without triggering exceptions.

### Screenshots

#### Before:

<img width="1908" height="896" alt="image" src="https://github.com/user-attachments/assets/17902b88-a842-4605-9d22-e236fd023e59" />

#### After:

<img width="1870" height="973" alt="image" src="https://github.com/user-attachments/assets/7890b7e0-9dc4-43a8-baa8-f43515cf9c81" />

**_Here SettingsNotFound Exception does not occur in the console while triggering the FirstChanceException_**

Device Name: **Redmi Note 11 Pro 5G**
**With Animator duration Scale as 1.5x**

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/7a12ee78-fc97-408a-9f70-936f53b6f362" />

**With Animator duration Scale as off**

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/2a1c9621-b6bf-4aee-a930-39bfe5d61af4" />

**_Here SettingsNotFound Exception does not occur in the console while triggering the FirstChanceException_**

### Test cases

- Test case for chart rendering with animation enabled
- Test case for chart rendering with animation disabled
- Test case for chart rendering when Developer Options are not enabled
