### PR TITLE
Added property to change close button icon color in Popup

### DIFF
--- a/maui/src/Popup/PopupCloseButton.cs
+++ b/maui/src/Popup/PopupCloseButton.cs
@@ -229,7 +229,7 @@ namespace Syncfusion.Maui.Toolkit.Popup
 					_closeButtonImage.IsVisible = false;
 				}
 
-				canvas.StrokeColor = _popupView._popup.PopupStyle.GetCloseButtonIconStroke();
+				canvas.StrokeColor = _popupView._popup.PopupStyle.GetCloseIconColor();
 				canvas.StrokeSize = (float)_popupView._popup.PopupStyle.GetCloseButtonIconStrokeThickness();
 				PointF firstLine = new Point(0, 0);
 				PointF secondLine = new Point(0, 0);

--- a/maui/src/Popup/Style/PopupStyle.cs
+++ b/maui/src/Popup/Style/PopupStyle.cs
@@ -190,10 +190,10 @@ namespace Syncfusion.Maui.Toolkit.Popup
 			BindableProperty.Create(nameof(CloseButtonIcon), typeof(ImageSource), typeof(PopupStyle), null);
 
 		/// <summary>
-		/// Identifies the <see cref="CloseButtonIconStroke"/> <see cref="BindableProperty"/>.
+		/// Identifies the <see cref="CloseIconColor"/> <see cref="BindableProperty"/>.
 		/// </summary>
-		internal static BindableProperty CloseButtonIconStrokeProperty =
-			BindableProperty.Create(nameof(CloseButtonIconStroke), typeof(Color), typeof(PopupStyle), defaultValue: Color.FromArgb("#49454F"));
+		public static BindableProperty CloseIconColorProperty =
+			BindableProperty.Create(nameof(CloseIconColor), typeof(Color), typeof(PopupStyle), defaultValue: Color.FromArgb("#49454F"));
 
 		/// <summary>
 		/// Identifies the <see cref="CloseButtonIconStrokeThickness"/> <see cref="BindableProperty"/>.
@@ -924,18 +924,31 @@ namespace Syncfusion.Maui.Toolkit.Popup
 			set => SetValue(CloseButtonIconProperty, value);
 		}
 
+		/// <summary>
+		/// Gets or sets the color of the close icon displayed in the <see cref="SfPopup"/>.
+		/// </summary>
+		/// <example>
+		/// <para>The following code example demonstrates how to set <see cref="CloseIconColor"/> for the <see cref="SfPopup"/> control.</para>
+		/// <code lang="XAML">
+		/// <![CDATA[
+		/// <popup:SfPopup x:Name="popup">
+		///     <popup:SfPopup.PopupStyle>
+		///         <popup:PopupStyle CloseIconColor="Red" />
+		///     </popup:SfPopup.PopupStyle>
+		/// </popup:SfPopup>
+		/// ]]>
+		/// </code>
+		/// </example>
+		/// <seealso cref="SfPopup.ShowCloseButton"/>
+		public Color CloseIconColor
+		{
+			get => (Color)GetValue(CloseIconColorProperty);
+			set => SetValue(CloseIconColorProperty, value);
+		}
+
 		#endregion
 
 		#region Internal Properties
-
-		/// <summary>
-		/// Gets or sets the icon color for close button.
-		/// </summary>
-		internal Color CloseButtonIconStroke
-		{
-			get => (Color)GetValue(CloseButtonIconStrokeProperty);
-			set => SetValue(CloseButtonIconStrokeProperty, value);
-		}
 
 		/// <summary>
 		/// Gets or sets the icon stroke thickness for close button.
@@ -1113,7 +1126,7 @@ namespace Syncfusion.Maui.Toolkit.Popup
 		/// Gets the icon color for close button.
 		/// </summary>
 		/// <returns> icon color for close button.</returns>
-		internal Color GetCloseButtonIconStroke() => CloseButtonIconStroke;
+		internal Color GetCloseIconColor() => CloseButtonIconStroke;
 
 		/// <summary>
 		/// Gets the icon stroke thickness for close button.
@@ -1160,7 +1173,7 @@ namespace Syncfusion.Maui.Toolkit.Popup
 			ApplyDynamicResource(HeaderFontSizeProperty, "SfPopupNormalHeaderFontSize");
 			ApplyDynamicResource(MessageFontSizeProperty, "SfPopupNormalMessageFontSize");
 			ApplyDynamicResource(FooterFontSizeProperty, "SfPopupNormalFooterFontSize");
-			ApplyDynamicResource(CloseButtonIconStrokeProperty, "SfPopupNormalCloseButtonIconStroke");
+			ApplyDynamicResource(CloseIconColorProperty, "SfPopupNormalCloseButtonIconStroke");
 			ApplyDynamicResource(CloseButtonIconStrokeThicknessProperty, "SfPopupNormalCloseButtonIconStrokeThickness");
 			ApplyDynamicResource(HoveredCloseButtonIconBackgroundProperty, "SfPopupHoverCloseButtonIconBackground");
 			ApplyDynamicResource(PressedCloseButtonIconBackgroundProperty, "SfPopupPressedCloseButtonIconBackground");

--- a/maui/src/Popup/Style/PopupStyle.cs
+++ b/maui/src/Popup/Style/PopupStyle.cs
@@ -1126,7 +1126,7 @@ namespace Syncfusion.Maui.Toolkit.Popup
 		/// Gets the icon color for close button.
 		/// </summary>
 		/// <returns> icon color for close button.</returns>
-		internal Color GetCloseIconColor() => CloseButtonIconStroke;
+		internal Color GetCloseIconColor() => CloseIconColor;
 
 		/// <summary>
 		/// Gets the icon stroke thickness for close button.


### PR DESCRIPTION
**Requirement**
The close button foreground color in the Toolkit Popup was not customizable via public API.

**Solution**
Modified the internal CloseButtonIconStroke property to be public accessible, allowing developers to set the foreground color of the close button in the Toolkit Popup. Renamed the API name to CloseIconColor.

**API Summary**
API Name: CloseIconColor
Namespace: Syncfusion.Maui.Toolkit.Popup
Input Type: Color
Access Specifier: public

**FR link**
https://github.com/syncfusion/maui-toolkit/issues/154

**Screenshots**
**Default CloseIconColor**
<img width="1920" height="1128" alt="image" src="https://github.com/user-attachments/assets/ae778fbe-a905-47ab-81db-24e6f9101623" />
**CloseIconColor="OrangeRed"** 
<img width="1920" height="1128" alt="image" src="https://github.com/user-attachments/assets/72f2fc1e-26f4-4415-81a8-0269d2e215ee" />
