### PR TITLE
Correcting Mac Catalyst issues with SfSegmentedControl and SafeArea in TitleBar

### DIFF
--- a/maui/samples/Sandbox/App.xaml.cs
+++ b/maui/samples/Sandbox/App.xaml.cs
@@ -9,7 +9,9 @@
 
 		protected override Window CreateWindow(IActivationState? activationState)
 		{
-			return new Window(new AppShell());
+			AppWindow window = new AppWindow();
+            window.Page = new AppShell();
+            return window;
 		}
 	}
 }

--- a/maui/samples/Sandbox/AppWindow.xaml
+++ b/maui/samples/Sandbox/AppWindow.xaml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Window xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:sf="https://schemas.syncfusion.com/maui/toolkit"
+    x:Class="Syncfusion.Maui.Samples.Sandbox.AppWindow">
+    <Window.TitleBar>
+        <TitleBar Title="Sandbox"
+                  BackgroundColor="#512BD4"
+                  ForegroundColor="White"                  
+                  HeightRequest="50">
+                  <TitleBar.LeadingContent>
+                    <Grid>
+                    </Grid>
+                  </TitleBar.LeadingContent>
+            <TitleBar.Content>
+                <HorizontalStackLayout HorizontalOptions="Center">
+                    <SearchBar Placeholder="Search"
+                           PlaceholderColor="White"
+                           Background="#512BD4"
+                           MaximumWidthRequest="400"
+                           HorizontalOptions="Fill"
+                           VerticalOptions="Center" />
+                    </HorizontalStackLayout>
+            </TitleBar.Content>            
+            <TitleBar.TrailingContent>
+                <HorizontalStackLayout Spacing="8" VerticalOptions="Fill">
+                    
+
+                    <sf:SfSegmentedControl 
+                        x:Name="ThemeSegmentedControl"
+                        SelectionChanged="SfSegmentedControl_SelectionChanged" 
+                        SegmentWidth="36" SegmentHeight="36">
+                        <sf:SfSegmentedControl.ItemsSource>
+                            <x:Array Type="{x:Type sf:SfSegmentItem}">
+                                <sf:SfSegmentItem ImageSource="{StaticResource IconLight}"/>
+                                <sf:SfSegmentItem ImageSource="{StaticResource IconDark}"/>
+                            </x:Array>
+                        </sf:SfSegmentedControl.ItemsSource>
+                    </sf:SfSegmentedControl>
+                </HorizontalStackLayout>
+            </TitleBar.TrailingContent>
+        </TitleBar>
+    </Window.TitleBar>
+</Window>

--- a/maui/samples/Sandbox/AppWindow.xaml.cs
+++ b/maui/samples/Sandbox/AppWindow.xaml.cs
@@ -1,0 +1,10 @@
+namespace Syncfusion.Maui.Samples.Sandbox
+{
+	public partial class AppWindow
+	{
+		public AppWindow()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/maui/src/SegmentedControl/Views/SegmentLayout.cs
+++ b/maui/src/SegmentedControl/Views/SegmentLayout.cs
@@ -42,7 +42,12 @@ namespace Syncfusion.Maui.Toolkit.SegmentedControl
 		/// <param name="itemInfo">The <see cref="ISegmentItemInfo"/> providing information about the segment items.</param>
 		internal SegmentLayout(ISegmentItemInfo itemInfo)
 		{
-#if __IOS__
+#if __IOS__ || MACCATALYST
+			// Ignore the safe area on iOS and Mac Catalyst so the control is laid out using the
+			// full bounds provided by its parent. Without this on Mac Catalyst, the initial window
+			// (non–fullscreen) can report a smaller client area and the segmented control may appear
+			// shifted upward / clipped beneath the title bar until a subsequent resize or fullscreen
+			// transition triggers a proper re-measure. (See GitHub issue: SegmentedControl TitleBar layout on macOS.)
 			this.IgnoreSafeArea = true;
 #endif
 			FlowDirection = Microsoft.Maui.FlowDirection.LeftToRight;


### PR DESCRIPTION
### Root Cause of the Issue

<!-- Enter the root cause of the issue in this section. -->

### Description of Change

<!-- Enter description of the fix in this section. -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

### Screenshots

#### Before:

#### After:
