### PR TITLE
Resolved the DrawingView IOS issues in SfTabView.

### DIFF
--- a/maui/src/TabView/Control/HorizontalContent/SfHorizontalContent.iOS.cs
+++ b/maui/src/TabView/Control/HorizontalContent/SfHorizontalContent.iOS.cs
@@ -76,12 +76,13 @@ namespace Syncfusion.Maui.Toolkit.TabView
 					var textInputView = FindSfTextInputLayout(uiTouch.View?.Superview);
                     this._canProcessTouch = true;
 
-					var touchViewType = touchView?.GetType().FullName;
-                    if (touchViewType != null && touchViewType.Contains("CommunityToolkit.Maui.Core.Views.MauiDrawingView", StringComparison.Ordinal))
-                    {
-                         this._canProcessTouch = false;
-                         return;
-                    }
+					const string MauiDrawingViewTypeName = "CommunityToolkit.Maui.Core.Views.MauiDrawingView"; 
+					var touchViewType = touchView?.GetType().FullName; 
+					if (touchViewType is not null && touchViewType.Contains(MauiDrawingViewTypeName, StringComparison.Ordinal)) 
+					{ 
+						this._canProcessTouch = false; 
+						return; 
+					}
 
                     if (textInputView != null)
                     {


### PR DESCRIPTION
### Root Cause of the Issue

The SfTabView's internal gesture handling interferes with the DrawingView's touch processing. Specifically, the tab view's gesture recognizer prematurely cancels the touch event, causing the DrawingView to interpret the interaction as cancelled rather than completed. This happens because the tab view's gesture listener (ITapGestureListener) does not differentiate between general views and specialized touch-sensitive views like DrawingView.

### Description of Change

Added a type check in the ShouldHandleTap method of SfTabView's horizontal content iOS class to detect if the touched view is a MauiDrawingView. If so, the tab view disables its own touch processing to allow the DrawingView to handle the gesture correctly.

### Issues Fixed
Issue : https://github.com/syncfusion/maui-toolkit/issues/258

