### PR TITLE
SfTabView HeaderItemSpacing property

### DIFF
--- a/maui/src/TabView/Control/SfTabBar.cs
+++ b/maui/src/TabView/Control/SfTabBar.cs
@@ -30,7 +30,6 @@ namespace Syncfusion.Maui.Toolkit.TabView
 
 		// Dimension and positioning fields
 
-		readonly int _defaultTextPadding = 36;
         double _previousTabX = 0d;
         double _selectedTabX = 0d;
         double _currentIndicatorWidth = 0d;
@@ -214,6 +213,17 @@ namespace Syncfusion.Maui.Toolkit.TabView
                 typeof(DataTemplate),
                 typeof(SfTabBar),
                 propertyChanged: OnHeaderTemplateChanged);
+
+		/// <summary>
+		/// Identifies the <see cref="HeaderItemSpacing"/> bindable property.
+		/// </summary>
+		internal static readonly BindableProperty HeaderItemSpacingProperty =
+			BindableProperty.Create(
+				nameof(HeaderItemSpacing),
+				typeof(int),
+				typeof(SfTabBar),
+				36,
+				propertyChanged: OnHeaderItemSpacingChanged);
 
         /// <summary>
         /// Identifies the <see cref="HeaderDisplayMode"/> bindable property.
@@ -511,6 +521,18 @@ namespace Syncfusion.Maui.Toolkit.TabView
         {
             get => (DataTemplate?)GetValue(HeaderItemTemplateProperty);
             set => SetValue(HeaderItemTemplateProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the value that defines the spacing between header items.
+        /// </summary>
+        /// <value>
+        /// It accepts int values and the default value is 36.
+        /// </value>
+        internal int HeaderItemSpacing
+        {
+	        get => (int)GetValue(HeaderItemSpacingProperty);
+	        set => SetValue(HeaderItemSpacingProperty, value);
         }
 
         /// <summary>
@@ -1481,6 +1503,11 @@ namespace Syncfusion.Maui.Toolkit.TabView
 			CalculateTabItemsSourceWidth();
 		}
 
+        void UpdateTabHeaderItemSpacing()
+        {
+	        CalculateTabItemWidth();
+        }
+
         void AddTabViewItemFromTemplate(object? item)
         {
             var view = item as View;
@@ -2125,8 +2152,8 @@ namespace Syncfusion.Maui.Toolkit.TabView
                     if (item.Header != null)
                     {
                         Size desiredSize = item.Header.Measure((float)item.FontSize, item.FontAttributes, item.FontFamily);
-                        double width = desiredSize.Width + _defaultTextPadding;
-                        UpdateTabItemWidth(item, item.IsSelected ? width : _tabHeaderImageSize + _defaultTextPadding);
+                        double width = desiredSize.Width + HeaderItemSpacing;
+                        UpdateTabItemWidth(item, item.IsSelected ? width : _tabHeaderImageSize + HeaderItemSpacing);
                     }
                 }
             }
@@ -2163,7 +2190,7 @@ namespace Syncfusion.Maui.Toolkit.TabView
 				if (item.HeaderContent != null)
 				{
 					Size headerContentSize = item.HeaderContent.Measure(double.PositiveInfinity, double.PositiveInfinity);
-					width = headerContentSize.Width + _defaultTextPadding;
+					width = headerContentSize.Width + HeaderItemSpacing;
 				}
 				else if (item.ImageSource != null && !string.IsNullOrEmpty(item.Header))
                 {
@@ -2172,12 +2199,12 @@ namespace Syncfusion.Maui.Toolkit.TabView
                 else if (item.ImageSource != null)
                 {
                     item.HeaderDisplayMode = TabBarDisplayMode.Image;
-                    width = _tabHeaderImageSize + _defaultTextPadding;
+                    width = _tabHeaderImageSize + HeaderItemSpacing;
                 }
                 else
                 {
                     item.HeaderDisplayMode = TabBarDisplayMode.Text;
-                    width = desiredSize.Width + _defaultTextPadding;
+                    width = desiredSize.Width + HeaderItemSpacing;
                 }
                 UpdateTabItemWidth(item, width);
             }
@@ -2189,22 +2216,22 @@ namespace Syncfusion.Maui.Toolkit.TabView
 			if (HeaderDisplayMode == TabBarDisplayMode.Image)
             {
                 item.HeaderDisplayMode = TabBarDisplayMode.Image;
-                return _tabHeaderImageSize + _defaultTextPadding;
+                return _tabHeaderImageSize + HeaderItemSpacing;
             }
             else if (HeaderDisplayMode == TabBarDisplayMode.Text)
             {
                 item.HeaderDisplayMode = TabBarDisplayMode.Text;
-                return desiredSize.Width + _defaultTextPadding;
+                return desiredSize.Width + HeaderItemSpacing;
             }
             else
             {
                 if (item.ImagePosition == TabImagePosition.Left || item.ImagePosition == TabImagePosition.Right)
                 {
-                    return desiredSize.Width + _defaultTextPadding + _tabHeaderImageSize + item.ImageTextSpacing;
+                    return desiredSize.Width + HeaderItemSpacing + _tabHeaderImageSize + item.ImageTextSpacing;
                 }
                 else
                 {
-                    return desiredSize.Width + _defaultTextPadding;
+                    return desiredSize.Width + HeaderItemSpacing;
                 }
             }
         }
@@ -3495,6 +3522,8 @@ namespace Syncfusion.Maui.Toolkit.TabView
         static void OnItemsChanged(BindableObject bindable, object oldValue, object newValue) => (bindable as SfTabBar)?.UpdateItems();
 
         static void OnHeaderTemplateChanged(BindableObject bindable, object oldValue, object newValue) => (bindable as SfTabBar)?.UpdateItemsSource();
+
+        static void OnHeaderItemSpacingChanged(BindableObject bindable, object oldValue, object newValue) => (bindable as SfTabBar)?.UpdateTabHeaderItemSpacing();
 
         static void OnItemsSourceChanged(BindableObject bindable, object oldValue, object newValue) => (bindable as SfTabBar)?.UpdateItemsSource();
 

--- a/maui/src/TabView/Control/SfTabView.cs
+++ b/maui/src/TabView/Control/SfTabView.cs
@@ -229,6 +229,17 @@ namespace Syncfusion.Maui.Toolkit.TabView
 				propertyChanged: OnHeaderItemTemplateChanged);
 
 		/// <summary>
+		/// Identifies the <see cref="HeaderItemSpacing"/> bindable property.
+		/// </summary>
+		public static readonly BindableProperty HeaderItemSpacingProperty =
+			BindableProperty.Create(
+				nameof(HeaderItemSpacing),
+				typeof(int),
+				typeof(SfTabView),
+				36,
+				propertyChanged: OnHeaderItemSpacingChanged);
+
+		/// <summary>
 		/// Identifies the <see cref="ContentItemTemplate"/> bindable property.
 		/// </summary>
 		public static readonly BindableProperty ContentItemTemplateProperty =
@@ -1032,6 +1043,33 @@ namespace Syncfusion.Maui.Toolkit.TabView
 		{
 			get => (DataTemplate?)GetValue(HeaderItemTemplateProperty);
 			set => SetValue(HeaderItemTemplateProperty, value);
+		}
+		
+		/// <summary>
+		/// Gets or sets the value that defines the spacing between header items.
+		/// </summary>
+		/// <value>
+		/// It accepts int values and the default value is 36.
+		/// </value>
+		/// <example>
+		/// Here is an example of how to set the <see cref="HeaderItemSpacing"/> property.
+		/// 
+		/// # [XAML](#tab/tabid-1)
+		/// <code><![CDATA[
+		/// <tabView:SfTabView HeaderItemSpacing="32" />
+		/// ]]></code>
+		/// 
+		/// # [C#](#tab/tabid-2)
+		/// <code><![CDATA[
+		/// SfTabView tabView = new SfTabView();
+		/// tabView.HeaderItemSpacing = 32;
+		/// Content = tabView;
+		/// ]]></code>
+		/// </example>
+		public int HeaderItemSpacing
+		{
+			get => (int)GetValue(HeaderItemSpacingProperty);
+			set => SetValue(HeaderItemSpacingProperty, value);
 		}
 
 		/// <summary>
@@ -1962,6 +2000,11 @@ namespace Syncfusion.Maui.Toolkit.TabView
 		static void OnHeaderItemTemplateChanged(BindableObject bindable, object oldValue, object newValue) => (bindable as SfTabView)?.UpdateHeaderItemTemplate();
 
 		/// <summary>
+		/// Handles changes to the <see cref="HeaderItemSpacing"/> property.
+		/// </summary>
+		static void OnHeaderItemSpacingChanged(BindableObject bindable, object oldValue, object newValue) => (bindable as SfTabView)?.UpdateHeaderSpacing();
+
+		/// <summary>
 		/// Handles changes to the <see cref="ContentItemTemplate"/> property.
 		/// </summary>
 		static void OnContentItemTemplateChanged(BindableObject bindable, object oldValue, object newValue) => (bindable as SfTabView)?.UpdateContentItemTemplate();
@@ -2093,6 +2136,17 @@ namespace Syncfusion.Maui.Toolkit.TabView
 			{
 				_tabHeaderContainer.ItemsSource = ItemsSource;
 				_tabHeaderContainer.HeaderItemTemplate = HeaderItemTemplate;
+			}
+		}
+
+		/// <summary>
+		/// Updates the header item spacing of the tab bar.
+		/// </summary>
+		void UpdateHeaderSpacing()
+		{
+			if (_tabHeaderContainer != null)
+			{
+				_tabHeaderContainer.HeaderItemSpacing = HeaderItemSpacing;
 			}
 		}
 


### PR DESCRIPTION
### Root Cause of the Issue

We need to customize the spacing between header items in the TabView. This spacing is currently hardcoded to 36 (see https://github.com/syncfusion/maui-toolkit/blob/main/maui/src/TabView/Control/SfTabBar.cs#L33). 

### Description of Change

Introduces  a new HeaderItemSpacing property on SfTabView, piped down to SfTabBar.

Preserves current value 36 as default value.


### Screenshots

![headeritemspacing](https://github.com/user-attachments/assets/3de9ea89-bb83-49e3-9146-f31d98895b51)

