### PR TITLE
sfTimePicker: Apply maximum in the second and millisecond column

### DIFF
--- a/maui/src/Picker/SfTimePicker.cs
+++ b/maui/src/Picker/SfTimePicker.cs
@@ -1052,7 +1052,7 @@ namespace Syncfusion.Maui.Toolkit.Picker
 			int minute = 0;
 			if (_minuteColumn.ItemsSource != null && _minuteColumn.ItemsSource is ObservableCollection<string> minuteCollection && minuteCollection.Count > e.NewValue)
 			{
-				//// Get the hour value based on the selected index changes value.
+				// Get the hour value based on the selected index changes value.
 				minute = int.Parse(minuteCollection[e.NewValue]);
 			}
 


### PR DESCRIPTION
### Root Cause of the Issue

In sfTimePicker add support to reflect the maximum seconds when a MaximumTime is set that also limits the seconds. For instance the MaximumTime is 4 minutes and 15 seconds, then when selecting 4 minutes the second column would display all seconds from 0 to 59. This should be limited to the actual maximum of seconds which in our example is 15 seconds. This also applies to MilliSeconds.

### Description of Change

This PR updates the seconds and milliseconds column to refelect the correct maximum.

### Issues Fixed

Fixes #299

### Screenshots

#### Before:
<img width="734" height="436" alt="image" src="https://github.com/user-attachments/assets/98dd7c78-d61d-46de-93e4-bc2fd6046551" />

#### After:
<img width="739" height="439" alt="image" src="https://github.com/user-attachments/assets/f5bd2082-7344-4b0b-9d9c-859797dcd1e3" />