### PR TITLE
fix: SfBottomSheet theme customization

### DIFF
--- a/maui/src/BottomSheet/SfBottomSheet.cs
+++ b/maui/src/BottomSheet/SfBottomSheet.cs
@@ -1549,6 +1549,8 @@ namespace Syncfusion.Maui.Toolkit.BottomSheet
 		void ApplyThemeResources()
 		{
 		   SetDynamicResource(OverlayBackgroundColorProperty, "SfBottomSheetOverlayBackgroundColor");
+		   SetDynamicResource(BackgroundProperty, "SfBottomSheetBackground");
+		   SetDynamicResource(GrabberBackgroundProperty, "SfBottomSheetGrabberBackground");
 		}
 
 		/// <summary>


### PR DESCRIPTION
### Root Cause of the Issue

SfBottomSheet theme customization does not work following the doc: https://help.syncfusion.com/maui-toolkit/themes/keys

The root cause was missing SetDynamicResource calls for the Background and GrabberBackground properties in the ApplyThemeResources method.

### Description of Change

Added SetDynamicResource call for BackgroundProperty with key "SfBottomSheetBackground."
Added SetDynamicResource call for GrabberBackgroundProperty with key "SfBottomSheetGrabberBackground."
