### PR TITLE
Fix TabView touch interception for Android 15+

### DIFF
--- a/maui/src/TabView/Control/HorizontalContent/SfHorizontalContent.Android.cs
+++ b/maui/src/TabView/Control/HorizontalContent/SfHorizontalContent.Android.cs
@@ -82,8 +82,13 @@ namespace Syncfusion.Maui.Toolkit.TabView
 								OnHandleTouchInteraction(PointerActions.Pressed, _initialPoint);
 								return true;
 							}
+							break;
 						}
+					case MotionEventActions.Cancel:
+					{
+						_shouldProcessTouchForSwipe = false;
 						break;
+					}
 				}
 			}
 


### PR DESCRIPTION
### Root Cause of the Issue

Previously, there was an incorrect if statement that only checked whether there was any movement (delta != 0) in the horizontal direction. This did not accurately distinguish between swipe gestures and taps.

### Description of Change

I have fixed the if statement that handles the initial touch interaction. I updated the check to determine whether the user's movement was more horizontal than vertical, and whether it exceeded the minimum threshold required to be considered a swipe. Additionally, I introduced a control variable _shouldProcessTouchForSwipe, which is now checked in ITouchListener.OnTouch event. If _shouldProcessTouchForSwipe is false, the method returns early, preventing the touch from being processed as a swipe.

### Issues Fixed

Clicking on Android 15 and newer now works as expected. Even if I move my finger a little while tapping, the click is registered.

Fixes #304 
