### PR TITLE
Resolved the TabView touch interaction issue on navigation page

### DIFF
--- a/maui/src/TabView/Control/SfTabBar.cs
+++ b/maui/src/TabView/Control/SfTabBar.cs
@@ -3449,6 +3449,17 @@ namespace Syncfusion.Maui.Toolkit.TabView
 					}
 				}
 			}
+            else
+			{
+				if (Items != null)
+				{
+					foreach (var item in Items)
+					{
+						item.Touched -= OnTabItemTouched;
+						item.Touched += OnTabItemTouched;
+					}
+				}
+			}
 
 			base.OnHandlerChanged();
 		}


### PR DESCRIPTION
### Root Cause of the Issue
 
The TabItemTouched event was getting detached when navigating back to the main page and was not re-attached after returning to the Tab View control page.
 
### Description of Change
 
Added logic to re-attach the event in the handler and updated the implementation in the SfTabBar class to ensure the TabItemTouched event remains functional after navigation.
