### PR TITLE
Resolved the TabView DrawingView issues in MAC and IOS.

### DIFF
--- a/maui/src/TabView/Control/HorizontalContent/SfHorizontalContent.iOS.cs
+++ b/maui/src/TabView/Control/HorizontalContent/SfHorizontalContent.iOS.cs
@@ -4,6 +4,7 @@ using PointerEventArgs = Syncfusion.Maui.Toolkit.Internals.PointerEventArgs;
 using UIKit;
 using Syncfusion.Maui.Toolkit.Platform;
 using Syncfusion.Maui.Toolkit.TextInputLayout;
+using Microsoft.Maui.Graphics;
 
 namespace Syncfusion.Maui.Toolkit.TabView
 {
@@ -75,6 +76,18 @@ namespace Syncfusion.Maui.Toolkit.TabView
                     var touchLocation = uiTouch.LocationInView(uiTouch.View?.Superview);
 					var textInputView = FindSfTextInputLayout(uiTouch.View?.Superview);
                     this._canProcessTouch = true;
+
+                    var touchViewType = touchView?.GetType();
+                    if (touchViewType is not null)
+                    {
+						var hasDrawAction = touchViewType.GetProperties().Any(p => p.PropertyType == typeof(Action<ICanvas, RectF>));
+                        if (hasDrawAction)
+                        {
+                            this._canProcessTouch = false;
+                            return;
+                        }
+					}
+
                     if (textInputView != null)
                     {
                         if (uiTouch.GestureRecognizers != null)


### PR DESCRIPTION
### Root Cause of the Issue

The SfTabView's internal gesture handling interferes with the DrawingView's touch processing. Specifically, the tab view's gesture recognizer prematurely cancels the touch event, causing the DrawingView to interpret the interaction as cancelled rather than completed. This happens because the tab view's gesture listener (ITapGestureListener) does not differentiate between general views and specialized touch-sensitive views like DrawingView.

### Description of Change

Added a type check in the ShouldHandleTap method of SfTabView's horizontal content iOS class to detect if the touched view is a MauiDrawingView. If so, the tab view disables its own touch processing to allow the DrawingView to handle the gesture correctly.

### Issues Fixed
Issue : https://github.com/syncfusion/maui-toolkit/issues/258
