### PR TITLE
Fix TabView touch interception for Android

### DIFF
--- a/maui/src/TabView/Control/HorizontalContent/SfHorizontalContent.Android.cs
+++ b/maui/src/TabView/Control/HorizontalContent/SfHorizontalContent.Android.cs
@@ -20,11 +20,9 @@ namespace Syncfusion.Maui.Toolkit.TabView
 		double _moveY;
 
 		// Constants for touch movement thresholds
-		const double VerticalScrollThreshold = 2;
-		const double HorizontalScrollThreshold = 6;
 		double _density = Android.App.Application.Context.Resources.DisplayMetrics.Density;
-		double _horizontalScrollThreshold => HorizontalScrollThreshold * _density;
-		double _verticalScrollThreshold => VerticalScrollThreshold * _density;
+		double _swipeThreshold => 5 * _density;
+
 
 		#endregion
 
@@ -63,13 +61,13 @@ namespace Syncfusion.Maui.Toolkit.TabView
 							_moveY = motionEvent.GetY();
 
 							// Check for vertical scrolling threshold
-							if (Math.Abs(_downY - _moveY) > _verticalScrollThreshold  && Math.Abs(_downX - _moveX) < _horizontalScrollThreshold)
+							if (Math.Abs(_downY - _moveY) > _swipeThreshold && Math.Abs(_downX - _moveX) < _swipeThreshold)
 							{
 								return false;
 							}
 
 							// Handle initial touch interaction
-							if (!_isPressed && Math.Abs(_downY - _moveY) > _verticalScrollThreshold && Math.Abs(_downX - _moveX)  > _horizontalScrollThreshold)
+							if (!_isPressed && Math.Abs(_downY - _moveY) > _swipeThreshold && Math.Abs(_downX - _moveX)  > _swipeThreshold)
 							{
 								OnHandleTouchInteraction(PointerActions.Pressed, _initialPoint);
 								return true;


### PR DESCRIPTION
**Root Cause of the Issue**
Previously, there was an incorrect if statement that checked only for any horizontal movement (delta != 0). As a result, it failed to accurately distinguish between swipe gestures and taps.

**Description of Change**
The swipe gesture `if` statement has been corrected. The movement check has been updated to verify whether the user's gesture exceeds the default threshold scaled by the device’s density, ensuring accurate differentiation between swipe gestures and taps.

Issues Fixed

Fixes https://github.com/syncfusion/maui-toolkit/issues/304