### PR TITLE
1000399: Android - Support to close Popup using back button

### DIFF
--- a/maui/src/Core/WindowOverlay/WindowOverlayContainer/Handler/OverlayContainerHandler.Android.cs
+++ b/maui/src/Core/WindowOverlay/WindowOverlayContainer/Handler/OverlayContainerHandler.Android.cs
@@ -10,7 +10,11 @@ namespace Syncfusion.Maui.Toolkit.Internals
       
         protected override WindowOverlayStack CreatePlatformView()
         {
-            return new WindowOverlayStack(Context);
-        }
+			// Creates the platform WindowOverlayStack that hosts overlay elements.
+			// Assigns the cross platform VirtualView so platform events can be routed back.
+			var windowOverlayStack = new WindowOverlayStack(Context);
+			windowOverlayStack.OverlayContanier = VirtualView as WindowOverlayContainer;
+			return windowOverlayStack;
+		}
     }
 }

--- a/maui/src/Core/WindowOverlay/WindowOverlayContainer/PlatformView/WindowOverlayStack.Android.cs
+++ b/maui/src/Core/WindowOverlay/WindowOverlayContainer/PlatformView/WindowOverlayStack.Android.cs
@@ -1,6 +1,7 @@
 ﻿using Android.Content;
 using Android.Runtime;
 using Android.Util;
+using Android.Views;
 using Android.Widget;
 
 namespace Syncfusion.Maui.Toolkit.Internals
@@ -10,7 +11,10 @@ namespace Syncfusion.Maui.Toolkit.Internals
 		// To check whether the popup has Overlay Mode blur.
 		internal bool HasBlurMode { get; set; }
 
-        public WindowOverlayStack(Context context)
+		// Represents the cross platform overlay view used for event delegation.
+		internal WindowOverlayContainer? OverlayContanier { get; set; }
+
+		public WindowOverlayStack(Context context)
             : base(context)
         {
         }
@@ -33,7 +37,23 @@ namespace Syncfusion.Maui.Toolkit.Internals
         protected WindowOverlayStack(IntPtr javaReference, JniHandleOwnership transfer)
             : base(javaReference, transfer)
         {
-        }
-    }
+		}
+
+		/// <summary>
+		/// Handles key events dispatched to the current view.
+		/// </summary>
+		/// <param name="e">The key event for this action, or null.</param>
+		/// <returns>True if handled by the view hierarchy; otherwise, false.</returns>
+		public override bool DispatchKeyEvent(KeyEvent? e)
+		{
+			// Forwards the Back key press to the OverlayContanier for handling overlay actions.
+			if (e != null && e.KeyCode == Keycode.Back && OverlayContanier != null)
+			{
+				OverlayContanier.ProcessBackButtonPressed();
+			}
+
+			return base.DispatchKeyEvent(e);
+		}
+	}
 
 }

--- a/maui/src/Core/WindowOverlay/WindowOverlayContainer/WindowOverlayContainer.cs
+++ b/maui/src/Core/WindowOverlay/WindowOverlayContainer/WindowOverlayContainer.cs
@@ -7,5 +7,8 @@
             get { return false; }
         }
         internal virtual void ProcessTouchInteraction(float x, float y) { }
-    }
+
+		// Handles Back button interactions for overlays
+		internal virtual void ProcessBackButtonPressed() { }
+	}
 }

--- a/maui/src/Popup/SfPopupOverlayContainer.cs
+++ b/maui/src/Popup/SfPopupOverlayContainer.cs
@@ -67,6 +67,17 @@ namespace Syncfusion.Maui.Toolkit.Popup
 			Background = overlayColor;
 		}
 
+		/// <summary>
+		/// Attempts to close the popup; the Closing event may cancel the action.
+		/// </summary>
+		internal override void ProcessBackButtonPressed()
+		{
+			if (_popup.IsOpen)
+			{
+				_popup.IsOpen = false;
+			}
+		}
+
 		#endregion
 
 		#region Private Methods


### PR DESCRIPTION
**Feature Description**
Adds support for closing SfPopup on Android using the device Back button.
Integrates with the overlay pipeline to route Back‑key events to the popup.
Ensures consistent closing behavior across platforms.

**toolkit**: https://gitea.syncfusion.com/essential-studio/maui-toolkit/pulls/1453

**Purpose / Benefits:** 
Improves usability by aligning popup behavior with native Android expectations.
Reduces accidental app navigation when popups remain open.
Provides a predictable, user‑friendly closure mechanism.

**Use Cases**

User presses the device Back button while a popup is open.
Apps requiring modal interactions where users must quickly dismiss popups.
Scenarios where consistent navigation behavior is essential.

**Solution description**
Back‑key events are forwarded from WindowOverlayStack to ProcessBackButtonPressed().
If the popup is open, it sets IsOpen = false, respecting the Closing event.
Integrates seamlessly with existing overlay and popup lifecycle.

**Competitor Comparison**
Yes, most modern UI frameworks support dismissing dialogs/popups via Back button.

**Areas affected and ensured**

Touch/Back event routing in WindowOverlayStack.
Popup lifecycle logic in overlay container.
Ensured no regression in touch, blur mode, or overlay stacking behavior.

**Behavioral Changes**
Pressing Back closes the popup when it is open.
Closing event may cancel the action if needed.
Back navigation proceeds normally only after popups are dismissed.

**Output screenshots**

**Android : **
**Before**
<video src="attachments/19dd1f5e-1753-43cd-9800-fb4372c9094b" title="Android Emulator - pixel_7_-_api_36_5554 2026-01-12 14-49-06.mp4" controls></video>
**After**

 <video src="attachments/53fbeeaf-0bed-43e5-9bd6-9da696714179" title="Android Emulator - pixel_7_-_api_36_5554 2026-01-12 14-55-12.mp4" controls></video>



**Sample :**[PopupUGSample.zip](/attachments/54917f5a-c73b-44ac-aec7-8d1c08394fcd)
