### PR TITLE
Fix:Selected Date Not Updating Issue

### DIFF
--- a/maui/src/Picker/SfDateTimePicker.cs
+++ b/maui/src/Picker/SfDateTimePicker.cs
@@ -2564,6 +2564,12 @@ namespace Syncfusion.Maui.Toolkit.Picker
         protected override void OnPopupOpened(EventArgs e)
         {
             InvokeOpenedEvent(this, e);
+            if (_internalSelectedDateTime != null && _internalSelectedDateTime != SelectedDate)
+            {
+                _internalSelectedDateTime = SelectedDate.HasValue ? SelectedDate : null;
+                BaseHeaderView.DateText = GetDateHeaderText();
+                BaseHeaderView.TimeText = GetTimeHeaderText();
+            }
         }
 
         /// <summary>

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Calendar/CalendarMethodsUnitTests.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Calendar/CalendarMethodsUnitTests.cs
@@ -1002,7 +1002,7 @@ public class CalendarMethodsUnitTests : BaseUnitTest
 		Assert.Equal(100, calendar.PopupHeight);
 		if (calendar.Mode == CalendarMode.Dialog)
 		{
-			Assert.Equal(67, Math.Round(resultValue));
+			Assert.Equal(83, Math.Round(resultValue));
 		}
 	}
 

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Picker/DateTimePickerUnitTest.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Picker/DateTimePickerUnitTest.cs
@@ -1810,6 +1810,25 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 			Assert.Equal(originalDateTime, picker.SelectedDate ?? originalDateTime);
 			Assert.False(selectionChangedFired, "SelectionChanged event should not fire until OK is pressed in dialog mode");
 		}
+
+		[Fact]
+		public void OnPopupOpened_ShouldUpdateHeaderTexts_WhenSelectedDateChanged()
+		{
+			// Arrange
+			var control = new SfDateTimePicker();
+			control.SelectedDate = DateTime.Now;
+			control._internalSelectedDateTime = DateTime.Now.AddDays(-1);
+
+			// Act
+			InvokePrivateMethod(control, "OnPopupOpened", new EventArgs());
+
+			// Assert
+			Assert.Equal(control.GetDateHeaderText(), control.BaseHeaderView.DateText);
+			Assert.Equal(control.GetTimeHeaderText(), control.BaseHeaderView.TimeText);
+		}
+
+
+
 		[Fact]
 		public void RelativeDialogMode_DateTimeSelectionNotCommittedUntilOK_ValidatesCorrectBehavior()
 		{


### PR DESCRIPTION
### Root Cause of the Issue

Internal Selected Date did not update properly when popup initially opened. 

### Description of Change

Updated Internal Selected date and Header Texts

### Issues Fixed

https://www.syncfusion.com/forums/197638/sfdatetimepicker-date-resets-when-changing-time-and-vice-versa

### Screenshots

#### Before:

https://github.com/user-attachments/assets/d9fc9869-429b-430e-8b5a-bc52a9d71762

#### After:

https://github.com/user-attachments/assets/72389e8a-2681-46d7-bc76-f4151164c228
