### PR TITLE
Fix: SfTextInputLayout hint text was not shown after modal page is close and open again

### DIFF
--- a/maui/src/TextInputLayout/SfTextInputLayout.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.cs
@@ -1419,15 +1419,6 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 				ConfigureAccessibilityForAssistiveLabels();
 #endif
 			}
-			else
-			{
-				if (HintLabelStyle != null && HelperLabelStyle != null && ErrorLabelStyle != null)
-				{
-					HintLabelStyle = null;
-					ErrorLabelStyle = null;
-					HelperLabelStyle = null;
-				}
-			}
 		}
 
         #endregion

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Calendar/CalendarMethodsUnitTests.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Calendar/CalendarMethodsUnitTests.cs
@@ -1002,7 +1002,7 @@ public class CalendarMethodsUnitTests : BaseUnitTest
 		Assert.Equal(100, calendar.PopupHeight);
 		if (calendar.Mode == CalendarMode.Dialog)
 		{
-			Assert.Equal(83, Math.Round(resultValue));
+			Assert.Equal(67, Math.Round(resultValue));
 		}
 	}
 

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Calendar/CalendarMethodsUnitTests.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Calendar/CalendarMethodsUnitTests.cs
@@ -1002,7 +1002,7 @@ public class CalendarMethodsUnitTests : BaseUnitTest
 		Assert.Equal(100, calendar.PopupHeight);
 		if (calendar.Mode == CalendarMode.Dialog)
 		{
-			Assert.Equal(67, Math.Round(resultValue));
+			Assert.Equal(83, Math.Round(resultValue));
 		}
 	}
 


### PR DESCRIPTION

### Root Cause of the Issue

When a modal page is dismissed on iOS, OnHandlerChanged fires with Handler == null, which clears HintLabelStyle, HelperLabelStyle, and ErrorLabelStyle to null. When the modal reopens and the handler reconnects, these styles remain null. DrawHintText has a HintLabelStyle != null guard, so the hint text is never rendered.

### Description of Change

Removed the explicit null assignments for HintLabelStyle, HelperLabelStyle, and ErrorLabelStyle in OnHandlerChanged. These properties already handle nullification in their respective Unwired events. With this change, the styles persist correctly across modal open → close → reopen cycles, ensuring that hint text and related labels render as expected.

### Issues Fixed
Fixes https://github.com/syncfusion/maui-toolkit/issues/329

### Screenshots

#### Before:
https://github.com/user-attachments/assets/9c5d947b-b560-448e-b189-479c17e9bc86

#### After:
https://github.com/user-attachments/assets/12c2d644-0acc-48c1-bbea-a2b0aa178fe4
