### PR TITLE
Fix: SfNumericEntry substring issue in iOS and MacCatalyst with VoiceOver and AllowNull

### DIFF
--- a/maui/src/NumericEntry/SfNumericEntry.Methods.cs
+++ b/maui/src/NumericEntry/SfNumericEntry.Methods.cs
@@ -1904,7 +1904,7 @@ namespace Syncfusion.Maui.Toolkit.NumericEntry
 #elif ANDROID
 			return _previousText != null ? _previousText.Substring(caretPosition, _selectionLength) : string.Empty;
 #elif MACCATALYST || IOS
-			return _textBox != null && _previousText != null ? _previousText.Substring(caretPosition, _textBox.SelectionLength) : string.Empty;
+			return _textBox != null && _previousText != null && _textBox.SelectionLength + caretPosition <= _previousText.Length ? _previousText.Substring(caretPosition, _textBox.SelectionLength) : string.Empty;
 #else
 			return string.Empty;
 #endif


### PR DESCRIPTION
This PR introduces a check on the validity of a SubString range before returning, fixing an ArgumentOutOfRangeException  where these values do not correctly reflect the situation.

### Root Cause of the Issue

In VoiceOver the text gets automatically deselected shortly after activating. The corresponding SelectionLength is not updated correctly. When this value is then used for a substring a crash occurs, as it becomes out-of-bound.

### Description of Change

A check to ensure the substring value is within range. If not an empty string is returned, which is then handled by existing logic.

### Issues Fixed

Fixes #324