### PR TITLE
Fix: SfTimePicker resets minutes and seconds when hour changes with interval set

### DIFF
--- a/maui/src/Picker/SfTimePicker.cs
+++ b/maui/src/Picker/SfTimePicker.cs
@@ -1002,7 +1002,7 @@ namespace Syncfusion.Maui.Toolkit.Picker
             }
 
             int minute = 0;
-            if (_minuteColumn.ItemsSource != null && _minuteColumn.ItemsSource is ObservableCollection<string> minuteCollection && minuteCollection.Contains(previousSelectedTime.Value.Minutes.ToString()))
+            if (_minuteColumn.ItemsSource != null && _minuteColumn.ItemsSource is ObservableCollection<string> minuteCollection && minuteCollection.Select(m => int.Parse(m)).Contains(previousSelectedTime.Value.Minutes))
             {
                 minute = previousSelectedTime.Value.Minutes;
             }
@@ -1015,7 +1015,7 @@ namespace Syncfusion.Maui.Toolkit.Picker
             }
 
             int second = 0;
-            if (_secondColumn.ItemsSource != null && _secondColumn.ItemsSource is ObservableCollection<string> secondCollection && secondCollection.Contains(previousSelectedTime.Value.Seconds.ToString()))
+            if (_secondColumn.ItemsSource != null && _secondColumn.ItemsSource is ObservableCollection<string> secondCollection && secondCollection.Select(m => int.Parse(m)).Contains(previousSelectedTime.Value.Seconds))
             {
                 second = previousSelectedTime.Value.Seconds;
             }
@@ -1064,7 +1064,7 @@ namespace Syncfusion.Maui.Toolkit.Picker
             }
 
             int second = 0;
-            if (_secondColumn.ItemsSource != null && _secondColumn.ItemsSource is ObservableCollection<string> secondCollection && secondCollection.Contains(previousSelectedTime.Value.Seconds.ToString()))
+            if (_secondColumn.ItemsSource != null && _secondColumn.ItemsSource is ObservableCollection<string> secondCollection && secondCollection.Select(m => int.Parse(m)).Contains(previousSelectedTime.Value.Seconds))
             {
                 second = previousSelectedTime.Value.Seconds;
             }

--- a/maui/src/Picker/SfTimePicker.cs
+++ b/maui/src/Picker/SfTimePicker.cs
@@ -1002,7 +1002,7 @@ namespace Syncfusion.Maui.Toolkit.Picker
             }
 
             int minute = 0;
-            if (_minuteColumn.ItemsSource != null && _minuteColumn.ItemsSource is ObservableCollection<string> minuteCollection && minuteCollection.Count > previousSelectedTime.Value.Minutes)
+            if (_minuteColumn.ItemsSource != null && _minuteColumn.ItemsSource is ObservableCollection<string> minuteCollection && minuteCollection.Contains(previousSelectedTime.Value.Minutes.ToString()))
             {
                 minute = previousSelectedTime.Value.Minutes;
             }
@@ -1015,7 +1015,7 @@ namespace Syncfusion.Maui.Toolkit.Picker
             }
 
             int second = 0;
-            if (_secondColumn.ItemsSource != null && _secondColumn.ItemsSource is ObservableCollection<string> secondCollection && secondCollection.Count > previousSelectedTime.Value.Seconds)
+            if (_secondColumn.ItemsSource != null && _secondColumn.ItemsSource is ObservableCollection<string> secondCollection && secondCollection.Contains(previousSelectedTime.Value.Seconds.ToString()))
             {
                 second = previousSelectedTime.Value.Seconds;
             }
@@ -1064,7 +1064,7 @@ namespace Syncfusion.Maui.Toolkit.Picker
             }
 
             int second = 0;
-            if (_secondColumn.ItemsSource != null && _secondColumn.ItemsSource is ObservableCollection<string> secondCollection && secondCollection.Count > previousSelectedTime.Value.Seconds)
+            if (_secondColumn.ItemsSource != null && _secondColumn.ItemsSource is ObservableCollection<string> secondCollection && secondCollection.Contains(previousSelectedTime.Value.Seconds.ToString()))
             {
                 second = previousSelectedTime.Value.Seconds;
             }

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Calendar/CalendarMethodsUnitTests.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Calendar/CalendarMethodsUnitTests.cs
@@ -1002,7 +1002,7 @@ public class CalendarMethodsUnitTests : BaseUnitTest
 		Assert.Equal(100, calendar.PopupHeight);
 		if (calendar.Mode == CalendarMode.Dialog)
 		{
-			Assert.Equal(83, Math.Round(resultValue));
+			Assert.Equal(100, Math.Round(resultValue));
 		}
 	}
 

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Picker/TimePickerUnitTest.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Picker/TimePickerUnitTest.cs
@@ -2317,7 +2317,7 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
             Assert.Equal("15", seconds[1]);
             Assert.Equal("30", seconds[2]);
             Assert.Equal("45", seconds[3]);
-            Assert.Equal(0, result.SelectedIndex);
+            Assert.Equal(2, result.SelectedIndex);
         }
 
         [Fact]
@@ -2347,7 +2347,7 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
             Assert.Equal(9, seconds.Count);
 #pragma warning restore CS8602 // Dereference of a possibly null reference.
             Assert.Equal("28", seconds[4]);
-            Assert.Equal(0, result.SelectedIndex);
+            Assert.Equal(4, result.SelectedIndex);
         }
 
         [Fact]
@@ -2366,7 +2366,7 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 #pragma warning restore CS8602 // Dereference of a possibly null reference.
             Assert.Equal("00", seconds[0]);
             Assert.Equal("30", seconds[1]);
-            Assert.Equal(0, result.SelectedIndex);
+            Assert.Equal(1, result.SelectedIndex);
         }
 
         [Fact]

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Picker/TimePickerUnitTest.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Picker/TimePickerUnitTest.cs
@@ -3070,5 +3070,60 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 		}
 
 		#endregion
+
+		#region Bug Fix Tests - Hour Change with Interval Preservation
+
+		[Fact]
+		public void GenerateSecondColumn_CustomInterval15Seconds_CorrectlySelectsMatchingValue()
+		{
+			var timePicker = new SfTimePicker();
+			timePicker.SecondInterval = 15;
+			timePicker.SelectedTime = new TimeSpan(10, 30, 30);
+			var result = InvokePrivateMethod(timePicker, "GenerateSecondColumn") as PickerColumn;
+			Assert.NotNull(result);
+			var seconds = result.ItemsSource as ObservableCollection<string>;
+			Assert.Equal("00", seconds?[0]);
+			Assert.Equal("15", seconds?[1]);
+			Assert.Equal("30", seconds?[2]);
+			Assert.Equal("45", seconds?[3]);
+			Assert.Equal(2, result.SelectedIndex);
+		}
+
+		[Fact]
+		public void GenerateSecondColumn_Interval7Seconds_CorrectlySelectsMatchingValue()
+		{
+			var timePicker = new SfTimePicker();
+			timePicker.SecondInterval = 7;
+			timePicker.SelectedTime = new TimeSpan(10, 30, 28);
+
+			var result = InvokePrivateMethod(timePicker, "GenerateSecondColumn") as PickerColumn;
+
+			Assert.NotNull(result);
+			var seconds = result.ItemsSource as ObservableCollection<string>;
+			// 28 should be in the collection at some index
+			var containsValue = seconds?.Any(s => s == "28");
+			Assert.True(containsValue, "Collection should contain '28'");
+			// The selected index should point to 28
+			Assert.Equal(4, result.SelectedIndex);
+		}
+
+		[Fact]
+		public void GenerateSecondColumn_Interval30Seconds_CorrectlySelectsMatchingValue()
+		{
+			var timePicker = new SfTimePicker();
+			timePicker.SecondInterval = 30;
+			timePicker.SelectedTime = new TimeSpan(10, 30, 30);
+
+			var result = InvokePrivateMethod(timePicker, "GenerateSecondColumn") as PickerColumn;
+
+			Assert.NotNull(result);
+			var seconds = result.ItemsSource as ObservableCollection<string>;
+			Assert.Equal("00", seconds?[0]);
+			Assert.Equal("30", seconds?[1]);
+			// The selected index should be 1 because 30 is at index 1
+			Assert.Equal(1, result.SelectedIndex);
+		}
+
+		#endregion
 	}
 }

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Picker/TimePickerUnitTest.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Picker/TimePickerUnitTest.cs
@@ -3095,15 +3095,11 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 			var timePicker = new SfTimePicker();
 			timePicker.SecondInterval = 7;
 			timePicker.SelectedTime = new TimeSpan(10, 30, 28);
-
 			var result = InvokePrivateMethod(timePicker, "GenerateSecondColumn") as PickerColumn;
-
 			Assert.NotNull(result);
 			var seconds = result.ItemsSource as ObservableCollection<string>;
-			// 28 should be in the collection at some index
 			var containsValue = seconds?.Any(s => s == "28");
 			Assert.True(containsValue, "Collection should contain '28'");
-			// The selected index should point to 28
 			Assert.Equal(4, result.SelectedIndex);
 		}
 
@@ -3113,14 +3109,11 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 			var timePicker = new SfTimePicker();
 			timePicker.SecondInterval = 30;
 			timePicker.SelectedTime = new TimeSpan(10, 30, 30);
-
 			var result = InvokePrivateMethod(timePicker, "GenerateSecondColumn") as PickerColumn;
-
 			Assert.NotNull(result);
 			var seconds = result.ItemsSource as ObservableCollection<string>;
 			Assert.Equal("00", seconds?[0]);
 			Assert.Equal("30", seconds?[1]);
-			// The selected index should be 1 because 30 is at index 1
 			Assert.Equal(1, result.SelectedIndex);
 		}
 
@@ -3148,15 +3141,12 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 			timePicker.MinuteInterval = 20;
 			timePicker.SelectedTime = new TimeSpan(10, 40, 30);
 			var selectedDate = Convert.ToDateTime(timePicker.SelectedTime.ToString());
-
 			var result = InvokePrivateMethod(timePicker, "GenerateMinuteColumn", timePicker.SelectedTime, selectedDate) as PickerColumn;
-
 			Assert.NotNull(result);
 			var minutes = result.ItemsSource as ObservableCollection<string>;
 			Assert.Equal("00", minutes?[0]);
 			Assert.Equal("20", minutes?[1]);
 			Assert.Equal("40", minutes?[2]);
-			// The selected index should be 2 because 40 is at index 2
 			Assert.Equal(2, result.SelectedIndex);
 		}
 

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Picker/TimePickerUnitTest.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Picker/TimePickerUnitTest.cs
@@ -3124,6 +3124,42 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 			Assert.Equal(1, result.SelectedIndex);
 		}
 
+		[Fact]
+		public void GenerateMinuteColumn_CustomInterval15Minutes_CorrectlySelectsMatchingValue()
+		{
+			var timePicker = new SfTimePicker();
+			timePicker.MinuteInterval = 15;
+			timePicker.SelectedTime = new TimeSpan(10, 30, 45);
+			var selectedDate = Convert.ToDateTime(timePicker.SelectedTime.ToString());
+			var result = InvokePrivateMethod(timePicker, "GenerateMinuteColumn", timePicker.SelectedTime, selectedDate) as PickerColumn;
+			Assert.NotNull(result);
+			var minutes = result.ItemsSource as ObservableCollection<string>;
+			Assert.Equal("00", minutes?[0]);
+			Assert.Equal("15", minutes?[1]);
+			Assert.Equal("30", minutes?[2]);
+			Assert.Equal("45", minutes?[3]);
+			Assert.Equal(2, result.SelectedIndex);
+		}
+
+		[Fact]
+		public void GenerateMinuteColumn_Interval20Minutes_CorrectlySelectsMatchingValue()
+		{
+			var timePicker = new SfTimePicker();
+			timePicker.MinuteInterval = 20;
+			timePicker.SelectedTime = new TimeSpan(10, 40, 30);
+			var selectedDate = Convert.ToDateTime(timePicker.SelectedTime.ToString());
+
+			var result = InvokePrivateMethod(timePicker, "GenerateMinuteColumn", timePicker.SelectedTime, selectedDate) as PickerColumn;
+
+			Assert.NotNull(result);
+			var minutes = result.ItemsSource as ObservableCollection<string>;
+			Assert.Equal("00", minutes?[0]);
+			Assert.Equal("20", minutes?[1]);
+			Assert.Equal("40", minutes?[2]);
+			// The selected index should be 2 because 40 is at index 2
+			Assert.Equal(2, result.SelectedIndex);
+		}
+
 		#endregion
 	}
 }


### PR DESCRIPTION
### Root Cause of the Issue

A condition checks where "collection of total number of items greater than the actual value", gets failed leading to incorrect minutes and seconds value.

### Description of Change

Updated Condition to compare using int instead of string

### Issues Fixed

https://www.syncfusion.com/forums/197638/sfdatetimepicker-date-resets-when-changing-time-and-vice-versa

### Output
 #### Before: 

https://github.com/user-attachments/assets/5f530260-cd76-4cd5-80d6-ce3fbf9b1e99

#### After: 

https://github.com/user-attachments/assets/c520038d-7261-4771-801f-d987ee9b1efa

### Screenshots

#### Before:

<img width="475" height="996" alt="image" src="https://github.com/user-attachments/assets/03a18c18-4529-4be6-9d28-63a4a60c6e52" />

<img width="1528" height="616" alt="image" src="https://github.com/user-attachments/assets/e8abd042-5481-4aa4-a2b3-0362fb90e9be" />

#### After:

<img width="478" height="1036" alt="Screenshot 2026-05-08 104059" src="https://github.com/user-attachments/assets/efcbe04f-a953-45ba-b58b-8f1d1ee4ad20" />

<img width="1619" height="615" alt="image" src="https://github.com/user-attachments/assets/53d853ad-3df3-405d-9eba-8001c0a7f5c3" />