### PR TITLE
Feature(1002889): NET Native embedding support for SfPopup Android IOS 

### DIFF
--- a/maui/src/Core/WindowOverlay/WindowOverlay.Android.cs
+++ b/maui/src/Core/WindowOverlay/WindowOverlay.Android.cs
@@ -55,14 +55,22 @@ namespace Syncfusion.Maui.Toolkit.Internals
 		/// <returns></returns>
 		internal virtual WindowOverlayStack CreateStack(Context context)
 		{
+			// Prefer creating the overlay stack via the MAUI handler so gesture/touch plumbing is wired.
 			WindowOverlayStack? windowOverlayStack = null;
+
 			if (_window is not null && _window.Handler is not null)
 			{
 				IMauiContext? mauiContext = _window.Handler.MauiContext;
 				if (mauiContext is not null)
 				{
-					windowOverlayStack = (WindowOverlayStack?)_overlayStackView?.ToPlatform(mauiContext);
+					windowOverlayStack = _overlayStackView != null ? (WindowOverlayStack?)_overlayStackView.ToPlatform(mauiContext) : null;
 				}
+			}
+
+			// Fallback to HostMauiContext for native embedding (no MAUI Window).
+			if (windowOverlayStack == null && WindowOverlayHelper.HostMauiContext != null)
+			{
+				windowOverlayStack = _overlayStackView != null ? (WindowOverlayStack?)_overlayStackView.ToPlatform(WindowOverlayHelper.HostMauiContext) : null;
 			}
 
 			return windowOverlayStack is not null ? windowOverlayStack : new WindowOverlayStack(context);
@@ -246,6 +254,33 @@ namespace Syncfusion.Maui.Toolkit.Internals
 								_overlayContent = childView.ToPlatform(windowHandler.MauiContext);
 							}
 
+							return true;
+						}
+					}
+				}
+			}
+			else
+			{
+				// Native embedding path: no MAUI Window, use host Activity and IMauiContext set by the embedding app.
+				var activity = WindowOverlayHelper.HostActivity;
+				_density = WindowOverlayHelper._density;
+				_rootView = WindowOverlayHelper._platformRootView;
+				if (_rootView != null && activity != null)
+				{
+					_overlayStack = CreateStack(activity);
+					_windowManager = activity.WindowManager;
+					if (_overlayStack != null)
+					{
+						_overlayStack.LayoutChange += OnOverlayStackLayoutChange;
+						if (this._windowManagerLayoutParams == null)
+						{
+							this.GetWindowManagerLayoutParams();
+						}
+
+						// Prefer an existing native view if handler already realized.
+						if (WindowOverlayHelper.HostMauiContext != null)
+						{
+							_overlayContent = childView.ToPlatform(WindowOverlayHelper.HostMauiContext);
 							return true;
 						}
 					}

--- a/maui/src/Core/WindowOverlay/WindowOverlay.iOS.cs
+++ b/maui/src/Core/WindowOverlay/WindowOverlay.iOS.cs
@@ -27,37 +27,20 @@ namespace Syncfusion.Maui.Toolkit.Internals
 		internal virtual WindowOverlayStack CreateStack()
 		{
 			WindowOverlayStack? windowOverlayStack = null;
-			if (_window is not null && _window.Handler is not null)
+			IMauiContext? context = _window?.Handler?.MauiContext ?? SfWindowOverlay.MauiContext;
+			if (context is not null)
 			{
-				IMauiContext? context = _window?.Handler?.MauiContext ?? SfWindowOverlay.MauiContext;
-				if (context is not null)
-				{
-					windowOverlayStack = (WindowOverlayStack?)_overlayStackView?.ToPlatform(context);
+				windowOverlayStack = (WindowOverlayStack?)_overlayStackView?.ToPlatform(context);
 
-					if (windowOverlayStack is not null && _overlayStackView is not null)
-					{
-						windowOverlayStack._canHandleTouch = !_overlayStackView.canHandleTouch;
-						// If the handler didn't run ConnectHandler for some embedding scenarios,
-						// ensure the platform view is connected to the virtual view so touches are routed.
-						windowOverlayStack.Connect(_overlayStackView);
-					}
+				if (windowOverlayStack is not null && _overlayStackView is not null)
+				{
+					windowOverlayStack._canHandleTouch = !_overlayStackView.canHandleTouch;
 				}
 			}
 
-			if (windowOverlayStack is not null)
-			{
-				return windowOverlayStack;
-			}
-
-			var _windowOverlayStack = new WindowOverlayStack();
-			if (_overlayStackView is not null)
-			{
-				_windowOverlayStack._canHandleTouch = !_overlayStackView.canHandleTouch;
-				_windowOverlayStack.Connect(_overlayStackView);
-			}
-
-			return _windowOverlayStack;
+            return windowOverlayStack is not null ? windowOverlayStack : new WindowOverlayStack();
 		}
+
 
 		/// <summary>
 		/// Adds or updates the child layout absolutely to the overlay stack.
@@ -175,8 +158,6 @@ namespace Syncfusion.Maui.Toolkit.Internals
 		{
 			if (_overlayStack is not null)
 			{
-				// Ensure any manual Connect() is cleaned up when removing the platform view.
-				_overlayStack.DisConnect();
 				_overlayStack.ClearSubviews();
 				_overlayStack.RemoveFromSuperview();
 			}
@@ -344,11 +325,6 @@ namespace Syncfusion.Maui.Toolkit.Internals
 		/// </summary>
 		internal void Dispose()
 		{
-			// Ensure disconnect and removal happen deterministically.
-			if (this._overlayStack is not null)
-			{
-				_overlayStack.DisConnect();
-			}
 			RemoveOverlay();
 			_window = null;
 			_overlayContent = null;
@@ -363,8 +339,6 @@ namespace Syncfusion.Maui.Toolkit.Internals
 		{
 			if (_overlayStack is not null)
 			{
-				// Ensure disconnect before removing the platform view from the hierarchy.
-				_overlayStack.DisConnect();
 				ClearChildren();
 				_overlayStack.RemoveFromSuperview();
 				_overlayStack = null;

--- a/maui/src/Core/WindowOverlay/WindowOverlay.iOS.cs
+++ b/maui/src/Core/WindowOverlay/WindowOverlay.iOS.cs
@@ -10,6 +10,10 @@ namespace Syncfusion.Maui.Toolkit.Internals
 	{
 		#region Fields
 
+		internal static IMauiContext? MauiContext { get; set; }
+
+		internal static UIWindow? Window { get; set; }
+
 		UIView? _rootView;
 		WindowOverlayStack? _overlayStack;
 		UIView? _overlayContent;
@@ -25,7 +29,7 @@ namespace Syncfusion.Maui.Toolkit.Internals
 			WindowOverlayStack? windowOverlayStack = null;
 			if (_window is not null && _window.Handler is not null)
 			{
-				IMauiContext? context = _window.Handler.MauiContext;
+				IMauiContext? context = _window?.Handler?.MauiContext ?? SfWindowOverlay.MauiContext;
 				if (context is not null)
 				{
 					windowOverlayStack = (WindowOverlayStack?)_overlayStackView?.ToPlatform(context);
@@ -33,11 +37,26 @@ namespace Syncfusion.Maui.Toolkit.Internals
 					if (windowOverlayStack is not null && _overlayStackView is not null)
 					{
 						windowOverlayStack._canHandleTouch = !_overlayStackView.canHandleTouch;
+						// If the handler didn't run ConnectHandler for some embedding scenarios,
+						// ensure the platform view is connected to the virtual view so touches are routed.
+						windowOverlayStack.Connect(_overlayStackView);
 					}
 				}
 			}
 
-			return windowOverlayStack is not null ? windowOverlayStack : new WindowOverlayStack();
+			if (windowOverlayStack is not null)
+			{
+				return windowOverlayStack;
+			}
+
+			var _windowOverlayStack = new WindowOverlayStack();
+			if (_overlayStackView is not null)
+			{
+				_windowOverlayStack._canHandleTouch = !_overlayStackView.canHandleTouch;
+				_windowOverlayStack.Connect(_overlayStackView);
+			}
+
+			return _windowOverlayStack;
 		}
 
 		/// <summary>
@@ -156,6 +175,8 @@ namespace Syncfusion.Maui.Toolkit.Internals
 		{
 			if (_overlayStack is not null)
 			{
+				// Ensure any manual Connect() is cleaned up when removing the platform view.
+				_overlayStack.DisConnect();
 				_overlayStack.ClearSubviews();
 				_overlayStack.RemoveFromSuperview();
 			}
@@ -171,6 +192,22 @@ namespace Syncfusion.Maui.Toolkit.Internals
 		internal bool AddToOverlay(MauiView childView)
 		{
 			_window = WindowOverlayHelper._window;
+
+			// Native embedding path when MAUI Window is not yet available.
+			if ((_window == null || _window.Content == null) && SfWindowOverlay.MauiContext != null && SfWindowOverlay.Window != null)
+			{
+				_rootView = SfWindowOverlay.Window;
+				_overlayStack ??= CreateStack();
+				if (_overlayStack != null)
+				{
+					_overlayStack.AutoresizingMask = UIViewAutoresizing.All;
+					_overlayContent = childView.ToPlatform(SfWindowOverlay.MauiContext);
+					return true;
+				}
+
+				return false;
+			}
+
 			if (_window is not null && _window.Content is not null)
 			{
 				_rootView = WindowOverlayHelper._platformRootView;
@@ -260,7 +297,9 @@ namespace Syncfusion.Maui.Toolkit.Internals
 				keyWindow = UIApplication.SharedApplication.KeyWindow!;
 			}
 
-			if (_rootView != keyWindow)
+			// Only switch to the keyWindow if we actually found one. For native embedding scenarios.
+			// the initial rootView may be provided via SfWindowOverlay.Window and keyWindow can be null.
+			if (keyWindow != null && _rootView != keyWindow)
 			{
 				_rootView = keyWindow;
 			}
@@ -305,6 +344,11 @@ namespace Syncfusion.Maui.Toolkit.Internals
 		/// </summary>
 		internal void Dispose()
 		{
+			// Ensure disconnect and removal happen deterministically.
+			if (this._overlayStack is not null)
+			{
+				_overlayStack.DisConnect();
+			}
 			RemoveOverlay();
 			_window = null;
 			_overlayContent = null;
@@ -319,6 +363,8 @@ namespace Syncfusion.Maui.Toolkit.Internals
 		{
 			if (_overlayStack is not null)
 			{
+				// Ensure disconnect before removing the platform view from the hierarchy.
+				_overlayStack.DisConnect();
 				ClearChildren();
 				_overlayStack.RemoveFromSuperview();
 				_overlayStack = null;

--- a/maui/src/Core/WindowOverlay/WindowOverlayContainer/PlatformView/WindowOverlayStack.iOS.cs
+++ b/maui/src/Core/WindowOverlay/WindowOverlayContainer/PlatformView/WindowOverlayStack.iOS.cs
@@ -8,6 +8,7 @@ namespace Syncfusion.Maui.Toolkit.Internals
     {
         internal bool _canHandleTouch = false;
         WindowOverlayContainer? _virtualView;
+        bool _isConnected = false;
 
         public override UIView HitTest(CGPoint point, UIEvent? uievent)
         {
@@ -20,12 +21,24 @@ namespace Syncfusion.Maui.Toolkit.Internals
 
         internal void Connect(WindowOverlayContainer mauiView)
         {
+            if (_isConnected && ReferenceEquals(_virtualView, mauiView))
+            {
+                return;
+            }
+
             _virtualView = mauiView;
+            _isConnected = true;
         }
 
         internal void DisConnect()
         {
+            if (!_isConnected)
+            {
+                return;
+            }
+
             _virtualView = null;
+            _isConnected = false;
         }
 
         public override void TouchesBegan(NSSet touches, UIEvent? evt)

--- a/maui/src/Core/WindowOverlay/WindowOverlayContainer/PlatformView/WindowOverlayStack.iOS.cs
+++ b/maui/src/Core/WindowOverlay/WindowOverlayContainer/PlatformView/WindowOverlayStack.iOS.cs
@@ -8,7 +8,6 @@ namespace Syncfusion.Maui.Toolkit.Internals
     {
         internal bool _canHandleTouch = false;
         WindowOverlayContainer? _virtualView;
-        bool _isConnected = false;
 
         public override UIView HitTest(CGPoint point, UIEvent? uievent)
         {
@@ -21,24 +20,12 @@ namespace Syncfusion.Maui.Toolkit.Internals
 
         internal void Connect(WindowOverlayContainer mauiView)
         {
-            if (_isConnected && ReferenceEquals(_virtualView, mauiView))
-            {
-                return;
-            }
-
             _virtualView = mauiView;
-            _isConnected = true;
         }
 
         internal void DisConnect()
         {
-            if (!_isConnected)
-            {
-                return;
-            }
-
             _virtualView = null;
-            _isConnected = false;
         }
 
         public override void TouchesBegan(NSSet touches, UIEvent? evt)

--- a/maui/src/Core/WindowOverlay/WindowOverlayHelper.cs
+++ b/maui/src/Core/WindowOverlay/WindowOverlayHelper.cs
@@ -39,7 +39,11 @@ namespace Syncfusion.Maui.Toolkit.Internals
 		/// <summary>
 		/// Gets the device density.
 		/// </summary>
-		internal static float _density => _window is not null ? _window.RequestDisplayDensity() : 1f;
+#if ANDROID
+		internal static float _density => _window != null ? _window.RequestDisplayDensity() : (HostActivity != null ? HostActivity.Resources?.DisplayMetrics?.Density ?? 1f : 1f);
+#else
+		internal static float _density => _window != null ? _window.RequestDisplayDensity() : 1f;
+#endif
 
 		/// <summary>
 		/// Gets the root view of the device.
@@ -47,6 +51,16 @@ namespace Syncfusion.Maui.Toolkit.Internals
 		internal static PlatformRootView? _platformRootView => GetPlatformRootView();
 
 #if ANDROID
+
+		/// <summary>
+		/// Optional host Activity for embedding scenarios where MAUI Window is not available.
+		/// </summary>
+		internal static Activity? HostActivity;
+
+		/// <summary>
+		/// Optional host IMauiContext for embedding scenarios when converting views without a Window.
+		/// </summary>
+		internal static IMauiContext? HostMauiContext;
 
 		/// <summary>
 		/// Gets the decor view frame.
@@ -155,6 +169,20 @@ namespace Syncfusion.Maui.Toolkit.Internals
                 }
 #endif
 			}
+#if ANDROID
+			// Fallback for native embedding: derive root from host Activity when MAUI Window is unavailable.
+			else if (rootView == null && HostActivity != null)
+			{
+				try
+				{
+					rootView = HostActivity.FindViewById(Android.Resource.Id.Content) as ViewGroup;
+				}
+				catch
+				{
+					rootView = null;
+				}
+			}
+#endif
 
 			return rootView;
 		}
@@ -176,6 +204,17 @@ namespace Syncfusion.Maui.Toolkit.Internals
 				}
 
 				return platformActivity.Window;
+			}
+
+			// Fallback for native embedding: use HostActivity if available.
+			else if (HostActivity != null)
+			{
+				if (HostActivity.WindowManager != null && HostActivity.WindowManager.DefaultDisplay != null)
+				{
+					return HostActivity.Window;
+				}
+
+				return null;
 			}
 
 			return null;

--- a/maui/src/Popup/Helpers/PopupExtension/PopupExtension.Android.cs
+++ b/maui/src/Popup/Helpers/PopupExtension/PopupExtension.Android.cs
@@ -474,7 +474,17 @@ namespace Syncfusion.Maui.Toolkit.Popup
 			{
 				int[] relativeViewOrigin = new int[2];
 				nativeRelativeView.GetLocationInWindow(relativeViewOrigin);
-				relativeViewOrigin[1] = PopupExtension.GetLocationInApp(relativeView);
+
+				if (WindowOverlayHelper._decorViewContent is PlatformView decorView && nativeRelativeView.RootView == decorView)
+				{
+					relativeViewOrigin[1] = PopupExtension.GetLocationInApp(relativeView);
+				}
+				else
+				{
+					// 1008572: Popup relative position is incorrect when opening a popup within another popup on Android.
+					relativeViewOrigin[1] = (int)(relativeViewOrigin[1] / WindowOverlayHelper._density);
+				}
+
 				return new Rect(relativeViewOrigin[0] / WindowOverlayHelper._density, relativeViewOrigin[1], nativeRelativeView.Width / WindowOverlayHelper._density, nativeRelativeView.Height / WindowOverlayHelper._density);
 			}
 			else

--- a/maui/src/Popup/Helpers/PopupExtension/PopupExtension.iOS.cs
+++ b/maui/src/Popup/Helpers/PopupExtension/PopupExtension.iOS.cs
@@ -22,7 +22,21 @@ namespace Syncfusion.Maui.Toolkit.Popup
 		internal static int GetScreenWidth()
 		{
 			var rootView = WindowOverlayHelper._platformRootView;
-			return rootView is not null ? (int)rootView.Frame.Width : 0;
+			if (rootView is not null)
+			{
+				return (int)rootView.Frame.Width;
+			}
+
+			// Native embedding: Get width from the underlying UIWindow.
+			var window = (WindowOverlayHelper._window?.ToPlatform() as UIWindow) ?? GetActiveWindow();
+			if (window is not null)
+			{
+				return (int)window.Bounds.Width;
+			}
+
+			// use UIScreen.MainScreen width (iOS-specific).
+			var screen = UIScreen.MainScreen;
+			return screen is not null ? (int)screen.Bounds.Width : 0;
 		}
 
 		/// <summary>
@@ -32,7 +46,21 @@ namespace Syncfusion.Maui.Toolkit.Popup
 		internal static int GetScreenHeight()
 		{
 			var rootView = WindowOverlayHelper._platformRootView;
-			return rootView is not null ? (int)rootView.Frame.Height : 0;
+			if (rootView is not null)
+			{
+				return (int)rootView.Frame.Height;
+			}
+
+			// Native embedding: Get height from the underlying UIWindow.
+			var window = (WindowOverlayHelper._window?.ToPlatform() as UIWindow) ?? GetActiveWindow();
+			if (window is not null)
+			{
+				return (int)window.Bounds.Height;
+			}
+
+			// use UIScreen.MainScreen height (iOS-specific).
+			var screen = UIScreen.MainScreen;
+			return screen is not null ? (int)screen.Bounds.Height : 0;
 		}
 
 		/// <summary>
@@ -81,6 +109,43 @@ namespace Syncfusion.Maui.Toolkit.Popup
 		/// <returns>Returns the status bar height.</returns>
 		internal static double GetStatusBarHeight()
 		{
+			// Try to obtain the active platform window (supports native embedding scenarios).
+			var platformWindow = (WindowOverlayHelper._window?.ToPlatform() as UIWindow) ?? GetActiveWindow();
+
+			if (platformWindow is not null && WindowOverlayHelper._window is null)
+			{
+				try
+				{
+					// For iOS 13+ with scenes, use the StatusBarManager when available.
+					if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
+					{
+						var scene = platformWindow.WindowScene;
+						if (scene is not null)
+						{
+#if IOS || MACCATALYST
+							var statusBarManager = scene.StatusBarManager;
+							if (statusBarManager is not null)
+							{
+								return statusBarManager.StatusBarFrame.Height;
+							}
+#endif
+						}
+					}
+
+					// Fallback to the top safe area inset if present.
+					if (platformWindow.SafeAreaInsets.Top > 0)
+					{
+						return platformWindow.SafeAreaInsets.Top;
+					}
+				}
+				catch
+				{
+					// ignore and return 0 as final fallback.
+				}
+
+				return 0;
+			}
+
 			return 0;
 		}
 
@@ -90,7 +155,7 @@ namespace Syncfusion.Maui.Toolkit.Popup
 		/// <returns>Returns action bar height.</returns>
 		internal static int GetActionBarHeight()
 		{
-			var platformWindow = WindowOverlayHelper._window?.ToPlatform() as UIWindow;
+			var platformWindow = (WindowOverlayHelper._window?.ToPlatform() as UIWindow) ?? GetActiveWindow();
 
 			// To calculate the navigationBar height with the page Y position.
 			if (GetMainPage() is Page page && page.Handler is not null && page.Handler.PlatformView is UIView pageNativeView && platformWindow is not null)
@@ -120,53 +185,138 @@ namespace Syncfusion.Maui.Toolkit.Popup
 		internal static int GetSafeAreaHeight(string position)
 		{
 			// The popup is drawn within the safe area when shown relative to a view. Safe area calculations apply only to the iOS X simulator on iOS.
-#pragma warning disable CS0618 // Suppressing CS0618 warning because Page.GetUseSafeArea is marked obsolete in .NET 10.
-			if (Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.Page.GetUseSafeArea(GetMainPage()))
-#pragma warning restore CS0618
+			if (WindowOverlayHelper._window != null)
 			{
-				var platformWindow = WindowOverlayHelper._window?.ToPlatform() as UIWindow;
-				UIInterfaceOrientation? statusBarOrientation = null;
-				var scene = platformWindow?.WindowScene;
-				if (scene != null)
-				{
-#if IOS || MACCATALYST
-					if (OperatingSystem.IsIOSVersionAtLeast(16, 0) || OperatingSystem.IsMacCatalystVersionAtLeast(16, 0))
-					{
-						statusBarOrientation = scene.EffectiveGeometry.InterfaceOrientation;
-					}
-					else
-					{
-#pragma warning disable CA1422 // InterfaceOrientation is obsoleted on newer SDKs; guarded by OS version checks
-						statusBarOrientation = scene.InterfaceOrientation;
-#pragma warning restore CA1422
-					}
+				// PopUp is drawn in safe area also crap when it is shown based on relative to view point.
+				// Fix Details: SafeArea is calculated only for iOS X simulator in iOS.
+#if NET10_0
+				if (GetSafeAreaEdges())
+#else
+				if (Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.Page.GetUseSafeArea(GetMainPage()))
 #endif
-				}
+				{
+					var platformWindow = WindowOverlayHelper._window?.ToPlatform() as UIWindow;
+					UIInterfaceOrientation? statusBarOrientation = null;
+					var scene = platformWindow?.WindowScene;
+					if (scene != null)
+					{
+#if IOS || MACCATALYST
+						if (OperatingSystem.IsIOSVersionAtLeast(16, 0) || OperatingSystem.IsMacCatalystVersionAtLeast(16, 0))
+						{
+							statusBarOrientation = scene.EffectiveGeometry.InterfaceOrientation;
+						}
+						else
+						{
+#pragma warning disable CA1422 // InterfaceOrientation is obsoleted on newer SDKs; guarded by OS version checks
+							statusBarOrientation = scene.InterfaceOrientation;
+#pragma warning restore CA1422
+						}
+#endif
+					}
 
-				// Since StatusBarHeight is already calculated, the top safe area does not need to be computed.
-				if (position == "Top")
-				{
-					return platformWindow is not null ? (int)platformWindow.SafeAreaInsets.Top : 0;
+					// Since StatusBarHeight is already calculated, the top safe area does not need to be computed.
+					if (position == "Top")
+					{
+						return platformWindow is not null ? (int)platformWindow.SafeAreaInsets.Top : 0;
+					}
+					else if ((statusBarOrientation == UIInterfaceOrientation.Portrait || statusBarOrientation == UIInterfaceOrientation.PortraitUpsideDown || statusBarOrientation == UIInterfaceOrientation.LandscapeLeft || statusBarOrientation == UIInterfaceOrientation.LandscapeRight || UIDevice.CurrentDevice.Orientation == UIDeviceOrientation.FaceUp || UIDevice.CurrentDevice.Orientation == UIDeviceOrientation.FaceDown) && position == "Bottom")
+					{
+						return platformWindow?.SafeAreaInsets.Bottom > 0 ? (int)platformWindow.SafeAreaInsets.Bottom : 0;
+					}
+					else if ((UIDevice.CurrentDevice.Orientation == UIDeviceOrientation.FaceUp || UIDevice.CurrentDevice.Orientation == UIDeviceOrientation.FaceDown) && position == "Right" && GetScreenWidth() > GetScreenHeight())
+					{
+						return platformWindow?.SafeAreaInsets.Right > 0 ? (int)platformWindow.SafeAreaInsets.Right : 0;
+					}
+					else if ((UIDevice.CurrentDevice.Orientation == UIDeviceOrientation.FaceUp || UIDevice.CurrentDevice.Orientation == UIDeviceOrientation.FaceDown) && (position == "Left") && GetScreenWidth() > GetScreenHeight())
+					{
+						return platformWindow?.SafeAreaInsets.Left > 0 ? (int)platformWindow.SafeAreaInsets.Left : 0;
+					}
+					else if (statusBarOrientation == UIInterfaceOrientation.LandscapeLeft)
+					{
+						return platformWindow?.SafeAreaInsets.Left > 0 ? (int)platformWindow.SafeAreaInsets.Left : 0;
+					}
+					else if (statusBarOrientation == UIInterfaceOrientation.LandscapeRight)
+					{
+						return platformWindow?.SafeAreaInsets.Right > 0 ? (int)platformWindow.SafeAreaInsets.Right : 0;
+					}
 				}
-				else if ((statusBarOrientation == UIInterfaceOrientation.Portrait || statusBarOrientation == UIInterfaceOrientation.PortraitUpsideDown || statusBarOrientation == UIInterfaceOrientation.LandscapeLeft || statusBarOrientation == UIInterfaceOrientation.LandscapeRight || UIDevice.CurrentDevice.Orientation == UIDeviceOrientation.FaceUp || UIDevice.CurrentDevice.Orientation == UIDeviceOrientation.FaceDown) && position == "Bottom")
+			}
+			else
+			{
+				if (GetSafeAreaEdges())
 				{
-					return platformWindow?.SafeAreaInsets.Bottom > 0 ? (int)platformWindow.SafeAreaInsets.Bottom : 0;
-				}
-				else if ((UIDevice.CurrentDevice.Orientation == UIDeviceOrientation.FaceUp || UIDevice.CurrentDevice.Orientation == UIDeviceOrientation.FaceDown) && position == "Right" && GetScreenWidth() > GetScreenHeight())
-				{
-					return platformWindow?.SafeAreaInsets.Right > 0 ? (int)platformWindow.SafeAreaInsets.Right : 0;
-				}
-				else if ((UIDevice.CurrentDevice.Orientation == UIDeviceOrientation.FaceUp || UIDevice.CurrentDevice.Orientation == UIDeviceOrientation.FaceDown) && (position == "Left") && GetScreenWidth() > GetScreenHeight())
-				{
-					return platformWindow?.SafeAreaInsets.Left > 0 ? (int)platformWindow.SafeAreaInsets.Left : 0;
-				}
-				else if (statusBarOrientation == UIInterfaceOrientation.LandscapeLeft)
-				{
-					return platformWindow?.SafeAreaInsets.Left > 0 ? (int)platformWindow.SafeAreaInsets.Left : 0;
-				}
-				else if (statusBarOrientation == UIInterfaceOrientation.LandscapeRight)
-				{
-					return platformWindow?.SafeAreaInsets.Right > 0 ? (int)platformWindow.SafeAreaInsets.Right : 0;
+					// Prefer the platform root view's safe area in native embedding, then the platform window.
+					var rootView = WindowOverlayHelper._platformRootView as UIView
+					   ?? WindowOverlayHelper._window?.ToPlatform() as UIView
+					   ?? PopupExtension.GetActiveWindow() as UIView;
+
+					var platformWindow = (WindowOverlayHelper._window?.ToPlatform() as UIWindow) ?? GetActiveWindow();
+
+					UIInterfaceOrientation? statusBarOrientation = null;
+					var scene = platformWindow?.WindowScene;
+					if (scene != null)
+					{
+#if IOS || MACCATALYST
+						if (OperatingSystem.IsIOSVersionAtLeast(16, 0) || OperatingSystem.IsMacCatalystVersionAtLeast(16, 0))
+						{
+							statusBarOrientation = scene.EffectiveGeometry.InterfaceOrientation;
+						}
+						else
+						{
+#pragma warning disable CA1422 // InterfaceOrientation is obsoleted on newer SDKs; guarded by OS version checks.
+							statusBarOrientation = scene.InterfaceOrientation;
+#pragma warning restore CA1422
+						}
+#endif
+					}
+
+					// Top: prefer rootView inset, then window inset, then status bar height fallback.
+					if (position == "Top")
+					{
+						if (rootView != null && rootView.SafeAreaInsets.Top > 0)
+						{
+							return (int)rootView.SafeAreaInsets.Top;
+						}
+
+						if (platformWindow != null && platformWindow.SafeAreaInsets.Top > 0)
+						{
+							return (int)platformWindow.SafeAreaInsets.Top;
+						}
+
+						return (int)GetStatusBarHeight();
+					}
+
+					// Bottom: prefer rootView inset then window inset.
+					if (position == "Bottom")
+					{
+						if (rootView != null && rootView.SafeAreaInsets.Bottom > 0)
+						{
+							return (int)rootView.SafeAreaInsets.Bottom;
+						}
+
+						return platformWindow?.SafeAreaInsets.Bottom > 0 ? (int)platformWindow.SafeAreaInsets.Bottom : 0;
+					}
+
+					// Left/Right: consider device orientation and prefer rootView then window.
+					if (position == "Left")
+					{
+						if (rootView != null && rootView.SafeAreaInsets.Left > 0)
+						{
+							return (int)rootView.SafeAreaInsets.Left;
+						}
+
+						return platformWindow?.SafeAreaInsets.Left > 0 ? (int)platformWindow.SafeAreaInsets.Left : 0;
+					}
+
+					if (position == "Right")
+					{
+						if (rootView != null && rootView.SafeAreaInsets.Right > 0)
+						{
+							return (int)rootView.SafeAreaInsets.Right;
+						}
+
+						return platformWindow?.SafeAreaInsets.Right > 0 ? (int)platformWindow.SafeAreaInsets.Right : 0;
+					}
 				}
 			}
 
@@ -250,14 +400,99 @@ namespace Syncfusion.Maui.Toolkit.Popup
 			if (relativeView.Handler != null && relativeView.Handler.PlatformView != null && relativeView.Handler.PlatformView is PlatformView nativeRelativeView
 				&& WindowOverlayHelper._platformRootView != null)
 			{
-				PlatformView rootView = WindowOverlayHelper._platformRootView;
-				nfloat[] location = new nfloat[2];
-				CGPoint relativeViewOrigin = nativeRelativeView.ConvertPointToView(new CGPoint(0, 0), rootView);
+				PlatformView? rootView = WindowOverlayHelper._platformRootView as UIView
+					   ?? WindowOverlayHelper._window?.ToPlatform() as UIView
+					   ?? PopupExtension.GetActiveWindow() as UIView;
+				CGPoint relativeViewOrigin = rootView != null
+					? nativeRelativeView.ConvertPointToView(new CGPoint(0, 0), rootView)
+					: nativeRelativeView.ConvertPointToView(new CGPoint(0, 0), null);
 				return new Rect(relativeViewOrigin.X, relativeViewOrigin.Y, nativeRelativeView.Frame.Width, nativeRelativeView.Frame.Height);
 			}
 			else
 			{
 				return Rect.Zero;
+			}
+		}
+
+		/// <summary>
+		/// This method will returns the SafeAreEdges of the Content page.
+		/// </summary>
+		/// <returns>Returns the whether the SafeAreaEdges is set for the page.</returns>
+		internal static bool GetSafeAreaEdges()
+		{
+			if (WindowOverlayHelper._window != null)
+			{
+#if NET10_0
+				if (GetMainPage() != null && GetMainPage() is ContentPage page && page.SafeAreaEdges != SafeAreaEdges.None)
+				{
+					return true;
+				}
+#endif
+			}
+			else
+			{
+				var rootView = WindowOverlayHelper._platformRootView;
+				if (rootView != null)
+				{
+					if (rootView.SafeAreaInsets.Top > 0 || rootView.SafeAreaInsets.Bottom > 0 || rootView.SafeAreaInsets.Left > 0 || rootView.SafeAreaInsets.Right > 0)
+					{
+						return true;
+					}
+				}
+
+				var platformWindow = (WindowOverlayHelper._window?.ToPlatform() as UIWindow) ?? GetActiveWindow();
+				if (platformWindow != null)
+				{
+					if (platformWindow.SafeAreaInsets.Top > 0 || platformWindow.SafeAreaInsets.Bottom > 0 || platformWindow.SafeAreaInsets.Left > 0 || platformWindow.SafeAreaInsets.Right > 0)
+					{
+						return true;
+					}
+				}
+			}
+
+			return false;
+		}
+
+		/// <summary>
+		/// Attempts to get the active UIWindow for the application, including iOS 13+ multi-scene setups.
+		/// </summary>
+		/// <returns>The active UIWindow if available; otherwise null.</returns>
+		internal static UIWindow? GetActiveWindow()
+		{
+			try
+			{
+				if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
+				{
+					var app = UIApplication.SharedApplication;
+					foreach (var scene in app.ConnectedScenes)
+					{
+						UIWindow? keyWindow = null;
+						if (scene is UIWindowScene windowScene)
+						{
+							keyWindow = windowScene.Windows?.FirstOrDefault(w => w.IsKeyWindow);
+							if (keyWindow is not null)
+							{
+								return keyWindow;
+							}
+
+							keyWindow = windowScene.Windows?.FirstOrDefault();
+							if (keyWindow is not null)
+							{
+								return keyWindow;
+							}
+						}
+					}
+				}
+
+#pragma warning disable CA1422 // Fallback for pre-iOS 13 or if scenes are not available.
+				return UIApplication.SharedApplication?.KeyWindow
+					?? UIApplication.SharedApplication?.Windows?.FirstOrDefault(w => w.IsKeyWindow)
+					?? UIApplication.SharedApplication?.Windows?.FirstOrDefault();
+#pragma warning disable
+			}
+			catch
+			{
+				return null;
 			}
 		}
 

--- a/maui/src/Popup/PopupFooter.cs
+++ b/maui/src/Popup/PopupFooter.cs
@@ -73,6 +73,14 @@ namespace Syncfusion.Maui.Toolkit.Popup
 		/// </summary>
 		public PopupFooter()
 		{
+#if IOS
+			// 916944 : When setting SafeArea for a page, the value does not update within the popup content due to a framework issue.
+#if NET10_0
+			this.IgnoreSafeArea = !PopupExtension.GetSafeAreaEdges();
+#else
+			this.IgnoreSafeArea = !Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.Page.GetUseSafeArea(PopupExtension.GetMainPage());
+#endif
+#endif
 		}
 
 		/// <summary>

--- a/maui/src/Popup/PopupHeader.cs
+++ b/maui/src/Popup/PopupHeader.cs
@@ -57,6 +57,14 @@ namespace Syncfusion.Maui.Toolkit.Popup
 		/// </summary>
 		public PopupHeader()
 		{
+#if IOS
+			// 895700 : When Page SafeArea is false, close icon overlaps header.Because HeaderView arranging with safeArea.
+#if NET10_0
+			this.IgnoreSafeArea = !PopupExtension.GetSafeAreaEdges();
+#else
+			this.IgnoreSafeArea = !Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.Page.GetUseSafeArea(PopupExtension.GetMainPage());
+#endif
+#endif
 			Initialize();
 		}
 

--- a/maui/src/Popup/PopupMessageView.cs
+++ b/maui/src/Popup/PopupMessageView.cs
@@ -50,6 +50,14 @@ namespace Syncfusion.Maui.Toolkit.Popup
 		/// </summary>
 		public PopupMessageView()
 		{
+#if IOS
+			// 916944 : When setting SafeArea for a page, the value does not update within the popup content due to a framework issue.
+#if NET10_0
+			this.IgnoreSafeArea = !PopupExtension.GetSafeAreaEdges();
+#else
+			this.IgnoreSafeArea = !Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.Page.GetUseSafeArea(PopupExtension.GetMainPage());
+#endif
+#endif
 		}
 
 		/// <summary>

--- a/maui/src/Popup/SfPopup/SfPopup.Android.cs
+++ b/maui/src/Popup/SfPopup/SfPopup.Android.cs
@@ -45,6 +45,26 @@ namespace Syncfusion.Maui.Toolkit.Popup
 
 		#endregion
 
+		#region Constructor
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="SfPopup"/> class for native Android embedding scenarios where a MAUI Window is not available.
+		/// </summary>
+		/// <param name="activity">The host <see cref="Android.App.Activity"/> that provides the necessary Android context when embedding the popup in a native application.</param>
+		/// <param name="mauiContext">The host <see cref="IMauiContext"/> that provides access to MAUI-specific services when embedding the SfPopup in a native Android scenario.</param>
+		public SfPopup(Activity activity, IMauiContext mauiContext)
+			: this()
+		{
+			// Register the host Activity and optional IMauiContext for native embedding.
+			Syncfusion.Maui.Toolkit.Internals.WindowOverlayHelper.HostActivity = activity;
+			if (mauiContext != null)
+			{
+				Syncfusion.Maui.Toolkit.Internals.WindowOverlayHelper.HostMauiContext = mauiContext;
+			}
+		}
+
+		#endregion
+
 		#region Internal Methods
 
 		/// <summary>
@@ -63,6 +83,21 @@ namespace Syncfusion.Maui.Toolkit.Popup
 						nativeView.ViewTreeObserver.GlobalLayout += OnViewTreeObserverGlobalLayout;
 					}
 				}
+			}
+			else if (WindowOverlayHelper._window == null)
+			{
+				// Native Embedding: MainPage is null. Use the platform root or decor view to wire GlobalLayout.
+				// WindowOverlayHelper is initialized via SfPopup(Activity, IMauiContext) constructor in embedding scenarios.
+				var nativeView = WindowOverlayHelper._platformRootView as PlatformView
+								  ?? WindowOverlayHelper._decorViewContent as PlatformView;
+
+				if (nativeView != null && nativeView.ViewTreeObserver != null)
+				{
+					nativeView.ViewTreeObserver.GlobalLayout += this.OnViewTreeObserverGlobalLayout;
+				}
+
+				// In native embedding, handle orientation and display changes by listening to <see cref="Microsoft.Maui.Devices.DeviceDisplay.MainDisplayInfoChanged"/>.
+				DeviceDisplay.MainDisplayInfoChanged += this.OnViewTreeObserverGlobalLayout;
 			}
 		}
 
@@ -83,6 +118,19 @@ namespace Syncfusion.Maui.Toolkit.Popup
 					}
 				}
 			}
+			else if (WindowOverlayHelper._window == null)
+			{
+				var nativeView = WindowOverlayHelper._platformRootView as PlatformView
+								  ?? WindowOverlayHelper._decorViewContent as PlatformView;
+
+				if (nativeView != null && nativeView.ViewTreeObserver != null)
+				{
+					nativeView.ViewTreeObserver.GlobalLayout -= this.OnViewTreeObserverGlobalLayout;
+				}
+
+				// Unwire orientation/display change handler.
+				DeviceDisplay.MainDisplayInfoChanged -= this.OnViewTreeObserverGlobalLayout;
+			}
 		}
 
 		/// <summary>
@@ -90,7 +138,7 @@ namespace Syncfusion.Maui.Toolkit.Popup
 		/// </summary>
 		internal void PopupPositionBasedOnKeyboard()
 		{
-			if (_popupView is not null)
+			if (this._popupView is not null)
 			{
 				_popupView.HandlerChanged += OnPopupViewHandlerChanged;
 			}

--- a/maui/src/Popup/SfPopup/SfPopup.iOS.cs
+++ b/maui/src/Popup/SfPopup/SfPopup.iOS.cs
@@ -3,6 +3,7 @@ using CoreGraphics;
 using Foundation;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Platform;
+using Syncfusion.Maui.Toolkit.Internals;
 using UIKit;
 
 namespace Syncfusion.Maui.Toolkit.Popup
@@ -45,6 +46,24 @@ namespace Syncfusion.Maui.Toolkit.Popup
 
 		#endregion
 
+		#region Constructor
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="SfPopup"/> class for native iOS embedding scenarios where a MAUI Window is not available.
+		/// </summary>
+		/// <param name="window">The external <see cref="UIWindow"/> that hosts the popup when no MAUI Window exists.</param>
+		/// <param name="mauiContext">The <see cref="IMauiContext"/> providing access to MAUI services in native iOS embedding.</param>
+		public SfPopup(UIWindow window, IMauiContext mauiContext)
+			: this()
+		{
+			Syncfusion.Maui.Toolkit.Internals.SfWindowOverlay.MauiContext = mauiContext;
+			Syncfusion.Maui.Toolkit.Internals.SfWindowOverlay.Window = window;
+
+			// Try initializing overlay again with external host available.
+			this.InitializeOverlay();
+		}
+		#endregion
+
 		#region Internal Methods
 
 		/// <summary>
@@ -67,7 +86,10 @@ namespace Syncfusion.Maui.Toolkit.Popup
 				}
 				else
 				{
-					windowPage.SizeChanged += OnMainPageSizeChanged;
+					windowPage.SizeChanged += this.OnMainPageSizeChanged;
+
+					// In native embedding, handle orientation and display changes by listening to <see cref="Microsoft.Maui.Devices.DeviceDisplay.MainDisplayInfoChanged"/>.
+					DeviceDisplay.MainDisplayInfoChanged += this.OnMainPageSizeChanged;
 				}
 			}
 
@@ -94,7 +116,10 @@ namespace Syncfusion.Maui.Toolkit.Popup
 				}
 				else
 				{
-					windowPage.SizeChanged -= OnMainPageSizeChanged;
+					windowPage.SizeChanged -= this.OnMainPageSizeChanged;
+
+					// Unwire orientation/display change handler.
+					DeviceDisplay.MainDisplayInfoChanged -= this.OnMainPageSizeChanged;
 				}
 			}
 
@@ -206,7 +231,7 @@ namespace Syncfusion.Maui.Toolkit.Popup
 				SyncPopupDimensionFields();
 
 				// While show the popup using ShowRelativeToView, Popup is not positioned properly when resize the window in MAC and Split the screen in iOS.
-				if (_relativeView is not null)
+				if (_relativeView is not null || this.RelativeView is not null)
 				{
 					Dispatcher.Dispatch(ResetPopupWidthHeight);
 				}


### PR DESCRIPTION
 **Feature Description**
.NET Native embedding support for SfPopup Android & iOS.

**AI Usage:**
Code Studio used in this PR:  **Yes**

Primary use
Generate new code
Bug fix

Outcome:  **Neutral**

**Require one label on every PR: (single-select, easy to report):** **cs:used**

**PR**
Core: https://gitea.syncfusion.com/essential-studio/maui-core/pulls/3587

**Task**
Task 1002889: .NET Native embedding support for SfPopup Android

**Purpose / Benefits:**
Enable SfPopup in native Android Activities that host MAUI views (no MAUI Window).

**Solution description**
Overlay host (Android): AddToOverlay enhanced to support Native embedding: Native embedding path( Window is null): use WindowOverlayHelper.HostActivity and HostMauiContext to create 

 
**Native embedding path: no MAUI Window, use host Activity and IMauiContext set by the embedding app.**

```
Else // Window is
null
{
   
    var activity =
WindowOverlayHelper.HostActivity;
    density = WindowOverlayHelper.density;
    rootView =
WindowOverlayHelper.PlatformRootView;
    if (rootView != null && activity !=
null)
    {
        overlayStack = CreateStack(activity);
        windowManager = activity.WindowManager;
        if (overlayStack != null)
        {
            overlayStack.LayoutChange +=
OnOverlayStackLayoutChange;
            if (this.WindowManagerLayoutParams
== null)
            {
               
this.GetWindowManagerLayoutParams();
            }
 
            // Prefer an existing native view
if handler already realized.
            if
(WindowOverlayHelper.HostMauiContext != null)
            {
                overlayContent =
childView.ToPlatform(WindowOverlayHelper.HostMauiContext);
                return true;
            }
        }
    }
}
```

WindowOverlayStack and resolve WindowManager. Multi-window: PositionOverlayContent refreshes WindowManager from the active PlatformWindow
before Add/Update.


In WindowOverlayHelper.cs: Returned RootView based on the CurrentActivityparamer passed via SfPopup instance.

Created Internal Static methods to get the Current activity and MauiContexts 
```
**Sets the host Activity for embedding scenarios where there is no MAUI Window.**
internal static void **SetHostActivity**(Activity activity)
{
    HostActivity = activity;
}
```

**Sets the host IMauiContext for embedding scenarios where there is no MAUI Window.**
internal static void **SetHostMauiContext**(IMauiContext context)
{
    HostMauiContext = context;
}
 
```
And implemented code by referring previous code in AddToOverlay.
 
In WindowOverlay.Android - CreateStack method - Returned overlay based on the MauiContext passed via Popup instance.

 
**Fallback to HostMauiContext for native embedding (no MAUI Window).**

if (windowOverlayStack == null && WindowOverlayHelper.HostMauiContext
!= null)
{
    windowOverlayStack = overlayStackView !=
null ?
(WindowOverlayStack?)overlayStackView.ToPlatform(WindowOverlayHelper.HostMauiContext)
: null;
}


```

In SfPopup.Android.cs

In WirePlatformSpecificEvents method, the mainpage is null, the OnViewTreeObserverGlobalLayout event wiring is missed, I have added wired by using HostActivity & HostMauiContext

```
internal void WirePlatformSpecificEvents()
{
 .........
 else // mainPage is null
 {
     // Native Embedding: MainPage is null. Use the platform root or decor view to wire GlobalLayout
     // WindowOverlayHelper is initialized via SfPopup(Activity, IMauiContext) constructor in embedding scenarios
     var nativeView = WindowOverlayHelper.PlatformRootView as PlatformView
                       ?? WindowOverlayHelper.decorViewContent as PlatformView;

     if (nativeView != null && nativeView.ViewTreeObserver != null)
     {
         nativeView.ViewTreeObserver.GlobalLayout += this.OnViewTreeObserverGlobalLayout;
     }
 }
 }

```

Sample usage: new SfPopup(this, mauiContext) // Created SfPopup instance to get the CurrentActivity and MauiContext.

**Areas affected and ensured**
Popup lifecycle: open/close, animations, event wiring.
Keyboard Resize, Orientation, WindowManager Flags, PopupSize, LoadTime & Runtime cases.

**Behavioral Changes**
No

**Does it have any known**
issues?
No known issues.

**Test Cases**
[NativeEmbedding_Android_Testcases.docx](/attachments/e77e5f5b-0d1f-4801-a01c-054160b46a20)

MR CheckList
- [x] Have you ensured in iOS, Android, WinUI, and macOS(if supported)? **Android, iOS**
- [ ] If there is any API change, did you get approval from PLO through JIRA Tasks? NA
- [ ] Is there any existing behavior change of other features due to this code change? NA
- [ ] Have you enabled the necessary settings in your project, if you have created any new project? No
- [ ] Have you suppressed any warning or binding errors? No
- [x] Did you add a sample in the testbed for your feature? **Yes**
- [ ] Did you record this case in the unit test or UI test? **No**
- [ ] Whether the new APIs and its comments are added as per standard? NA
- [ ] Does it contain code that reflects any internal framework API? No
- [ ] Have you included license for your control(If it is stable)? NA
- [ ] Did you ensure the cases mentioned in this link? NA
- [ ] Did you test the memory leak with your feature? No
- [ ] Did you ensure the performance? Check this link to know more about performance optimization and how to automate? NA
- [ ] Does it need localization? If so, did you ensure the cases mentioned in this link? NA
- [ ] Does it follow the design system guidelines and support light and dark themes? No
- [ ] Did you ensure the new control / feature met accessibility requirements? NA
- [x] Did you ensure RTL? **Yes**
- [ ] If you added any interaction related code, have you used touch and gesture APIs from core project? NA
- [ ] If you use a third-party package, did you get approval to use it? If not, please get approval before merging. NA