### PR TITLE
Bug(1005033): Resolved the SfBottomSheet not working with screen reader and updated the accessibility support

### DIFF
--- a/maui/src/BottomSheet/SfBottomSheet.cs
+++ b/maui/src/BottomSheet/SfBottomSheet.cs
@@ -176,6 +176,16 @@ namespace Syncfusion.Maui.Toolkit.BottomSheet
 		/// </summary>
 		const double DefaultFullExpandedRatio = 1;
 
+		/// <summary>
+		/// Stores original accessibility Description and Hint for each VisualElement.
+		/// Key: VisualElement, Value: Tuple of (Description, Hint)
+		/// </summary>
+		Dictionary<VisualElement, (string? Description, string? Hint)> _originalAccessibilityProperties = new Dictionary<VisualElement, (string?, string?)>();
+		
+		#if ANDROID
+		Dictionary<VisualElement, string?> _androidContentDescriptions  = new Dictionary<VisualElement, string?>();
+		#endif
+
 		#endregion
 
 		#region Bindable Properties
@@ -1262,6 +1272,11 @@ namespace Syncfusion.Maui.Toolkit.BottomSheet
 			SetupBottomSheetForShow();
 			AnimateBottomSheet(GetTargetPosition());
 			IsOpen = true;
+
+#if !MACCATALYST && IOS
+			UpdateAccessibilityiOS();
+#endif
+
 		}
 
 		/// <summary>
@@ -1281,6 +1296,12 @@ namespace Syncfusion.Maui.Toolkit.BottomSheet
 		    {
 		        _bottomSheet.IsVisible = false;
 				RemoveOverlayFromView();
+				
+				// ACCESSIBILITY FIX: Restore accessibility after close
+#if !MACCATALYST && IOS
+				UpdateAccessibilityiOS();
+#endif
+
 			});
 
 			if (_isSheetOpen)
@@ -1301,6 +1322,14 @@ namespace Syncfusion.Maui.Toolkit.BottomSheet
 		{
 			return (int)Math.Max(0, AnimationDuration);
 		}
+		
+#if !MACCATALYST && IOS
+		/// <summary>
+		/// Platform-specific: iOS/macOS accessibility updates.
+		/// Implementation is in SfBottomSheet.iOS.cs
+		/// </summary>
+		partial void UpdateAccessibilityiOS();
+#endif
 
 		#endregion
 
@@ -1375,6 +1404,15 @@ namespace Syncfusion.Maui.Toolkit.BottomSheet
 		{
 			Children.Clear();
 			_isOverlayAdded = false; // Reset overlay state
+			if (IsOpen && IsModal)
+			{
+				UpdateContentAccessibility(Content, true);
+			}
+			else
+			{
+				UpdateContentAccessibility(Content, false);
+			}
+
 			UpdateAllChild();
 		}
 
@@ -1385,6 +1423,125 @@ namespace Syncfusion.Maui.Toolkit.BottomSheet
 		{
 			AddChild(Content);
 			AddChild(_bottomSheet);
+		}
+
+		/// <summary>
+		/// Recursively updates the SemanticProperties.ExcludeFromAccessibility for a given VisualElement and its descendants.
+		/// </summary>
+		/// <param name="element">The VisualElement to update.</param>
+		/// <param name="exclude">True to exclude from accessibility, false to include.</param>
+		void UpdateContentAccessibility(VisualElement element, bool exclude)
+		{
+			if (element == null)
+			{
+				return;
+			}
+
+			// If it's a layout, iterate through its children
+			if (element is Layout layout)
+			{
+				foreach (var child in layout.Children)
+				{
+					if (child is VisualElement visualChild)
+					{
+						UpdateSingleElement(visualChild,exclude);
+					}
+				}
+			}
+			// If it's a ContentView, recurse into its Content
+			else if (element is IContentView contentView && contentView.Content is Layout contentLayout)
+			{
+				foreach (var child in contentLayout.Children)
+				{
+					if (child is VisualElement visualChild)
+					{
+						UpdateSingleElement(visualChild,exclude);
+					}
+				}
+			}
+			else
+			{
+				// For any other VisualElement, update it directly
+				UpdateSingleElement(element,exclude);
+			}
+		}
+
+		/// <summary>
+        /// Updates the accessibility properties (Description and Hint) of a single VisualElement based on exclusion state.
+        /// </summary>
+        /// <param name="visualChild">The VisualElement to update.</param>
+        /// <param name="exclude">True to exclude from accessibility, false to include.</param>
+		void UpdateSingleElement(VisualElement visualChild,bool exclude)
+		{
+			if (!_originalAccessibilityProperties.ContainsKey(visualChild))
+			{
+				// Store original values only if not already stored
+				_originalAccessibilityProperties[visualChild] = (
+					SemanticProperties.GetDescription(visualChild),
+					SemanticProperties.GetHint(visualChild)
+				);
+			}
+
+			if (exclude)
+			{
+				// Exclude: Set to null to blank for screen readers
+				SemanticProperties.SetDescription(visualChild, null);
+				SemanticProperties.SetHint(visualChild, null);
+			}
+			else
+			{
+				// Reset: Restore original values
+				var (originalDesc, originalHint) = _originalAccessibilityProperties[visualChild];
+				SemanticProperties.SetDescription(visualChild, originalDesc);
+				SemanticProperties.SetHint(visualChild, originalHint);
+			}
+
+			// Update accessibility flags
+			AutomationProperties.SetIsInAccessibleTree(visualChild, !exclude);
+			AutomationProperties.SetExcludedWithChildren(visualChild, exclude);
+
+			#if IOS || MACCATALYST
+			if (visualChild.Handler?.PlatformView is UIKit.UIView nativeView)
+			{
+				nativeView.UserInteractionEnabled = !exclude;
+			}
+
+			#endif
+			#if WINDOWS
+			if (visualChild.Handler?.PlatformView is Microsoft.UI.Xaml.UIElement ui)
+			{
+				ui.IsTabStop = !exclude;  // Removes/adds from tab order
+			}
+			#endif
+
+			#if ANDROID
+			var nativeContent = Content?.Handler?.PlatformView as Android.Views.View;
+			if (nativeContent is Android.Views.View rootView)
+			{
+					if (Content != null && !_androidContentDescriptions.ContainsKey(Content))
+					{
+						_androidContentDescriptions[Content] =
+							rootView.ContentDescription;
+					}
+
+				if (exclude) // when you want to hide content
+				{
+					rootView.ImportantForAccessibility =
+						Android.Views.ImportantForAccessibility.NoHideDescendants;
+
+					rootView.ContentDescription = null; // extra safety
+				}
+				else
+				{
+					rootView.ImportantForAccessibility =
+						Android.Views.ImportantForAccessibility.Auto;
+					if (Content != null && _androidContentDescriptions.TryGetValue(Content, out var originalDesc))
+					{
+						rootView.ContentDescription = originalDesc;
+					}
+				}
+			}
+			#endif
 		}
 
 		/// <summary>
@@ -1505,6 +1662,7 @@ namespace Syncfusion.Maui.Toolkit.BottomSheet
 					Children.Insert(Children.Count - 1, _overlayGrid); // Insert before bottom sheet
 				}
 				_isOverlayAdded = true;
+				UpdateContentAccessibility(Content, true);
 			}
 		}
 
@@ -1520,6 +1678,7 @@ namespace Syncfusion.Maui.Toolkit.BottomSheet
 					Children.Remove(_overlayGrid);
 				}
 				_isOverlayAdded = false;
+				UpdateContentAccessibility(Content, false);
 			}
 		}
 

--- a/maui/src/BottomSheet/SfBottomSheet.iOS.cs
+++ b/maui/src/BottomSheet/SfBottomSheet.iOS.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Maui.Controls;
 using Syncfusion.Maui.Toolkit.Platform;
-
+using UIKit;
 namespace Syncfusion.Maui.Toolkit.BottomSheet
 {
     public partial class SfBottomSheet
@@ -28,19 +28,156 @@ namespace Syncfusion.Maui.Toolkit.BottomSheet
             }
         }
 
-        void WireEvents()
-        {
-            if (Handler?.PlatformView is LayoutViewExt nativeView)
-            {
-                _layoutViewExt = nativeView;
-                _layoutViewExt.UserInteractionEnabled = false;
-            }
-        }
+		void WireEvents()
+		{
+			if (Handler?.PlatformView is LayoutViewExt nativeView)
+			{
+				_layoutViewExt = nativeView;
+				// Sheet container must receive interactions
+				_layoutViewExt.UserInteractionEnabled = false;
+				_layoutViewExt.IsAccessibilityElement = false;
+				_layoutViewExt.AccessibilityTraits = (UIAccessibilityTrait)UIAccessibilityTraits.None;
+			}
+		}
 
         void UnwireEvents()
         {
             _layoutViewExt = null;
         }
+
+#if !MACCATALYST && IOS
+		/// <summary>
+		/// Updates accessibility tree for iOS/macOS after layout stabilization.
+		/// 
+		/// CRITICAL: This method is called with a 50ms delay from Show() to ensure:
+		/// 1. UIView hierarchy is fully laid out
+		/// 2. Accessibility APIs recognize the new hierarchy before VoiceOver queries it
+		/// 3. First-time focus doesn't leak to background on macOS/iOS
+		/// 
+		/// When IsOpen is true:
+		///   - Sheet is marked as modal (AccessibilityViewIsModal = true)
+		///   - Background content is hidden (AccessibilityElementsHidden = true)
+		///   - Overlay is hidden from accessibility tree
+		///   - VoiceOver focus is trapped within sheet
+		///   - Accessibility tree is refreshed via UIAccessibility notification
+		/// 
+		/// When IsOpen is false:
+		///   - Sheet is unmarked as modal
+		///   - Background content is made accessible again
+		///   - Accessibility tree is refreshed to restore focus
+		/// </summary>
+		partial void UpdateAccessibilityiOS()
+		{
+			// Get native UIView references from MAUI handlers
+			var nativeContent = Content?.Handler?.PlatformView as UIView;
+			var nativeSheet = _bottomSheetContent?.Handler?.PlatformView as UIView;
+			var nativeOverlay = _overlayGrid?.Handler?.PlatformView as UIView;
+ 			bool isSingle = IsSingleContentElement(Content);
+
+			if (IsOpen && IsModal)
+			{
+
+				// === MODAL STATE: Trap focus within sheet ===
+
+				// 1. Mark bottom sheet content as modal region
+				// This instructs VoiceOver to limit focus/navigation to elements within this view
+				// CRITICAL: Must be set BEFORE posting the accessibility notification
+				if (nativeSheet != null)
+				{
+					nativeSheet.AccessibilityViewIsModal = true;
+					nativeSheet.IsAccessibilityElement = false;  // Container, not a standalone element					
+
+				}
+
+				// 2. Hide background content from VoiceOver
+				// This prevents VoiceOver from navigating to, focusing on, or reading background content
+				if (nativeContent != null)
+				{
+					if(isSingle)
+                    {
+                        nativeContent.AccessibilityElementsHidden = true;
+						nativeContent.IsAccessibilityElement = false;
+                    }
+					else
+					{
+						nativeContent.AccessibilityElementsHidden = false;
+						nativeContent.IsAccessibilityElement = true;
+					}
+				}
+
+				// 4. Notify VoiceOver to rebuild focus order and accessibility tree
+				// This is CRITICAL for first-time open - tells VoiceOver about the new modal state
+				// Use ScreenChanged to indicate major UI change (like modal appearing)
+				if (nativeSheet != null)
+				{
+					UIAccessibility.PostNotification(
+						UIAccessibilityPostNotification.ScreenChanged,
+						nativeSheet);
+				}
+
+				if(Content != null)
+				{
+					UpdateContentAccessibility(Content,true);
+				}
+			}
+			else
+			{
+
+				// === NON-MODAL STATE: Restore background accessibility ===
+				// 1. Unmark sheet as modal
+				if (nativeSheet != null)
+				{
+					nativeSheet.AccessibilityViewIsModal = false;
+				}
+
+				// 2. Restore background accessibility
+				if (nativeContent != null)
+				{
+					if(isSingle)
+                    {
+						nativeContent.AccessibilityElementsHidden = false;
+						nativeContent.IsAccessibilityElement = true;
+                    }
+					else
+					{
+						nativeContent.AccessibilityElementsHidden = true;
+						nativeContent.IsAccessibilityElement = false;
+					}
+				}
+
+				// 4. Notify VoiceOver to restore focus to background
+				if (nativeContent != null)
+				{
+					UIAccessibility.PostNotification(
+						UIAccessibilityPostNotification.ScreenChanged,
+						nativeContent);
+				}
+
+				if(Content != null)
+				{
+					UpdateContentAccessibility(Content,false);
+				}
+			}
+		}
+
+		bool IsSingleContentElement(View? content)
+		{
+			if (content == null)
+				return false;
+
+			if (content is Layout layout)
+				return layout.Children.Count == 1;
+
+			
+			if (content is IContentView contentView &&
+					contentView.Content is Layout innerLayout)
+				{
+					return innerLayout.Children.Count == 1;
+				}
+
+			return true;
+		}
+#endif
 
 		#endregion
 


### PR DESCRIPTION
**Bug Description**

When using the SfBottomSheet control :

- Screen reader focus does not move to the BottomSheet content when it opens.
- Users are unable to navigate to the BottomSheet or its elements.
- Accessibility focus incorrectly shifts to background/overlay content.
- Initial focus remains outside the BottomSheet.
- Focus leakage allows unintended navigation outside the sheet.

**Root Cause**

This issue occurs because:
- Background elements remain part of the accessibility tree.
- Modal behavior is not enforced.
- No explicit focus redirection is implemented when the BottomSheet opens.
- Some controls allow unintended accessibility traversal outside the BottomSheet.

**Solution description**

This PR primarily resolves the issue where screen reader focus does not move to the BottomSheet and users cannot navigate to it, by enforcing proper accessibility focus handling and modal isolation.

**Key Improvements:**

- Restricted accessibility focus strictly within the BottomSheet when open.
- Prevented focus movement to underlying overlay/background content.
- Ensured initial focus moves correctly to BottomSheet elements on iOS/macOS.
- Implemented recursive accessibility updates using:
    - AutomationProperties.SetIsInAccessibleTree
    - AutomationProperties.SetExcludedWithChildren
- Temporarily removed semantic properties (Description & Hint) for background elements and restored them on close.
- Introduced platform-specific fix for iOS/macOS:
    - Enabled modal accessibility using AccessibilityViewIsModal
    - Managed background visibility using AccessibilityElementsHidden
    - Triggered accessibility focus update via UIAccessibility.PostNotification(ScreenChanged)
- Disabled interaction for background elements to avoid accidental focus/navigation.
- Ensured accessibility state is restored when BottomSheet is closed.

**Areas affected and ensured**

- BottomSheet open/close lifecycle
- Accessibility focus behavior
- Screen reader navigation (VoiceOver)
- Modal interaction consistency

**Issue Fixed:**

https://github.com/syncfusion/maui-toolkit/issues/310

