### PR TITLE
Bug(1023872) - SfOtpInput Fails to AutoFill OTP from System OneTime Code Suggestion

### DIFF
--- a/maui/src/OtpInput/SfOtpInput.cs
+++ b/maui/src/OtpInput/SfOtpInput.cs
@@ -1586,7 +1586,18 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 
 						if (isValidText)
 						{
-							Value = new string(valueArray);
+
+#if IOS
+							if (index == Length - 1 && hasText)
+							{
+								Value = string.Concat(_otpEntries
+									.Where(e => !string.IsNullOrEmpty(e.Text))
+									.Select(e => e.Text));
+							}
+
+#else
+							Value = new string(valueArray); 
+#endif
 						}
 						_oldText = e.OldTextValue;
 						HandleFocus(index, hasText);
@@ -1977,6 +1988,12 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 #else
 				_otpEntries[_focusedIndex].Text = input.ToString();
 #endif
+
+#if IOS
+ 				bool hasText = !string.IsNullOrEmpty(_otpEntries[_focusedIndex].Text) && _otpEntries[_focusedIndex].Text is not "\0";
+                HandleFocus(_focusedIndex, hasText);
+#endif
+
 			}
         }
 


### PR DESCRIPTION
**Bug Description**

On iOS devices, when the OTP is autofilled using the system-provided “One-Time Code” suggestion, the OTP input control does not function as expected. The autofill behavior fails to correctly manage focus transitions and does not properly aggregate the complete OTP value across all input fields.
As a result:

- The OTP fields may appear partially filled.
- Focus does not move correctly between input fields during autofill.
- The final OTP value is not correctly captured.

**Root Cause**

- On iOS, when OTP is autofilled using the system “One‑Time Code” suggestion, the control was not properly updating focus and final value aggregation.
- The existing implementation only updated the current field (_focusedIndex) without:
- Moving focus to the next field correctly.
- Recomputing the full OTP value when all fields are populated.
- As a result, the OTP autofill appeared partially filled or did not trigger completion logic.

**Solution description**

To handle iOS autofill scenarios correctly, the following changes were introduced:

- Focus Handling After Text Update
- Added iOS-specific logic after updating the entry value:
- Final OTP Value Aggregation for Autofill
- Added logic to detect when all fields are filled and concatenate values:

**Issue Fixed:**

https://github.com/syncfusion/maui-toolkit/issues/343

