### PR TITLE
Enable background interaction and fix popup close on Android back button when overlay is disabled.

### DIFF
--- a/maui/src/Core/WindowOverlay/WindowOverlay.Android.cs
+++ b/maui/src/Core/WindowOverlay/WindowOverlay.Android.cs
@@ -278,7 +278,7 @@ namespace Syncfusion.Maui.Toolkit.Internals
 
 			if (_overlayStack is not null && _overlayStackView is not null)
 			{
-				if (_overlayStack is not null && _overlayStackView is not null)
+				if (_windowManager is not null && !_overlayStackView.canHandleTouch)
 				{
 					if (_windowManagerLayoutParams is null)
 					{

--- a/maui/src/Core/WindowOverlay/WindowOverlay.Android.cs
+++ b/maui/src/Core/WindowOverlay/WindowOverlay.Android.cs
@@ -190,9 +190,16 @@ namespace Syncfusion.Maui.Toolkit.Internals
 				_overlayStack.LayoutChange -= OnOverlayStackLayoutChange;
 
 				//Checking whether OverlayStack Parent is null or not.
-				if (_overlayStack.Parent is not null && _windowManager is not null)
+				if (_overlayStack.Parent is not null)
 				{
-					_windowManager.RemoveView(_overlayStack);
+					if (_overlayStack.Parent == WindowOverlayHelper._platformRootView)
+					{
+						_overlayStack.RemoveFromParent();
+					}
+					else if (this._windowManager != null)
+					{
+						this._windowManager.RemoveView(_overlayStack);
+					}
 				}
 
 				if (_stackList is not null && _stackList.Contains(_overlayStack))
@@ -267,10 +274,11 @@ namespace Syncfusion.Maui.Toolkit.Internals
 		{
 			float posX = (float)x * _density;
 			float posY = (float)y * _density;
+			var platformWindow = WindowOverlayHelper.GetPlatformWindow();
 
-			if (_overlayStack is not null)
+			if (_overlayStack is not null && _overlayStackView is not null)
 			{
-				if (_windowManager is not null)
+				if (_overlayStack is not null && _overlayStackView is not null)
 				{
 					if (_windowManagerLayoutParams is null)
 					{
@@ -286,15 +294,39 @@ namespace Syncfusion.Maui.Toolkit.Internals
 						}
 					}
 
+					// If the overlay stack is currently attached to the application's root view,
+					// remove it first before attaching to the WindowManager. Calling
+					// UpdateViewLayout when the view is attached to the PlatformRootView
+					// results in an IllegalArgumentException (not attached to window manager).
 					if (_overlayStack.Parent is null)
 					{
 						_windowManager.AddView(_overlayStack, _windowManagerLayoutParams);
 					}
+					else if (_overlayStack.Parent == WindowOverlayHelper._platformRootView)
+					{
+						// Detach from the root view and add to the WindowManager
+						_overlayStack.RemoveFromParent();
+						_windowManager.AddView(_overlayStack, _windowManagerLayoutParams);
+					}
 					else
 					{
+						// Already attached to a WindowManager-backed parent, update layout.
 						_windowManager.UpdateViewLayout(_overlayStack, _windowManagerLayoutParams);
 					}
 				}
+				else if (_overlayStackView.canHandleTouch && WindowOverlayHelper._platformRootView is ViewGroup platformRootView && _overlayContent != null)
+				{
+					if (_overlayStack.Parent == null)
+					{
+						// When ShowOverlayAlways is set to false, the PopupView must be added as part of the root view. We cannot attach it to the WindowManager because doing so prevents touch from being properly passed through.
+						platformRootView.AddView(_overlayStack, new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MatchParent, ViewGroup.LayoutParams.MatchParent));
+						_overlayContent.Clickable = true;
+						_overlayContent.Focusable = true;
+					}
+				}
+
+				// refresh decor frame before positioning to ensure correct conversion from screen coordinates
+				_decorViewFrame = WindowOverlayHelper._decorViewFrame;
 
 				if (_overlayContent is not null)
 				{
@@ -314,8 +346,35 @@ namespace Syncfusion.Maui.Toolkit.Internals
 							new ViewGroup.LayoutParams(ViewGroup.LayoutParams.WrapContent, ViewGroup.LayoutParams.WrapContent));
 					}
 
-					_overlayContent.SetX(posX);
-					_overlayContent.SetY(posY);
+					// When the overlay stack is hosted in the PlatformRootView, convert screen coordinates to
+					// the overlay stack's local coordinate space by adding the decor view origin. This
+					// aligns popup placement with the application's visual origin (below system bars).
+					// Check window flags once to avoid redundant null checks
+					var isFullScreen = false;
+					var hasLayoutNoLimits = false;
+
+					if (platformWindow != null && platformWindow.Attributes != null)
+					{
+						isFullScreen = platformWindow.Attributes.Flags.HasFlag(WindowManagerFlags.Fullscreen);
+						hasLayoutNoLimits = platformWindow.Attributes.Flags.HasFlag(WindowManagerFlags.LayoutNoLimits);
+					}
+
+					// Determine if we need to apply decor offsets
+					var shouldApplyDecorOffset = _overlayStack.Parent == WindowOverlayHelper._platformRootView
+												&& !(hasLayoutNoLimits || isFullScreen) && WindowOverlayHelper._window != null;
+
+					if (shouldApplyDecorOffset)
+					{
+						var decorLeft = _decorViewFrame != null ? _decorViewFrame.Left : 0f;
+						var decorTop = isFullScreen ? 0f : (_decorViewFrame != null ? _decorViewFrame.Top : 0f);
+						_overlayContent.SetX(posX + decorLeft);
+						_overlayContent.SetY(posY + decorTop);
+					}
+					else
+					{
+						_overlayContent.SetX(posX);
+						_overlayContent.SetY(posY);
+					}
 				}
 			}
 		}
@@ -329,9 +388,16 @@ namespace Syncfusion.Maui.Toolkit.Internals
 			{
 				ClearChildren();
 				_overlayStack.LayoutChange -= OnOverlayStackLayoutChange;
-				if (_overlayStack.Parent is not null && _windowManager is not null)
+				if (_overlayStack.Parent is not null)
 				{
-					_windowManager.RemoveView(_overlayStack);
+					if (_overlayStack.Parent == WindowOverlayHelper._platformRootView)
+					{
+						_overlayStack.RemoveFromParent();
+					}
+					else if (this._windowManager != null)
+					{
+						this._windowManager.RemoveView(_overlayStack);
+					}
 				}
 
 				_windowManagerLayoutParams = null;

--- a/maui/src/Core/WindowOverlay/WindowOverlay.iOS.cs
+++ b/maui/src/Core/WindowOverlay/WindowOverlay.iOS.cs
@@ -313,6 +313,18 @@ namespace Syncfusion.Maui.Toolkit.Internals
 		}
 
 		/// <summary>
+		/// Refreshes the touch handling flags based on the current canHandleTouch value of the overlay container.
+		/// Call this when ShowOverlayAlways property changes after the overlay is already initialized.
+		/// </summary>
+		internal void RefreshTouchHandling()
+		{
+			if (_overlayStack != null && _overlayStackView != null)
+			{
+				_overlayStack._canHandleTouch = !_overlayStackView.canHandleTouch;
+			}
+		}
+
+		/// <summary>
 		/// Removes the current overlay window from root view with all its children.
 		/// </summary>
 		internal void RemoveFromWindow()

--- a/maui/src/Core/WindowOverlay/WindowOverlayContainer/PlatformView/WindowOverlayStack.Android.cs
+++ b/maui/src/Core/WindowOverlay/WindowOverlayContainer/PlatformView/WindowOverlayStack.Android.cs
@@ -3,11 +3,16 @@ using Android.Runtime;
 using Android.Util;
 using Android.Views;
 using Android.Widget;
+using AndroidX.Activity;
+using Microsoft.Maui.Handlers;
 
 namespace Syncfusion.Maui.Toolkit.Internals
 {
     internal class WindowOverlayStack : FrameLayout
     {
+		// Back press callback registered with the host activity's OnBackPressedDispatcher.
+		private OnBackPressedCallback? backPressedCallback;
+
 		// To check whether the popup has Overlay Mode blur.
 		internal bool HasBlurMode { get; set; }
 
@@ -53,6 +58,97 @@ namespace Syncfusion.Maui.Toolkit.Internals
 			}
 
 			return base.DispatchKeyEvent(e);
+		}
+
+		/// <summary>
+		/// Handles touch events dispatched to the current view.
+		/// </summary>
+		/// <param name="e">The touch event for this action, or null.</param>
+		/// <returns>True if handled by the view hierarchy; otherwise, false.</returns>
+		public override bool DispatchTouchEvent(MotionEvent? e)
+		{
+			if (e != null && OverlayContanier != null && OverlayContanier.canHandleTouch)
+			{
+				OverlayContanier.ProcessTouchInteraction(e.RawX / WindowOverlayHelper._density, e.RawY / WindowOverlayHelper._density);
+			}
+
+			return base.DispatchTouchEvent(e);
+		}
+
+		/// <summary>
+		/// Called when this view is attached to a window. Registers an <see cref="AndroidX.Activity.OnBackPressedCallback"/>
+		/// with the host <see cref="AndroidX.Activity.ComponentActivity"/>'s <see cref="AndroidX.Activity.OnBackPressedDispatcher"/>
+		/// so the overlay can handle system Back presses without requiring view focus.
+		/// </summary>
+		protected override void OnAttachedToWindow()
+		{
+			base.OnAttachedToWindow();
+
+			if (this.OverlayContanier != null && this.OverlayContanier.canHandleTouch)
+			{
+				var window = WindowOverlayHelper._window;
+				if (window != null && window.Handler != null && window.Handler is WindowHandler windowHandler
+						&& windowHandler.PlatformView is ComponentActivity activity && activity != null && this.backPressedCallback == null)
+				{
+					this.backPressedCallback = new BackPressedHandler(this.OverlayContanier);
+					activity.OnBackPressedDispatcher.AddCallback(this.backPressedCallback);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Called when this view is detached from the window. Unregisters any previously
+		/// registered back-press callback to avoid leaks and restore normal back handling.
+		/// </summary>
+		protected override void OnDetachedFromWindow()
+		{
+			if (this.backPressedCallback != null)
+			{
+				this.backPressedCallback.Remove();
+				this.backPressedCallback = null;
+			}
+
+			base.OnDetachedFromWindow();
+		}
+	}
+
+	/// <summary>
+	/// Handles Android back-button callbacks for the overlay stack.
+	/// </summary>
+	/// <remarks>
+	/// This callback is registered with the host Activity's
+	/// <see cref="AndroidX.Activity.ComponentActivity.OnBackPressedDispatcher"/> and
+	/// forwards back-press events to the cross-platform
+	/// <see cref="WindowOverlayContainer"/> so overlays can handle them.
+	/// </remarks>
+	internal class BackPressedHandler : OnBackPressedCallback
+	{
+		/// <summary>
+		/// Reference to the cross-platform overlay container that will receive
+		/// delegated back-button events. May be <c>null</c> if no container is available.
+		/// </summary>
+		private readonly WindowOverlayContainer? container;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="BackPressedHandler"/> class.
+		/// </summary>
+		/// <param name="container">The overlay container to which back presses are forwarded. May be <c>null</c>.</param>
+		internal BackPressedHandler(WindowOverlayContainer? container)
+			: base(true)
+		{
+			this.container = container;
+		}
+
+		/// <summary>
+		/// Called when the system back button is pressed. Forwards the event to
+		/// the <see cref="WindowOverlayContainer"/> if it is available.
+		/// </summary>
+		public override void HandleOnBackPressed()
+		{
+			if (this.container != null)
+			{
+				this.container.ProcessBackButtonPressed();
+			}
 		}
 	}
 

--- a/maui/src/Popup/Helpers/PopupExtension/PopupExtension.cs
+++ b/maui/src/Popup/Helpers/PopupExtension/PopupExtension.cs
@@ -5,6 +5,22 @@
 	/// </summary>
 	internal static partial class PopupExtension
 	{
+		/// <summary>
+		/// Tracks open popups in Z-order (the last element is the topmost popup).
+		/// </summary>
+		internal static System.Collections.Generic.List<SfPopup> OpenPopups = new System.Collections.Generic.List<SfPopup>();
+
+		/// <summary>
+		/// Gets the top-most open popup, or null if none.
+		/// </summary>
+		internal static SfPopup? TopMostOpenPopup
+		{
+			get
+			{
+				return OpenPopups.Count > 0 ? OpenPopups[OpenPopups.Count - 1] : null;
+			}
+		}
+
 		#region Internal Methods
 
 		/// <summary>

--- a/maui/src/Popup/SfPopup/SfPopup.Windows.cs
+++ b/maui/src/Popup/SfPopup/SfPopup.Windows.cs
@@ -4,6 +4,7 @@ using Microsoft.Maui.Platform;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Hosting;
+using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Shapes;
 using Syncfusion.Maui.Toolkit.Internals;
 using Syncfusion.Maui.Toolkit.Platform;
@@ -23,6 +24,11 @@ namespace Syncfusion.Maui.Toolkit.Popup
 		SpriteVisual? _shadowVisual;
 		Rectangle? _shadowHost;
 		DropShadow? _dropShadow;
+
+		/// <summary>
+		/// Stores the pointer event handler instance to ensure proper add/remove handler operations.
+		/// </summary>
+		private PointerEventHandler? rootPointerHandler;
 
 		#endregion
 
@@ -51,6 +57,9 @@ namespace Syncfusion.Maui.Toolkit.Popup
 			{
 				popupNativeView.SizeChanged += OnNativePopupViewSizeChanged;
 			}
+
+			// Add root pointer handler for pass-through touch when ShowOverlayAlways is false
+			this.AddRootPointerHandler();
 		}
 
 		/// <summary>
@@ -68,6 +77,8 @@ namespace Syncfusion.Maui.Toolkit.Popup
 			{
 				popupNativeView.SizeChanged -= OnNativePopupViewSizeChanged;
 			}
+
+			this.RemoveRootPointerHandler();
 		}
 
 		/// <summary>
@@ -157,6 +168,33 @@ namespace Syncfusion.Maui.Toolkit.Popup
 			if (_popupView is not null && _popupView.Handler is not null && _popupView.Handler.ContainerView is not null && _popupView.Handler.ContainerView is WrapperView wrapperView)
 			{
 				wrapperView.FlowDirection = _isRTL ? Microsoft.UI.Xaml.FlowDirection.RightToLeft : Microsoft.UI.Xaml.FlowDirection.LeftToRight;
+			}
+		}
+
+		/// <summary>
+		/// Adds a root-level pointer handler to detect taps outside the popup when ShowOverlayAlways is false.
+		/// </summary>
+		internal void AddRootPointerHandler()
+		{
+			if (!this.ShowOverlayAlways && WindowOverlayHelper._platformRootView is FrameworkElement root)
+			{
+				// Create and store the handler instance for proper removal later
+				this.rootPointerHandler = new PointerEventHandler(this.OnRootPointerPressed);
+
+				// Listen globally with handledEventsToo = true so we see events even if other elements handle them
+				root.AddHandler(UIElement.PointerPressedEvent, this.rootPointerHandler, true);
+			}
+		}
+
+		/// <summary>
+		/// Removes the root-level pointer handler.
+		/// </summary>
+		internal void RemoveRootPointerHandler()
+		{
+			if (WindowOverlayHelper._platformRootView is FrameworkElement root && this.rootPointerHandler != null)
+			{
+				root.RemoveHandler(UIElement.PointerPressedEvent, this.rootPointerHandler);
+				this.rootPointerHandler = null;
 			}
 		}
 
@@ -265,6 +303,19 @@ namespace Syncfusion.Maui.Toolkit.Popup
 			}
 		}
 
+		/// <summary>
+		/// Handles pointer pressed events on the root view to detect taps outside the popup.
+		/// </summary>
+		/// <param name="sender">The root view.</param>
+		/// <param name="e">The pointer event arguments.</param>
+		private void OnRootPointerPressed(object sender, PointerRoutedEventArgs e)
+		{
+			// Only the topmost popup should react to outside-clicks.
+			if (this.IsOpen && PopupExtension.TopMostOpenPopup == this && !this.RaisePopupClosingEvent() && !this.StaysOpen)
+			{
+				this.IsOpen = false;
+			}
+		}
 		#endregion
 	}
 }

--- a/maui/src/Popup/SfPopup/SfPopup.cs
+++ b/maui/src/Popup/SfPopup/SfPopup.cs
@@ -264,7 +264,7 @@ namespace Syncfusion.Maui.Toolkit.Popup
 		/// Identifies the ShowOverlay bindable property.
 		/// </summary>
 		public static readonly BindableProperty ShowOverlayAlwaysProperty =
-			BindableProperty.Create(nameof(ShowOverlayAlways), typeof(bool), typeof(SfPopup), true, BindingMode.Default, null, null);
+			BindableProperty.Create(nameof(ShowOverlayAlways), typeof(bool), typeof(SfPopup), true, BindingMode.Default, null, OnShowOverlayAlwaysChanged);
 
 		/// <summary>
 		/// Identifies the <see cref="SfPopup.OverlayMode"/> <see cref="BindableProperty"/>.
@@ -2130,6 +2130,12 @@ namespace Syncfusion.Maui.Toolkit.Popup
 
 				// position the popup when window size and orientation changed.
 				WirePlatformSpecificEvents();
+
+				// Track this popup as open/topmost.
+				if (!PopupExtension.OpenPopups.Contains(this))
+				{
+					PopupExtension.OpenPopups.Add(this);
+				}
 			}
 			else
 			{
@@ -2213,7 +2219,12 @@ namespace Syncfusion.Maui.Toolkit.Popup
 				}
 				else
 				{
+#if WINDOWS
+                    // When ShowOverlay is set to false, the popup’s background is set to null, allowing touch to pass through to the underlying controls.
+                    this._popupOverlayContainer.Background = null;
+#else
 					_popupOverlayContainer.ApplyBackgroundColor(Colors.Transparent);
+#endif
 				}
 			}
 		}
@@ -2659,6 +2670,12 @@ namespace Syncfusion.Maui.Toolkit.Popup
 
 		void RemovePopupViewAndResetValues()
 		{
+			// Remove from open popups stack.
+			if (PopupExtension.OpenPopups.Contains(this))
+			{
+				PopupExtension.OpenPopups.Remove(this);
+			}
+
 			if (_popupView is not null && _popupOverlay is not null)
 			{
 				if (_popupOverlayContainer is not null)
@@ -3614,6 +3631,50 @@ namespace Syncfusion.Maui.Toolkit.Popup
 			if (popup is not null && popup.IsOpen)
 			{
 				popup.ApplyOverlayBackground();
+			}
+		}
+
+		/// <summary>
+		/// Called when ShowOverlayAlways property changes to refresh native overlay touch handling.
+		/// </summary>
+		private static void OnShowOverlayAlwaysChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var popup = bindable as SfPopup;
+			if (popup != null)
+			{
+				bool showOverlayAlways = (bool)newValue;
+				popup.ApplyOverlayBackground();
+				if (popup._popupOverlayContainer is SfPopupOverlayContainer overlayContainer)
+				{
+					if (showOverlayAlways)
+					{
+#if ANDROID
+                        overlayContainer.AddTouchListener(overlayContainer);
+#elif WINDOWS
+                        popup.RemoveRootPointerHandler();
+#elif MACCATALYST || IOS
+                        popup.RemoveRootTapRecognizer();
+#endif
+					}
+					else
+					{
+#if ANDROID
+                        overlayContainer.RemoveTouchListener(overlayContainer);
+#elif WINDOWS
+                        popup.AddRootPointerHandler();
+#elif MACCATALYST || IOS
+                        popup.AddRootTapRecognizer();
+#endif
+					}
+				}
+
+				// If overlay exists, refresh native touch handling so canHandleTouch reflects the new value.
+#if IOS || MACCATALYST
+                if (popup._popupOverlay != null)
+                {
+                    popup._popupOverlay.RefreshTouchHandling();
+                }
+#endif
 			}
 		}
 

--- a/maui/src/Popup/SfPopup/SfPopup.iOS.cs
+++ b/maui/src/Popup/SfPopup/SfPopup.iOS.cs
@@ -3,6 +3,7 @@ using CoreGraphics;
 using Foundation;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Platform;
+using Syncfusion.Maui.Toolkit.Internals;
 using UIKit;
 
 namespace Syncfusion.Maui.Toolkit.Popup
@@ -15,6 +16,7 @@ namespace Syncfusion.Maui.Toolkit.Popup
 		#region Fields
 		NSObject? _keyboardShow;
 		NSObject? _keyboardHide;
+		private UITapGestureRecognizer? rootTapRecognizer;
 
 		/// <summary>
 		/// This field stores the blur effect view added by this popup.
@@ -72,6 +74,9 @@ namespace Syncfusion.Maui.Toolkit.Popup
 			}
 
 			WireKeyboardNotification();
+
+			// Enable pass-through touches and outside-tap close when ShowOverlayAlways is false
+			this.AddRootTapRecognizer();
 		}
 
 		/// <summary>
@@ -100,6 +105,8 @@ namespace Syncfusion.Maui.Toolkit.Popup
 
 			_keyboardHide?.Dispose();
 			_keyboardShow?.Dispose();
+
+			this.RemoveRootTapRecognizer();
 		}
 
 		/// <summary>
@@ -222,6 +229,134 @@ namespace Syncfusion.Maui.Toolkit.Popup
 				}
 
 				_popupView.InvalidateForceLayout();
+			}
+		}
+
+		/// <summary>
+		/// Adds a root-level tap recognizer on the key window to detect taps outside the popup
+		/// when ShowOverlayAlways is false. Does not cancel touches so underlying views remain interactive.
+		/// </summary>
+		private void AddRootTapRecognizer()
+		{
+			if (this.ShowOverlayAlways || !this.IsOpen)
+			{
+				return;
+			}
+
+			// Resolve current key window (multi-window aware)
+			UIWindow? keyWindow = PopupExtension.GetActiveWindow();
+			var root = (UIView?)(keyWindow ?? WindowOverlayHelper._platformRootView);
+			if (root == null)
+			{
+				return;
+			}
+
+			// If an existing recognizer is attached to a different root, remove it first
+			if (this.rootTapRecognizer != null)
+			{
+				var previousView = this.rootTapRecognizer.View;
+				if (previousView != null && previousView != root)
+				{
+					previousView.RemoveGestureRecognizer(this.rootTapRecognizer);
+				}
+
+				this.rootTapRecognizer.Dispose();
+				this.rootTapRecognizer = null;
+			}
+
+			this.rootTapRecognizer = new UITapGestureRecognizer(g =>
+			{
+				// Only the topmost popup should respond to outside taps.
+				if (PopupExtension.TopMostOpenPopup != this)
+				{
+					return;
+				}
+
+				if (!this.IsOpen || this._popupView == null || this.StaysOpen)
+				{
+					return;
+				}
+
+				var currentRoot = (UIView?)(WindowOverlayHelper._platformRootView ?? keyWindow ?? PopupExtension.GetActiveWindow());
+				if (currentRoot == null)
+				{
+					return;
+				}
+
+				if (this._popupView.Handler?.PlatformView is UIView popupNative)
+				{
+					var origin = popupNative.ConvertPointToView(new CGPoint(0, 0), currentRoot);
+					var rect = new CGRect(origin.X, origin.Y, popupNative.Bounds.Width, popupNative.Bounds.Height);
+					var location = g.LocationInView(currentRoot);
+					bool inside = rect.Contains(location);
+					if (!inside)
+					{
+						if (!this.RaisePopupClosingEvent())
+						{
+							// Close immediately so underlying control can still receive the tap
+							this.IsOpen = false;
+						}
+					}
+				}
+			})
+			{
+				CancelsTouchesInView = false,
+				DelaysTouchesBegan = false,
+				DelaysTouchesEnded = false,
+			};
+
+			// Allow recognizing simultaneously so the tap on underlying control still fires
+			this.rootTapRecognizer.ShouldRecognizeSimultaneously += (gesture, other) => true;
+
+			// Reject touches that began inside the popup so the root recognizer does not also treat the same tap as an outside-tap and close the popup.
+			this.rootTapRecognizer.ShouldReceiveTouch += (recognizer, touch) =>
+			{
+				try
+				{
+					var currentRoot = (UIView?)(WindowOverlayHelper._platformRootView ?? keyWindow ?? PopupExtension.GetActiveWindow());
+					if (currentRoot == null)
+					{
+						return true;
+					}
+
+					if (this._popupView?.Handler?.PlatformView is UIView popupNative)
+					{
+						// Convert popup origin to the root coordinate space and test containment.
+						var origin = popupNative.ConvertPointToView(new CGPoint(0, 0), currentRoot);
+						var rect = new CGRect(origin.X, origin.Y, popupNative.Bounds.Width, popupNative.Bounds.Height);
+						var location = touch.LocationInView(currentRoot);
+						if (rect.Contains(location))
+						{
+							// Touch began inside popup - do not let root recognizer handle it.
+							return false;
+						}
+					}
+				}
+				catch
+				{
+					// If anything goes wrong, fall back to allowing the recognizer to receive the touch.
+				}
+
+				return true;
+			};
+
+			root.AddGestureRecognizer(this.rootTapRecognizer);
+		}
+
+		/// <summary>
+		/// Removes the root-level tap recognizer.
+		/// </summary>
+		private void RemoveRootTapRecognizer()
+		{
+			// Resolve current key window to remove recognizer from active root
+			UIWindow? keyWindow = PopupExtension.GetActiveWindow();
+			var root = (UIView?)(keyWindow ?? WindowOverlayHelper._platformRootView);
+
+			if (root != null && this.rootTapRecognizer != null)
+			{
+				root.RemoveGestureRecognizer(this.rootTapRecognizer);
+				this.rootTapRecognizer.Dispose();
+				this.rootTapRecognizer = null;
 			}
 		}
 	}

--- a/maui/src/Popup/SfPopupOverlayContainer.cs
+++ b/maui/src/Popup/SfPopupOverlayContainer.cs
@@ -24,11 +24,33 @@ namespace Syncfusion.Maui.Toolkit.Popup
 		{
 			_popup = sfpopup;
 #if ANDROID
-			this.AddTouchListener(this);
+			if (this._popup.ShowOverlayAlways)
+			{
+				// The touch listener is added only when ShowOverlayAlways is true.
+				// When ShowOverlayAlways is false, touch must pass through to the controls behind.
+				// If we handle the touch here, it would prevent the touch from reaching the underlying controls.
+				this.AddTouchListener(this);
+			}
 #endif
 		}
 
 		#endregion
+
+		/// <summary>
+		/// Gets a value indicating whether the native overlay container should handle touch
+		/// interactions itself or allow touches to pass through to underlying views.
+		/// </summary>
+		/// <remarks>
+		/// When this property returns <c>true</c>, the overlay will capture touch events
+		/// (for example to detect taps on the overlay to close the popup). When it
+		/// returns <c>false</c>, the overlay will allow touches to pass through so
+		/// underlying controls can receive them. The value is driven by
+		/// <see cref="SfPopup.ShowOverlayAlways"/> on the associated popup instance.
+		/// </remarks>
+		internal override bool canHandleTouch
+		{
+			get { return !this._popup.ShowOverlayAlways; }
+		}
 
 		#region ITouchListener Callback
 #if ANDROID
@@ -47,7 +69,7 @@ namespace Syncfusion.Maui.Toolkit.Popup
 		#endregion
 
 		#region Internal Methods
-#if !ANDROID
+
 		/// <summary>
 		/// This method will be invoked when the touch interaction is made on the container.
 		/// </summary>
@@ -57,7 +79,7 @@ namespace Syncfusion.Maui.Toolkit.Popup
 		{
 			ClosePopupIfRequired(new Point(x, y));
 		}
-#endif
+
 		/// <summary>
 		/// Used to set background color for the container.
 		/// </summary>
@@ -88,6 +110,14 @@ namespace Syncfusion.Maui.Toolkit.Popup
 		/// <param name="touchPoint">The touch point of the container view.</param>
 		void ClosePopupIfRequired(Point touchPoint)
 		{
+#if ANDROID
+            // Only the topmost popup should respond to outside-touch events.
+            if (!this._popup.ShowOverlayAlways && PopupExtension.TopMostOpenPopup != this._popup)
+            {
+                return;
+            }
+#endif
+
 			if (_popup.IsOpen && !_popup._isPopupAnimationInProgress && !_popup._isContainerAnimationInProgress)
 			{
 				// TODO: CanLayoutForGivenSizeAndPosition


### PR DESCRIPTION
Feature description
Support to interact with background elements while Popup is open [When overlay is disabled]

Purpose/benefits of the feature
When the overlay is not there we can click the elements present behind and the popup closes on outside click.

Use cases
When the overlay is not there (ShowOverlayAlways = False), we can click the elements present behind and the popup closes on outside click.
When popup StaysOpen=true. The popup will not close on outside click but we can interact with the elements behind.

Solution description
Android:
Added the popupview to the PlatformRootView instead of adding it to the overlay.
Used DispatchTouchEvent to detect touch in the rootview.

Windows:
By setting the overlaystack background to null the touch passes.
Used pointer pressed events on the root view to detect taps outside the popup.

iOS and MAC:
Added a root-level UITapGestureRecognizer (rootTapRecognizer) to recognize outside tap to close the popup.
Set the overlaystack canhandleTouch to false when showOvelayalways is false, so that touch passes behind the popup.
