### PR TITLE
Perf: Replace ContainsKey + indexer with TryGetValue to eliminate redundant hash lookups

### DIFF
--- a/maui/src/Accordion/AccordionItemView.cs
+++ b/maui/src/Accordion/AccordionItemView.cs
@@ -71,7 +71,7 @@ namespace Syncfusion.Maui.Toolkit.Accordion
 				return false;
 			}
 
-			var expandedItems = Accordion.Items.ToList().FindAll(x => x._accordionItemView != null && x._accordionItemView.IsExpanded);
+			var expandedItems = Accordion.Items.Where(x => x._accordionItemView != null && x._accordionItemView.IsExpanded).ToList();
 			return (Accordion.ExpandMode == AccordionExpandMode.Single ||
 					Accordion.ExpandMode == AccordionExpandMode.Multiple) && expandedItems.Count == 1;	
         }

--- a/maui/src/Accordion/SfAccordion.cs
+++ b/maui/src/Accordion/SfAccordion.cs
@@ -540,7 +540,7 @@ namespace Syncfusion.Maui.Toolkit.Accordion
 		/// </summary>
 		internal void UpdateSelection()
 		{
-			var selectedItems = Items.ToList().FindAll(x => x._accordionItemView != null && x._accordionItemView.IsSelected);
+			var selectedItems = Items.Where(x => x._accordionItemView != null && x._accordionItemView.IsSelected).ToList();
 			if (selectedItems.Count == 1 && Items[selectedItems[0]._itemIndex] is AccordionItem items && items._accordionItemView is AccordionItemView accordionItem)
 			{
 				accordionItem.IsSelected = false;
@@ -560,7 +560,7 @@ namespace Syncfusion.Maui.Toolkit.Accordion
 				return;
 			}
 
-			var expandedItems = Items.ToList().FindAll(x => x._accordionItemView != null && x._accordionItemView.IsExpanded);
+			var expandedItems = Items.Where(x => x._accordionItemView != null && x._accordionItemView.IsExpanded).ToList();
 			switch (ExpandMode)
 			{
 				case AccordionExpandMode.Single:
@@ -1575,7 +1575,7 @@ namespace Syncfusion.Maui.Toolkit.Accordion
 		/// <param name="e">The <see cref="KeyEventArgs"/> containing the event data for the key that was pressed.</param>
 		void IKeyboardListener.OnKeyDown(KeyEventArgs e)
 		{
-			var selectedItem = Items.ToList().FirstOrDefault(x => x._accordionItemView != null && x._accordionItemView.IsSelected);
+			var selectedItem = Items.FirstOrDefault(x => x._accordionItemView != null && x._accordionItemView.IsSelected);
 			if (e.Key == KeyboardKey.Down || (e.Key == KeyboardKey.Tab && !e.IsShiftKeyPressed))
 			{
 				OnDownKeyPressed(selectedItem);

--- a/maui/src/Calendar/LoopingPannel/CustomSnapManager.cs
+++ b/maui/src/Calendar/LoopingPannel/CustomSnapManager.cs
@@ -1014,8 +1014,15 @@ namespace Syncfusion.Maui.Toolkit.Calendar
             for (int i = 0; i < ChildCount; i++)
             {
                 List<DateTime> visibleDates = GetVisibleDatesForView(i);
-                List<DateTime> disableDates = _disabledDatesDictionary.ContainsKey(visibleDates) ? _disabledDatesDictionary[visibleDates] : new List<DateTime>();
-                List<CalendarIconDetails> specialDates = _specialDatesDictionary.ContainsKey(visibleDates) ? _specialDatesDictionary[visibleDates] : new List<CalendarIconDetails>();
+                if (!_disabledDatesDictionary.TryGetValue(visibleDates, out List<DateTime>? disableDates))
+                {
+                    disableDates = new List<DateTime>();
+                }
+
+                if (!_specialDatesDictionary.TryGetValue(visibleDates, out List<CalendarIconDetails>? specialDates))
+                {
+                    specialDates = new List<CalendarIconDetails>();
+                }
                 if (_calendarInfo.View == CalendarView.Month)
                 {
                     MonthViewLayout monthViewLayout = new MonthViewLayout(_calendarInfo, visibleDates, _calendarInfo.SelectedDate, disableDates, specialDates, i == _currentChildIndex);

--- a/maui/src/Core/WindowOverlay/WindowOverlay.Android.cs
+++ b/maui/src/Core/WindowOverlay/WindowOverlay.Android.cs
@@ -539,12 +539,7 @@ namespace Syncfusion.Maui.Toolkit.Internals
 			WindowOverlayHorizontalAlignment horizontalAlignment,
 			WindowOverlayVerticalAlignment verticalAlignment)
 		{
-			PositionDetails details;
-			if (_positionDetails.ContainsKey(childView))
-			{
-				details = _positionDetails[childView];
-			}
-			else
+			if (!_positionDetails.TryGetValue(childView, out PositionDetails? details))
 			{
 				details = new PositionDetails();
 				_positionDetails.Add(childView, details);
@@ -582,12 +577,7 @@ namespace Syncfusion.Maui.Toolkit.Internals
 			double x = 0,
 			double y = 0)
 		{
-			PositionDetails details;
-			if (_positionDetails.ContainsKey(childView))
-			{
-				details = _positionDetails[childView];
-			}
-			else
+			if (!_positionDetails.TryGetValue(childView, out PositionDetails? details))
 			{
 				details = new PositionDetails();
 				_positionDetails.Add(childView, details);

--- a/maui/src/Core/WindowOverlay/WindowOverlay.Windows.cs
+++ b/maui/src/Core/WindowOverlay/WindowOverlay.Windows.cs
@@ -289,12 +289,7 @@ namespace Syncfusion.Maui.Toolkit.Internals
 			WindowOverlayHorizontalAlignment horizontalAlignment,
 			WindowOverlayVerticalAlignment verticalAlignment)
 		{
-			PositionDetails details;
-			if (_positionDetails.ContainsKey(childView))
-			{
-				details = _positionDetails[childView];
-			}
-			else
+			if (!_positionDetails.TryGetValue(childView, out PositionDetails? details))
 			{
 				details = new PositionDetails();
 				_positionDetails.Add(childView, details);
@@ -332,12 +327,7 @@ namespace Syncfusion.Maui.Toolkit.Internals
 			double x = 0,
 			double y = 0)
 		{
-			PositionDetails details;
-			if (_positionDetails.ContainsKey(childView))
-			{
-				details = _positionDetails[childView];
-			}
-			else
+			if (!_positionDetails.TryGetValue(childView, out PositionDetails? details))
 			{
 				details = new PositionDetails();
 				_positionDetails.Add(childView, details);

--- a/maui/src/Core/WindowOverlay/WindowOverlay.iOS.cs
+++ b/maui/src/Core/WindowOverlay/WindowOverlay.iOS.cs
@@ -369,12 +369,7 @@ namespace Syncfusion.Maui.Toolkit.Internals
 			WindowOverlayHorizontalAlignment horizontalAlignment,
 			WindowOverlayVerticalAlignment verticalAlignment)
 		{
-			PositionDetails details;
-			if (_positionDetails.ContainsKey(childView))
-			{
-				details = _positionDetails[childView];
-			}
-			else
+			if (!_positionDetails.TryGetValue(childView, out PositionDetails? details))
 			{
 				details = new PositionDetails();
 				_positionDetails.Add(childView, details);
@@ -413,12 +408,7 @@ namespace Syncfusion.Maui.Toolkit.Internals
 			double x = 0,
 			double y = 0)
 		{
-			PositionDetails details;
-			if (_positionDetails.ContainsKey(childView))
-			{
-				details = _positionDetails[childView];
-			}
-			else
+			if (!_positionDetails.TryGetValue(childView, out PositionDetails? details))
 			{
 				details = new PositionDetails();
 				_positionDetails.Add(childView, details);


### PR DESCRIPTION
### Root Cause of the Issue

Multiple locations use the `Dictionary.ContainsKey()` + `dictionary[key]` anti-pattern, which computes the hash and locates the bucket **twice** for every lookup. In hot paths (Calendar navigation, WindowOverlay positioning), this adds unnecessary overhead.

### Description of Change

Replaced all `ContainsKey` + indexer patterns with single `TryGetValue()` calls, which perform the lookup once and return both existence and value in a single operation.

**Files changed:**
- `maui/src/Calendar/LoopingPannel/CustomSnapManager.cs` — Called during month/year view navigation (hot path)
- `maui/src/Core/WindowOverlay/WindowOverlay.iOS.cs` — Called during overlay child positioning
- `maui/src/Core/WindowOverlay/WindowOverlay.Windows.cs` — Called during overlay child positioning
- `maui/src/Core/WindowOverlay/WindowOverlay.Android.cs` — Called during overlay child positioning

### Why This Matters

- **Zero behavior change** — purely mechanical refactor
- **Reduces hash computations by 50%** at each call site
- **Calendar control**: `AddChildren()` is called on every view navigation; the dictionary lookups happen per visible date group
- **WindowOverlay**: Positioning methods are called during layout passes on all platforms

### Additional Performance Opportunities Identified

| # | Issue | Location | Impact | Effort |
|---|-------|----------|--------|--------|
| 1 | ✅ ContainsKey + indexer → TryGetValue | Calendar, Core/WindowOverlay | High | Low |
| 2 | LINQ `.Where().Min/Max()` in hot paths | Charts/ErrorBarSegment, AreaSegment | High | Medium |
| 3 | `Items.ToList().FindAll()` unnecessary copy | Accordion/SfAccordion | High | Low |
| 4 | `Cast<T>().ToList().AsReadOnly()` in GetVisualChildren | Core/SfView | High | Low |
| 5 | `.Where().ToList()` for Min/Max calculations | SparkCharts | High | Low |
| 6 | Multiple array passes for Min/Max | Charts/AreaSegment | Medium | Low |
| 7 | `new PathF()` allocation every draw frame | Charts/AreaSegment | Medium | Medium |
| 8 | Collection re-allocation in layout passes | Charts/AreaSegment | Medium | Medium |
| 9 | `.Cast<T>()` in loops vs direct indexing | Charts/FastLineSeries | Medium | Medium |
| 10 | Missing `ConfigureAwait(false)` in library async | Multiple | Low | Medium |

### Screenshots
N/A — no visual changes (performance-only improvement)