### PR TITLE
Perf: Replace LINQ Min/Max with direct index access on sorted array in BoxAndWhiskerSeries

### DIFF
--- a/maui/src/Charts/Series/BoxAndWhiskerSeries.cs
+++ b/maui/src/Charts/Series/BoxAndWhiskerSeries.cs
@@ -1086,8 +1086,9 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				}
 				else
 				{
-					minimum = yList.Min();
-					maximum = yList.Max();
+					// yList is already sorted, so use direct index access instead of LINQ Min/Max.
+					minimum = yList[0];
+					maximum = yList[^1];
 				}
 
 				double actualMinimum = minimum;

--- a/maui/src/Charts/Series/BoxAndWhiskerSeries.cs
+++ b/maui/src/Charts/Series/BoxAndWhiskerSeries.cs
@@ -1040,6 +1040,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 				if (yList.Length > 0)
 				{
+					// The quartile, whisker, and min/max calculations below all rely on ascending values.
 					Array.Sort(yList);
 					average = yList.Average();
 				}
@@ -1086,7 +1087,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				}
 				else
 				{
-					// yList is already sorted, so use direct index access instead of LINQ Min/Max.
+					// yList was sorted above and is not modified afterwards, so first/last entries are the min/max.
 					minimum = yList[0];
 					maximum = yList[^1];
 				}


### PR DESCRIPTION
### Root Cause of the Issue

In `BoxAndWhiskerSeries.CreateSegments()`, after the `yList` array is sorted with `Array.Sort(yList)`, the code uses `yList.Min()` and `yList.Max()` (LINQ extension methods) to get the minimum and maximum values. These are O(n) operations that redundantly iterate through an already-sorted array.

### Description of Change

Replaced `yList.Min()` and `yList.Max()` with `yList[0]` and `yList[^1]` respectively. Since the array is guaranteed to be sorted at this point, the first element is the minimum and the last element is the maximum — giving O(1) access instead of O(n) iteration.

This improvement is especially relevant for charts with large datasets where this loop runs once per data point.

### Issues Fixed

Performance improvement — no associated issue.

### Screenshots
N/A — no visual change.