### PR TITLE
Perf: Cache Calendar instances in CalendarViewHelper to eliminate repeated allocations

### DIFF
--- a/maui/src/Calendar/Helper/CalendarViewHelper.cs
+++ b/maui/src/Calendar/Helper/CalendarViewHelper.cs
@@ -14,6 +14,18 @@ namespace Syncfusion.Maui.Toolkit.Calendar
     /// </summary>
     internal static class CalendarViewHelper
     {
+        #region Fields
+
+        static readonly GregorianCalendar s_gregorianCalendar = new GregorianCalendar();
+        static readonly HijriCalendar s_hijriCalendar = new HijriCalendar();
+        static readonly PersianCalendar s_persianCalendar = new PersianCalendar();
+        static readonly ThaiBuddhistCalendar s_thaiBuddhistCalendar = new ThaiBuddhistCalendar();
+        static readonly TaiwanCalendar s_taiwanCalendar = new TaiwanCalendar();
+        static readonly UmAlQuraCalendar s_umAlQuraCalendar = new UmAlQuraCalendar();
+        static readonly KoreanCalendar s_koreanCalendar = new KoreanCalendar();
+
+        #endregion
+
         #region Internal Methods
 
         /// <summary>
@@ -24,7 +36,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
         internal static DateTime GetValidDisplayDate(ICalendar calendarInfo)
         {
             // To get the calendar instance based on the calendar identifier.
-            Globalization.Calendar cultureCalendar = GetCalendar(calendarInfo.Identifier.ToString());
+            Globalization.Calendar cultureCalendar = GetCalendar(calendarInfo.Identifier);
             DateTime startDateRange = cultureCalendar.MinSupportedDateTime.Date;
             DateTime endDateRange = cultureCalendar.MaxSupportedDateTime.Date;
             DateTime minDate = startDateRange;
@@ -242,7 +254,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
         internal static bool IsValidNextDatesNavigation(List<DateTime> visibleDates, CalendarView view, int numberOfVisibleWeeks, DateTime maxDate, CalendarIdentifier calendarIdentifier)
         {
             // To get the calendar instance based on the calendar Identifier
-            Globalization.Calendar cultureCalendar = GetCalendar(calendarIdentifier.ToString());
+            Globalization.Calendar cultureCalendar = GetCalendar(calendarIdentifier);
 
             // Convert the maximum date to year, month on culture basis.
             // Need to check the maximum date to present max value, if the max value is given convert that date on culture basis
@@ -322,7 +334,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
         internal static bool IsValidPreviousDatesNavigation(List<DateTime> visibleDates, CalendarView view, int numberOfVisibleWeeks, DateTime minDate, CalendarIdentifier calendarIdentifier)
         {
             // To get the calendar instance based on the calendar identifier
-            Globalization.Calendar cultureCalendar = GetCalendar(calendarIdentifier.ToString());
+            Globalization.Calendar cultureCalendar = GetCalendar(calendarIdentifier);
 
             DateTime startDateRange = cultureCalendar.MinSupportedDateTime.Date;
             DateTime endDateRange = cultureCalendar.MaxSupportedDateTime.Date;
@@ -398,7 +410,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
         /// <returns>The week start date.</returns>
         internal static DateTime GetWeekStartDate(List<DateTime> visibleDates, CalendarIdentifier calendarIdentifier, DayOfWeek dayOfWeek)
         {
-            Globalization.Calendar cultureCalendar = GetCalendar(calendarIdentifier.ToString());
+            Globalization.Calendar cultureCalendar = GetCalendar(calendarIdentifier);
             foreach (DateTime dateTime in visibleDates)
             {
                 //// We have adjust mid day of week based on first day of week.
@@ -426,7 +438,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
             // If the type is not gregorian, need to get the week number based on the specified calendar identifier.
             if (!IsGregorianCalendar(calendarIdentifier))
             {
-                weekNumber = GetCalendar(calendarIdentifier.ToString()).GetWeekOfYear(dateTime, CalendarWeekRule.FirstDay, dayOfWeek);
+                weekNumber = GetCalendar(calendarIdentifier).GetWeekOfYear(dateTime, CalendarWeekRule.FirstDay, dayOfWeek);
             }
             else
             {
@@ -453,7 +465,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
             }
 
             const int daysPerWeek = 7;
-            Globalization.Calendar calendar = GetCalendar(identifier.ToString());
+            Globalization.Calendar calendar = GetCalendar(identifier);
             //// Use the middle item in the visible range to discover which year/month is currently in view.
             DateTime date = visibleDates[visibleDates.Count / 2];
             int year = calendar.GetYear(date);
@@ -503,7 +515,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
         internal static bool IsDisabledDate(DateTime dateTime, CalendarView view, bool enablePastDate, DateTime minDate, DateTime maxDate, CalendarSelectionMode selectionMode, CalendarRangeSelectionDirection selectionDirection, CalendarDateRange? selectedDateRange, bool allowViewNavigation, CalendarIdentifier calendarIdentifier)
         {
             // To get the calendar instance based on the calendar identifier.
-            Globalization.Calendar cultureCalendar = GetCalendar(calendarIdentifier.ToString());
+            Globalization.Calendar cultureCalendar = GetCalendar(calendarIdentifier);
 
             DateTime startDateRange = cultureCalendar.MinSupportedDateTime.Date;
             DateTime endDateRange = cultureCalendar.MaxSupportedDateTime.Date;
@@ -636,7 +648,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
         internal static bool IsLeadingAndTrailingDate(DateTime dateTime, DateTime currentViewDate, CalendarView view, CalendarIdentifier calendarIdentifier)
         {
             // To get the calendar instance based on the calendar identifier.
-            Globalization.Calendar cultureCalendar = GetCalendar(calendarIdentifier.ToString());
+            Globalization.Calendar cultureCalendar = GetCalendar(calendarIdentifier);
 
             // Get year and month value for the dateTime corresponding to the specified calendar identifier.
             int year = cultureCalendar.GetYear(dateTime);
@@ -680,7 +692,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
             }
 
             // To get the calendar instance based on the calendar identifier.
-            Globalization.Calendar cultureCalendar = GetCalendar(calendarIdentifier.ToString());
+            Globalization.Calendar cultureCalendar = GetCalendar(calendarIdentifier);
             DateTime minSupportedDate = cultureCalendar.MinSupportedDateTime;
             DateTime maxSupportedDate = cultureCalendar.MaxSupportedDateTime;
 
@@ -804,7 +816,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
         internal static bool IsSameDisplayDateView(ICalendar calendar, List<DateTime> visibleDates, DateTime previousDisplayDate, DateTime displayDate)
         {
             // To get the calendar instance based on the calendar identifier.
-            Globalization.Calendar cultureCalendar = GetCalendar(calendar.Identifier.ToString());
+            Globalization.Calendar cultureCalendar = GetCalendar(calendar.Identifier);
 
             DateTime startDateRange = cultureCalendar.MinSupportedDateTime.Date;
             DateTime endDateRange = cultureCalendar.MaxSupportedDateTime.Date;
@@ -871,7 +883,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
             }
 
             DateTime currentDate = date;
-            Globalization.Calendar calendar = GetCalendar(calendarIdentifier.ToString());
+            Globalization.Calendar calendar = GetCalendar(calendarIdentifier);
             int currentYear = calendar.GetYear(currentDate);
             int currentMonth = calendar.GetMonth(currentDate);
             DateTime minDate = calendar.MinSupportedDateTime;
@@ -915,7 +927,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
         internal static string GetYearCellText(DateTime dateTime, ICalendarYear calendar, bool isAccessibility = false)
         {
             // To get the calendar instance based on the calendar identifier.
-            Globalization.Calendar cultureCalendar = GetCalendar(calendar.Identifier.ToString());
+            Globalization.Calendar cultureCalendar = GetCalendar(calendar.Identifier);
 
             // Get the year based on the calendar identifier.
             int year = cultureCalendar.GetYear(dateTime);
@@ -1142,7 +1154,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
             }
 
             // To get the calendar instance based on the calendar identifier.
-            Globalization.Calendar cultureCalendar = GetCalendar(calendarIdentifier.ToString());
+            Globalization.Calendar cultureCalendar = GetCalendar(calendarIdentifier);
             DateTime minSupportedDate = cultureCalendar.MinSupportedDateTime;
             DateTime maxSupportedDate = cultureCalendar.MaxSupportedDateTime;
 
@@ -1269,7 +1281,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
             }
 
             // To get the calendar instance based on the calendar identifier.
-            Globalization.Calendar cultureCalendar = GetCalendar(calendarIdentifier.ToString());
+            Globalization.Calendar cultureCalendar = GetCalendar(calendarIdentifier);
 
             DateTime startDateTime = cultureCalendar.MinSupportedDateTime;
             DateTime endDateTime = cultureCalendar.MaxSupportedDateTime;
@@ -1330,7 +1342,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
             }
 
             // To get the calendar instance based on the calendar identifier.
-            Globalization.Calendar cultureCalendar = GetCalendar(calendarIdentifier.ToString());
+            Globalization.Calendar cultureCalendar = GetCalendar(calendarIdentifier);
             DateTime endDateTime = cultureCalendar.MaxSupportedDateTime;
             DateTime startDateTime = cultureCalendar.MinSupportedDateTime.Date;
 
@@ -1394,7 +1406,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
         internal static DateTime GetViewLastDate(CalendarView view, DateTime date, CalendarIdentifier calendarIdentifier)
         {
             // To get the calendar instance based on the calendar identifier.
-            Globalization.Calendar cultureCalendar = GetCalendar(calendarIdentifier.ToString());
+            Globalization.Calendar cultureCalendar = GetCalendar(calendarIdentifier);
 
             // Get the year based on the calendar identifier.
             DateTime maxDate = cultureCalendar.MaxSupportedDateTime;
@@ -1445,7 +1457,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
         /// <returns>It returns different between the day of weeks.</returns>
         internal static int GetFirstDayOfWeekDifference(DateTime currentDate, DayOfWeek dayOfWeek, CalendarIdentifier calendarIdentifier)
         {
-            Globalization.Calendar cultureCalendar = GetCalendar(calendarIdentifier.ToString());
+            Globalization.Calendar cultureCalendar = GetCalendar(calendarIdentifier);
 
             // Get difference between currentDate of day of week and day of week.
             // currentDate.DayOfWeek = Monday(1). And first day of Week = Tuesday(2).
@@ -1674,32 +1686,43 @@ namespace Syncfusion.Maui.Toolkit.Calendar
         }
 
         /// <summary>
-        /// Get calendar instance using its calendar identifier.
+        /// Get a cached calendar instance using its calendar identifier enum.
+        /// </summary>
+        /// <param name="calendarIdentifier">The calendar identifier enum value.</param>
+        /// <returns>A cached calendar instance.</returns>
+        internal static Globalization.Calendar GetCalendar(CalendarIdentifier calendarIdentifier)
+        {
+            return calendarIdentifier switch
+            {
+                CalendarIdentifier.Gregorian => s_gregorianCalendar,
+                CalendarIdentifier.Hijri => s_hijriCalendar,
+                CalendarIdentifier.Persian => s_persianCalendar,
+                CalendarIdentifier.ThaiBuddhist => s_thaiBuddhistCalendar,
+                CalendarIdentifier.Taiwan => s_taiwanCalendar,
+                CalendarIdentifier.UmAlQura => s_umAlQuraCalendar,
+                CalendarIdentifier.Korean => s_koreanCalendar,
+                _ => CultureInfo.CurrentUICulture.DateTimeFormat.Calendar,
+            };
+        }
+
+        /// <summary>
+        /// Get a cached calendar instance using its calendar identifier string.
         /// </summary>
         /// <param name="calendarIdentifier">The name of the calendar.</param>
-        /// <returns>A calendar instance.</returns>
+        /// <returns>A cached calendar instance.</returns>
         internal static Globalization.Calendar GetCalendar(string calendarIdentifier)
         {
-            switch (calendarIdentifier)
+            return calendarIdentifier switch
             {
-                case "Gregorian":
-                    return new GregorianCalendar();
-                case "Hijri":
-                    return new HijriCalendar();
-                case "Persian":
-                    return new PersianCalendar();
-                case "ThaiBuddhist":
-                    return new ThaiBuddhistCalendar();
-                case "Taiwan":
-                    return new TaiwanCalendar();
-                case "UmAlQura":
-                    return new UmAlQuraCalendar();
-                case "Korean":
-                    return new KoreanCalendar();
-                default:
-                    // If calendar identifier is specified wrongly, then default calendar will be used.
-                    return CultureInfo.CurrentUICulture.DateTimeFormat.Calendar;
-            }
+                "Gregorian" => s_gregorianCalendar,
+                "Hijri" => s_hijriCalendar,
+                "Persian" => s_persianCalendar,
+                "ThaiBuddhist" => s_thaiBuddhistCalendar,
+                "Taiwan" => s_taiwanCalendar,
+                "UmAlQura" => s_umAlQuraCalendar,
+                "Korean" => s_koreanCalendar,
+                _ => CultureInfo.CurrentUICulture.DateTimeFormat.Calendar,
+            };
         }
 
         /// <summary>
@@ -1926,7 +1949,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
         internal static DateTime? GeKeyNavigationDate(ICalendar calendar, KeyEventArgs args, DateTime oldSelectedDate)
         {
             // To get the calendar instance based on the calendar identifier.
-            Globalization.Calendar cultureCalendar = GetCalendar(calendar.Identifier.ToString());
+            Globalization.Calendar cultureCalendar = GetCalendar(calendar.Identifier);
 
             DateTime startDateRange = cultureCalendar.MinSupportedDateTime.Date;
             DateTime endDateRange = cultureCalendar.MaxSupportedDateTime.Date;
@@ -2333,7 +2356,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
         internal static bool IsDateInCurrentVisibleDate(ICalendar calendar, List<DateTime> visibleDates, DateTime selectedDate)
         {
             // To get the calendar instance based on the calendar identifier.
-            Globalization.Calendar cultureCalendar = GetCalendar(calendar.Identifier.ToString());
+            Globalization.Calendar cultureCalendar = GetCalendar(calendar.Identifier);
 
             DateTime startDateRange = cultureCalendar.MinSupportedDateTime.Date;
             DateTime endDateRange = cultureCalendar.MaxSupportedDateTime.Date;

--- a/maui/src/Calendar/LoopingPannel/CustomSnapManager.cs
+++ b/maui/src/Calendar/LoopingPannel/CustomSnapManager.cs
@@ -308,7 +308,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
             DateTime todayDate = date != null ? date.Value : DateTime.Now.Date;
             int numberOfWeeks = _calendarInfo.MonthView.GetNumberOfWeeks();
             bool isMonthView = _calendarInfo.View == CalendarView.Month && numberOfWeeks == 6;
-            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarInfo.Identifier.ToString());
+            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarInfo.Identifier);
             DateTime minDate = cultureCalendar.MinSupportedDateTime;
             int minYear = cultureCalendar.GetYear(minDate);
             int minMonth = cultureCalendar.GetMonth(minDate);
@@ -346,7 +346,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
             DateTime todayDate = date != null ? date.Value : DateTime.Now.Date;
             int numberOfWeeks = _calendarInfo.MonthView.GetNumberOfWeeks();
             bool isMonthView = _calendarInfo.View == CalendarView.Month && numberOfWeeks == 6;
-            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarInfo.Identifier.ToString());
+            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarInfo.Identifier);
             DateTime minDate = cultureCalendar.MinSupportedDateTime;
             int minYear = cultureCalendar.GetYear(minDate);
             int minMonth = cultureCalendar.GetMonth(minDate);
@@ -410,7 +410,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
 
             int numberOfWeeks = _calendarInfo.MonthView.GetNumberOfWeeks();
             bool isMonthView = _calendarInfo.View == CalendarView.Month && numberOfWeeks == 6;
-            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarInfo.Identifier.ToString());
+            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarInfo.Identifier);
             DateTime minDate = cultureCalendar.MinSupportedDateTime;
             int minYear = cultureCalendar.GetYear(minDate);
             int minMonth = cultureCalendar.GetMonth(minDate);
@@ -462,7 +462,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
 
             int numberOfWeeks = _calendarInfo.MonthView.GetNumberOfWeeks();
             bool isMonthView = _calendarInfo.View == CalendarView.Month && numberOfWeeks == 6;
-            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarInfo.Identifier.ToString());
+            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarInfo.Identifier);
             DateTime minDate = cultureCalendar.MinSupportedDateTime;
             int minYear = cultureCalendar.GetYear(minDate);
             int minMonth = cultureCalendar.GetMonth(minDate);
@@ -637,7 +637,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
 
                 int numberOfWeeks = _calendarInfo.MonthView.GetNumberOfWeeks();
                 bool isMonthView = _calendarInfo.View == CalendarView.Month && numberOfWeeks == 6;
-                Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarInfo.Identifier.ToString());
+                Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarInfo.Identifier);
                 DateTime minDate = cultureCalendar.MinSupportedDateTime;
                 int minYear = cultureCalendar.GetYear(minDate);
                 int minMonth = cultureCalendar.GetMonth(minDate);
@@ -1037,7 +1037,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
         /// <returns>The visible dates collection based on visible date.</returns>
         List<DateTime> GetVisibleDates(DateTime date)
         {
-            Globalization.Calendar calendar = CalendarViewHelper.GetCalendar(_calendarInfo.Identifier.ToString());
+            Globalization.Calendar calendar = CalendarViewHelper.GetCalendar(_calendarInfo.Identifier);
             _startYearDateTime = calendar.MinSupportedDateTime.Date;
             _endYearDateTime = calendar.MaxSupportedDateTime.Date;
             int startRangeYear = calendar.GetYear(_startYearDateTime);
@@ -1239,7 +1239,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
         /// <returns>The previous view visible start date.</returns>
         DateTime GetPreviousViewStartDate(DateTime date)
         {
-            Globalization.Calendar calendar = CalendarViewHelper.GetCalendar(_calendarInfo.Identifier.ToString());
+            Globalization.Calendar calendar = CalendarViewHelper.GetCalendar(_calendarInfo.Identifier);
             _startYearDateTime = calendar.MinSupportedDateTime.Date;
             _endYearDateTime = calendar.MaxSupportedDateTime.Date;
             int startRangeYear = calendar.GetYear(_startYearDateTime);
@@ -1300,7 +1300,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
         /// <returns>The next view visible start date.</returns>
         DateTime GetNextViewStartDate(DateTime date)
         {
-            Globalization.Calendar calendar = CalendarViewHelper.GetCalendar(_calendarInfo.Identifier.ToString());
+            Globalization.Calendar calendar = CalendarViewHelper.GetCalendar(_calendarInfo.Identifier);
             _startYearDateTime = calendar.MinSupportedDateTime.Date;
             _endYearDateTime = calendar.MaxSupportedDateTime.Date;
             int endRangeYear = calendar.GetYear(_endYearDateTime);

--- a/maui/src/Calendar/SfCalendar.cs
+++ b/maui/src/Calendar/SfCalendar.cs
@@ -981,7 +981,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
         /// <returns>The current culture.</returns>
         DateTime ConvertToCurrentCulture(DateTime date, bool adjustDay = false)
         {
-            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(Identifier.ToString());
+            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(Identifier);
             int day = 0;
             if (adjustDay)
             {
@@ -1148,7 +1148,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
             int numberOfWeeks = MonthView.GetNumberOfWeeks();
             if (View == CalendarView.Month && numberOfWeeks == 6)
             {
-                Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(Identifier.ToString());
+                Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(Identifier);
                 DateTime minDate = cultureCalendar.MinSupportedDateTime;
                 int minYear = cultureCalendar.GetYear(minDate);
                 int minMonth = cultureCalendar.GetMonth(minDate);

--- a/maui/src/Calendar/Views/CalendarView/MonthView/MonthHoverView.cs
+++ b/maui/src/Calendar/Views/CalendarView/MonthView/MonthHoverView.cs
@@ -328,7 +328,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
                 xPosition += startIndex * cellWidthOffset;
             }
 
-            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarViewInfo.Identifier.ToString());
+            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarViewInfo.Identifier);
             int currentMonthYear = cultureCalendar.GetMonth(currentMonth);
             for (int i = 0; i < visibleDateCount; i++)
             {

--- a/maui/src/Calendar/Views/CalendarView/MonthView/MonthView.cs
+++ b/maui/src/Calendar/Views/CalendarView/MonthView/MonthView.cs
@@ -432,7 +432,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
             }
             else
             {
-                Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarViewInfo.Identifier.ToString());
+                Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarViewInfo.Identifier);
                 int visibleDatesCount = _visibleDates.Count;
 				bool isMonthView = _numberOfWeeks == 6 || _isAutoFitEnabled;
 				int currentMonth = isMonthView ? cultureCalendar.GetMonth(_visibleDates[visibleDatesCount / 2]) : cultureCalendar.GetMonth(_visibleDates[0]);
@@ -1590,7 +1590,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
             // Get the culture info based on the calendar identifier.
             CultureInfo cultureInfo = CalendarViewHelper.GetCurrentUICultureInfo(_calendarViewInfo.Identifier);
             bool isGregorianCalendar = CalendarViewHelper.IsGregorianCalendar(_calendarViewInfo.Identifier);
-            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarViewInfo.Identifier.ToString());
+            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarViewInfo.Identifier);
 
             // The visible dates count not a multiple value of 7 and number of weeks then need to render the date based on the first day of week basis.
             // Example: Assume display date is 0001,01,01 first day of week is Tuesday(Enumeration Value = 2) and number of weeks is 2.
@@ -1873,7 +1873,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
                 xPosition += startIndex * cellWidthOffset;
             }
 
-            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarViewInfo.Identifier.ToString());
+            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarViewInfo.Identifier);
             int currentMonthValue = cultureCalendar.GetMonth(currentMonth);
             for (int i = 0; i < visibleDateCount; i++)
             {
@@ -1992,7 +1992,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
 
             CalendarTextStyle weekNumberTextStyle = _calendarViewInfo.MonthView.WeekNumberStyle.TextStyle;
             DateTime monthWeekStartDate = CalendarViewHelper.GetWeekStartDate(_visibleDates, _calendarViewInfo.Identifier, _calendarViewInfo.MonthView.FirstDayOfWeek);
-            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarViewInfo.Identifier.ToString());
+            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarViewInfo.Identifier);
             //// The starting date of the calendar.
             DateTime minDate = cultureCalendar.MinSupportedDateTime;
             //// The ending date of the calendar.
@@ -2399,7 +2399,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
         /// <returns>Returns the current month start date index in the visible date collection.</returns>
         int GetMonthStartDateIndex(int currentMonth)
         {
-            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarViewInfo.Identifier.ToString());
+            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarViewInfo.Identifier);
             for (int i = 0; i < _visibleDates.Count; i++)
             {
                 int month = cultureCalendar.GetMonth(_visibleDates[i]);
@@ -2443,7 +2443,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
         /// <returns>Returns the month cell details.</returns>
         CalendarCellDetails GetMonthCellDetails(int currentMonth, DateTime dateTime)
         {
-            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarViewInfo.Identifier.ToString());
+            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarViewInfo.Identifier);
             int month = cultureCalendar.GetMonth(dateTime);
 			//// If numberofweeks is 6 or autofit is enabled consider monthview.
 			bool isMonthView = _numberOfWeeks == 6 || _isAutoFitEnabled;
@@ -2460,7 +2460,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
         /// <param name="isCurrentView">Checks whether the view is current view or not.</param>
         void GenerateMonthCells(bool isCurrentView)
         {
-            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarViewInfo.Identifier.ToString());
+            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarViewInfo.Identifier);
             int currentMonth = cultureCalendar.GetMonth(_visibleDates[_visibleDates.Count / 2]);
             DataTemplate? template = _calendarViewInfo.MonthView.CellTemplate;
 
@@ -2836,7 +2836,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
             }
 
             DateTime currentMonthDate = _visibleDates[visibleDateCount / 2];
-            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarViewInfo.Identifier.ToString());
+            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarViewInfo.Identifier);
             int currentYear = cultureCalendar.GetYear(currentMonthDate);
             int currentMonth = cultureCalendar.GetMonth(currentMonthDate);
 
@@ -2946,7 +2946,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
             if (_calendarViewInfo.MonthView.ShowWeekNumber)
             {
                 DateTime monthWeekStartDate = CalendarViewHelper.GetWeekStartDate(_visibleDates, _calendarViewInfo.Identifier, _calendarViewInfo.MonthView.FirstDayOfWeek);
-                Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarViewInfo.Identifier.ToString());
+                Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarViewInfo.Identifier);
                 //// The starting date of the calendar.
                 DateTime minDate = cultureCalendar.MinSupportedDateTime;
                 //// The ending date of the calendar.

--- a/maui/src/Calendar/Views/CalendarView/MonthView/MonthViewHeader.cs
+++ b/maui/src/Calendar/Views/CalendarView/MonthView/MonthViewHeader.cs
@@ -487,7 +487,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
             }
 
             CultureInfo cultureInfo = CalendarViewHelper.GetCurrentUICultureInfo(_calendarInfo.Identifier);
-            Globalization.Calendar calendar = CalendarViewHelper.GetCalendar(_calendarInfo.Identifier.ToString());
+            Globalization.Calendar calendar = CalendarViewHelper.GetCalendar(_calendarInfo.Identifier);
             string textFormat = viewHeaderSettings.TextFormat;
             //// Need to show full week day name for all calendars except Gregorian calendar while the text format is "ddddd".
             if (textFormat == "ddddd" && !CalendarViewHelper.IsGregorianCalendar(_calendarInfo.Identifier))

--- a/maui/src/Calendar/Views/CalendarView/YearView/YearView.cs
+++ b/maui/src/Calendar/Views/CalendarView/YearView/YearView.cs
@@ -1098,7 +1098,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
         DateTime GetVisibleEndDate()
         {
             DateTime visibleEndDate = _visibleDates[_visibleDates.Count - 1];
-            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarViewInfo.Identifier.ToString());
+            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarViewInfo.Identifier);
             DateTime maxDate = cultureCalendar.MaxSupportedDateTime.Date;
             int maxDateYear = cultureCalendar.GetYear(maxDate);
             switch (_calendarViewInfo.View)
@@ -1951,7 +1951,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
             int childIndex = 0;
             DateTime currentViewDate = _visibleDates[0];
             int maxCellCount = _visibleDates.Count;
-            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarViewInfo.Identifier.ToString());
+            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarViewInfo.Identifier);
             int minYear = cultureCalendar.GetYear(cultureCalendar.MinSupportedDateTime);
             if (!_calendarViewInfo.ShowTrailingAndLeadingDates)
             {
@@ -2396,7 +2396,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
                 return;
             }
 
-            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarViewInfo.Identifier.ToString());
+            Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_calendarViewInfo.Identifier);
             DateTime previousViewStartDate = previousVisibleDates[0];
             DateTime currentViewStartDate = _visibleDates[0];
             int previousYearDifference = cultureCalendar.GetYear(previousVisibleDates[1]) - cultureCalendar.GetYear(previousViewStartDate);

--- a/maui/src/Calendar/Views/HeaderView/HeaderLayout.cs
+++ b/maui/src/Calendar/Views/HeaderView/HeaderLayout.cs
@@ -421,7 +421,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
             string headerDateString = string.Empty;
             int numberOfWeeks = _headerInfo.NumberOfVisibleWeeks;
             CultureInfo cultureInfo = CalendarViewHelper.GetCurrentUICultureInfo(_headerInfo.Identifier);
-            Globalization.Calendar calendar = CalendarViewHelper.GetCalendar(_headerInfo.Identifier.ToString());
+            Globalization.Calendar calendar = CalendarViewHelper.GetCalendar(_headerInfo.Identifier);
             switch (_headerInfo.View)
             {
                 case CalendarView.Month:
@@ -592,7 +592,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
                 //// Set the tapped value as month start date(1) for calendar month view to restrict
                 //// the assignment of trailing dates value.
                 tappedDate = _headerInfo.VisibleDates[_headerInfo.VisibleDates.Count / 2];
-                Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_headerInfo.Identifier.ToString());
+                Globalization.Calendar cultureCalendar = CalendarViewHelper.GetCalendar(_headerInfo.Identifier);
                 DateTime minDate = cultureCalendar.MinSupportedDateTime;
                 int minDateYear = cultureCalendar.GetYear(minDate);
                 int minDateMonth = cultureCalendar.GetMonth(minDate);


### PR DESCRIPTION
### Root Cause of the Issue

The `CalendarViewHelper.GetCalendar()` method is called ~40 times across the Calendar control's rendering and calculation paths. Each call:
1. Converts a `CalendarIdentifier` enum to a string via `.ToString()` (heap allocation)
2. Creates a **new** `Calendar` object (e.g., `new GregorianCalendar()`) (heap allocation)

This results in ~80 unnecessary allocations per calendar render cycle, creating GC pressure especially during scrolling and view transitions.

### Description of Change

- **Cached Calendar instances** as `static readonly` fields in `CalendarViewHelper`, since `Calendar` objects are stateless for the read operations used here (`GetYear`, `GetMonth`, `GetDayOfWeek`, etc.)
- **Added a `GetCalendar(CalendarIdentifier)` enum overload** that switches directly on the enum, eliminating the `enum.ToString()` string allocation at every call site
- **Updated all ~40 call sites** across `CalendarViewHelper.cs`, `MonthView.cs`, `YearView.cs`, `HeaderLayout.cs`, `MonthViewHeader.cs`, `MonthHoverView.cs`, `CustomSnapManager.cs`, and `SfCalendar.cs` to pass the enum directly
- **Retained the `GetCalendar(string)` overload** (now also returning cached instances) for backward compatibility with internal string-based callers

### Impact

- Eliminates ~40 string allocations per calendar render cycle
- Eliminates ~40 `Calendar` object allocations per calendar render cycle
- Reduces GC pressure during calendar navigation and scrolling
- All 1477 Calendar unit tests pass

### Issues Fixed

N/A — Performance improvement

### Screenshots

N/A — No visual changes