### PR TITLE
Perf: Eliminate LINQ allocations in BoxAndWhiskerSeries.GenerateSegments

### DIFF
--- a/maui/src/Charts/Series/BoxAndWhiskerSeries.cs
+++ b/maui/src/Charts/Series/BoxAndWhiskerSeries.cs
@@ -1034,14 +1034,20 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 			for (int i = 0; i < PointsCount; i++)
 			{
-				var yList = YDataCollection[i].Where(x => !double.IsNaN(x)).ToArray();
+				var yList = FilterNaNValues(YDataCollection[i]);
 
 				List<double> outliers = [];
 
 				if (yList.Length > 0)
 				{
 					Array.Sort(yList);
-					average = yList.Average();
+					double sum = 0;
+					for (int j = 0; j < yList.Length; j++)
+					{
+						sum += yList[j];
+					}
+
+					average = sum / yList.Length;
 				}
 
 				int yCount = yList.Length;
@@ -1086,8 +1092,8 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				}
 				else
 				{
-					minimum = yList.Min();
-					maximum = yList.Max();
+					minimum = yList[0];
+					maximum = yList[^1];
 				}
 
 				double actualMinimum = minimum;
@@ -1485,6 +1491,33 @@ namespace Syncfusion.Maui.Toolkit.Charts
 					break;
 				}
 			}
+		}
+
+		/// <summary>
+		/// Filters out NaN values from the source list without LINQ allocations.
+		/// </summary>
+		static double[] FilterNaNValues(IList<double> source)
+		{
+			int count = 0;
+			for (int i = 0; i < source.Count; i++)
+			{
+				if (!double.IsNaN(source[i]))
+				{
+					count++;
+				}
+			}
+
+			var result = new double[count];
+			int index = 0;
+			for (int i = 0; i < source.Count; i++)
+			{
+				if (!double.IsNaN(source[i]))
+				{
+					result[index++] = source[i];
+				}
+			}
+
+			return result;
 		}
 
 		void GetQuartileValues(double[] yList, int len, out double lowerQuartile, out double upperQuartile)


### PR DESCRIPTION
### Root Cause of the Issue

The `GenerateSegments` method in `BoxAndWhiskerSeries` runs a loop over every data point, and each iteration performed several unnecessary LINQ allocations:

1. `.Where(x => !double.IsNaN(x)).ToArray()` — allocates a closure, an intermediate `IEnumerable` enumerator, and a final array on every iteration
2. `.Average()` — LINQ extension that enumerates the array again with overhead
3. `.Min()` / `.Max()` — iterates the entire sorted array when the result is simply `yList[0]` / `yList[^1]`

### Description of Change

- **Replace LINQ filter with `FilterNaNValues` helper**: A simple two-pass loop (count then copy) that avoids closure/enumerator allocations entirely.
- **Replace `yList.Average()` with manual sum loop**: Eliminates LINQ overhead for a trivial arithmetic operation.
- **Replace `yList.Min()`/`yList.Max()` with direct index access**: Since the array is already sorted by `Array.Sort(yList)`, the min and max are at known positions.

These changes reduce GC pressure in a hot path that executes once per data point during chart segment generation.

### Issues Fixed

Performance improvement — no associated issue.

### Screenshots

N/A — no visual changes, behavior is identical.