### PR TITLE
Perf: Replace O(n²) lookups with Dictionary in CategoryAxis.GroupData

### DIFF
--- a/maui/src/Charts/Axis/CategoryAxis.cs
+++ b/maui/src/Charts/Axis/CategoryAxis.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Syncfusion.Maui.Toolkit.Charts
@@ -32,9 +32,8 @@ namespace Syncfusion.Maui.Toolkit.Charts
 		internal void GroupData()
 		{
 			List<string> groupingValues = [];
-			var groupingValuesSet = new HashSet<string>();
 			List<object> groupedDatas = [];
-			var groupingSet = new HashSet<string>(StringComparer.Ordinal);
+			var groupingValuesSet = new HashSet<string>(StringComparer.Ordinal);
 
 			foreach (var item in RegisteredSeries)
 			{
@@ -63,7 +62,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				}
 				else if (series.ActualXValues is List<double> doubleValues)
 				{
-					foreach (var val in (series.ActualXValues as List<double>)!)
+					foreach (var val in doubleValues)
 					{
 						var str = val.ToString();
 						groupingValues.Add(str);
@@ -78,7 +77,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 			}
 
 			var distinctXValues = groupingValues.Distinct().ToList();
-			var indexMap = new Dictionary<string, int>(distinctXValues.Count);
+			var indexMap = new Dictionary<string, int>(distinctXValues.Count, StringComparer.Ordinal);
 			for (int i = 0; i < distinctXValues.Count; i++)
 			{
 				indexMap[distinctXValues[i]] = i;
@@ -90,11 +89,23 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 				if (series.ActualXValues is List<string> list)
 				{
-					series.GroupedXValuesIndexes = list.Select(val => (double)indexMap[val]).ToList();
+					var indexes = new List<double>(list.Count);
+					foreach (var val in list)
+					{
+						indexes.Add(indexMap.TryGetValue(val, out int idx) ? idx : -1);
+					}
+
+					series.GroupedXValuesIndexes = indexes;
 				}
 				else if (series.ActualXValues is List<double> doubleList)
 				{
-					series.GroupedXValuesIndexes = (series.ActualXValues as List<double>)!.Select(val => (double)indexMap[val.ToString()]).ToList();
+					var indexes = new List<double>(doubleList.Count);
+					foreach (var val in doubleList)
+					{
+						indexes.Add(indexMap.TryGetValue(val.ToString(), out int idx) ? idx : -1);
+					}
+
+					series.GroupedXValuesIndexes = indexes;
 				}
 
 				series.GroupedXValues = distinctXValues;

--- a/maui/src/Charts/Axis/CategoryAxis.cs
+++ b/maui/src/Charts/Axis/CategoryAxis.cs
@@ -33,6 +33,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 		{
 			List<string> groupingValues = [];
 			List<object> groupedDatas = [];
+			var groupingSet = new HashSet<string>(StringComparer.Ordinal);
 
 			foreach (CartesianSeries series in RegisteredSeries.Cast<CartesianSeries>())
 			{
@@ -40,9 +41,9 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				{
 					if (groupedDatas.Count != 0)
 					{
-						for (int j = 0; j <= xValues.Count - 1; j++)
+						for (int j = 0; j < xValues.Count; j++)
 						{
-							if (!groupingValues.Contains(xValues[j]))
+							if (groupingSet.Add(xValues[j]))
 							{
 								groupingValues.Add(xValues[j]);
 							}
@@ -51,11 +52,22 @@ namespace Syncfusion.Maui.Toolkit.Charts
 					else
 					{
 						groupingValues.AddRange(xValues);
+						foreach (var val in xValues)
+						{
+							groupingSet.Add(val);
+						}
 					}
 				}
-				else if (series.ActualXValues != null)
+				else if (series.ActualXValues is List<double> doubleValues)
 				{
-					groupingValues.AddRange(from val in (series.ActualXValues as List<double>) select val.ToString());
+					foreach (var val in doubleValues)
+					{
+						var strVal = val.ToString();
+						if (groupingSet.Add(strVal))
+						{
+							groupingValues.Add(strVal);
+						}
+					}
 				}
 
 				if (groupingValues.Count != groupedDatas.Count)
@@ -66,15 +78,34 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 			var distinctXValues = groupingValues.Distinct().ToList();
 
+			// Build an O(1) lookup dictionary for index resolution instead of O(n) IndexOf calls
+			var indexLookup = new Dictionary<string, int>(distinctXValues.Count, StringComparer.Ordinal);
+			for (int i = 0; i < distinctXValues.Count; i++)
+			{
+				indexLookup[distinctXValues[i]] = i;
+			}
+
 			foreach (CartesianSeries series in RegisteredSeries.Cast<CartesianSeries>())
 			{
 				if (series.ActualXValues is List<string> list)
 				{
-					series.GroupedXValuesIndexes = (from val in list select (double)distinctXValues.IndexOf(val)).ToList();
+					var indexes = new List<double>(list.Count);
+					foreach (var val in list)
+					{
+						indexes.Add(indexLookup.TryGetValue(val, out int idx) ? idx : -1);
+					}
+
+					series.GroupedXValuesIndexes = indexes;
 				}
-				else if (series.ActualXValues != null)
+				else if (series.ActualXValues is List<double> doubleList)
 				{
-					series.GroupedXValuesIndexes = (from val in series.ActualXValues as List<double> select (double)distinctXValues.IndexOf(val.ToString())).ToList();
+					var indexes = new List<double>(doubleList.Count);
+					foreach (var val in doubleList)
+					{
+						indexes.Add(indexLookup.TryGetValue(val.ToString(), out int idx) ? idx : -1);
+					}
+
+					series.GroupedXValuesIndexes = indexes;
 				}
 
 				series.GroupedXValues = distinctXValues;

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Chart/Features/ChartFeatureAxisUnitTest.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Chart/Features/ChartFeatureAxisUnitTest.cs
@@ -2505,5 +2505,157 @@ namespace Syncfusion.Maui.Toolkit.UnitTest.Charts
 
         #endregion
 
+		#region GroupData Performance Tests
+
+		[Fact]
+		public void GroupData_WithDuplicateValues_ProducesCorrectIndexes()
+		{
+			var axis = new CategoryAxis();
+			var series1 = new LineSeries
+			{
+				ActualXValues = new List<string> { "A", "B", "A", "C", "B" },
+				ActualData = [1, 2, 3, 4, 5]
+			};
+
+			axis.RegisteredSeries = [series1];
+
+			axis.GroupData();
+
+			var expectedDistinctXValues = new List<string> { "A", "B", "C" };
+			var expectedIndexes = new List<double> { 0, 1, 0, 2, 1 };
+
+			Assert.Equal(expectedDistinctXValues, series1.GroupedXValues);
+			Assert.Equal(expectedIndexes, series1.GroupedXValuesIndexes);
+		}
+
+		[Fact]
+		public void GroupData_WithDoubleXValues_ProducesCorrectIndexes()
+		{
+			var axis = new CategoryAxis();
+			var series1 = new LineSeries
+			{
+				ActualXValues = new List<double> { 1.0, 2.0, 3.0 },
+				ActualData = [10, 20, 30]
+			};
+
+			var series2 = new LineSeries
+			{
+				ActualXValues = new List<double> { 2.0, 3.0, 4.0 },
+				ActualData = [40, 50, 60]
+			};
+
+			axis.RegisteredSeries = [series1, series2];
+
+			axis.GroupData();
+
+			var expectedDistinctXValues = new List<string> { "1", "2", "3", "4" };
+			var expectedIndexesSeries1 = new List<double> { 0, 1, 2 };
+			var expectedIndexesSeries2 = new List<double> { 1, 2, 3 };
+
+			Assert.Equal(expectedDistinctXValues, series1.GroupedXValues);
+			Assert.Equal(expectedIndexesSeries1, series1.GroupedXValuesIndexes);
+			Assert.Equal(expectedIndexesSeries2, series2.GroupedXValuesIndexes);
+		}
+
+		[Fact]
+		public void GroupData_WithMultipleSeriesOverlappingValues_DeduplicatesCorrectly()
+		{
+			var axis = new CategoryAxis();
+			var series1 = new LineSeries
+			{
+				ActualXValues = new List<string> { "X", "Y", "Z" },
+				ActualData = [1, 2, 3]
+			};
+
+			var series2 = new LineSeries
+			{
+				ActualXValues = new List<string> { "X", "Y", "Z" },
+				ActualData = [4, 5, 6]
+			};
+
+			axis.RegisteredSeries = [series1, series2];
+
+			axis.GroupData();
+
+			var expectedDistinctXValues = new List<string> { "X", "Y", "Z" };
+			var expectedIndexes = new List<double> { 0, 1, 2 };
+
+			Assert.Equal(expectedDistinctXValues, series1.GroupedXValues);
+			Assert.Equal(expectedIndexes, series1.GroupedXValuesIndexes);
+			Assert.Equal(expectedIndexes, series2.GroupedXValuesIndexes);
+		}
+
+		[Fact]
+		public void GroupData_WithSingleSeries_ProducesCorrectResults()
+		{
+			var axis = new CategoryAxis();
+			var series1 = new LineSeries
+			{
+				ActualXValues = new List<string> { "Mon", "Tue", "Wed", "Thu", "Fri" },
+				ActualData = [10, 20, 30, 40, 50]
+			};
+
+			axis.RegisteredSeries = [series1];
+
+			axis.GroupData();
+
+			var expectedDistinctXValues = new List<string> { "Mon", "Tue", "Wed", "Thu", "Fri" };
+			var expectedIndexes = new List<double> { 0, 1, 2, 3, 4 };
+
+			Assert.Equal(expectedDistinctXValues, series1.GroupedXValues);
+			Assert.Equal(expectedIndexes, series1.GroupedXValuesIndexes);
+		}
+
+		[Fact]
+		public void GroupData_WithLargeDataset_CompletesWithCorrectResults()
+		{
+			var axis = new CategoryAxis();
+			int dataSize = 1000;
+			var xValues1 = new List<string>(dataSize);
+			var xValues2 = new List<string>(dataSize);
+			var data1 = new List<object>(dataSize);
+			var data2 = new List<object>(dataSize);
+
+			for (int i = 0; i < dataSize; i++)
+			{
+				xValues1.Add($"Item_{i}");
+				data1.Add(i);
+			}
+
+			for (int i = 500; i < dataSize + 500; i++)
+			{
+				xValues2.Add($"Item_{i}");
+				data2.Add(i);
+			}
+
+			var series1 = new LineSeries
+			{
+				ActualXValues = xValues1,
+				ActualData = data1
+			};
+
+			var series2 = new LineSeries
+			{
+				ActualXValues = xValues2,
+				ActualData = data2
+			};
+
+			axis.RegisteredSeries = [series1, series2];
+
+			axis.GroupData();
+
+			// Should have 1500 distinct values (0-999 from series1, 1000-1499 from series2)
+			Assert.Equal(1500, series1.GroupedXValues.Count);
+
+			// First series indexes should be 0..999
+			Assert.Equal(0.0, series1.GroupedXValuesIndexes[0]);
+			Assert.Equal(999.0, series1.GroupedXValuesIndexes[999]);
+
+			// Second series: "Item_500" should map to index 500
+			Assert.Equal(500.0, series2.GroupedXValuesIndexes[0]);
+		}
+
+		#endregion
+
     }
 }


### PR DESCRIPTION
### Root Cause of the Issue

The `CategoryAxis.GroupData()` method had two O(n²) performance bottlenecks:

1. **`List.Contains()` in a loop** (line 45): For each x-value, `groupingValues.Contains()` performs a linear scan of the list to check for duplicates — O(n) per call × n calls = O(n²).

2. **`List.IndexOf()` in a LINQ query** (lines 73, 77): For each value in a series, `distinctXValues.IndexOf(val)` performs a linear search — O(n) per call × n calls = O(n²).

For charts with large datasets (thousands of data points), these patterns cause noticeable delays during chart initialization and data grouping.

### Description of Change

- **Replaced `List.Contains()` with `HashSet.Add()`** — provides O(1) amortized lookup for deduplication while maintaining insertion order via the parallel list.
- **Built a `Dictionary<string, int>` index lookup** — maps each distinct x-value to its index for O(1) lookups instead of O(n) `List.IndexOf()` calls.
- **Used explicit pattern matching** for `ActualXValues` type checks (`is List<double>` instead of `as List<double>`).
- **Pre-allocated lists** with known capacity to reduce reallocations.

**Complexity improvement**: O(n²) → O(n) for the grouping operation.

### Unit Tests Added

5 new unit tests covering:
- Duplicate values produce correct indexes
- Double (numeric) x-values are handled correctly
- Multiple series with overlapping values deduplicate properly
- Single series produces sequential indexes
- Large dataset (1000+ items) completes with correct results

### Issues Fixed

N/A — Proactive performance improvement

### Screenshots

N/A — No visual changes