### PR TITLE
Perf: Eliminate unnecessary List allocations in Accordion control

### DIFF
--- a/maui/src/Accordion/AccordionItemView.cs
+++ b/maui/src/Accordion/AccordionItemView.cs
@@ -71,9 +71,21 @@ namespace Syncfusion.Maui.Toolkit.Accordion
 				return false;
 			}
 
-			var expandedItems = Accordion.Items.ToList().FindAll(x => x._accordionItemView != null && x._accordionItemView.IsExpanded);
+			var expandedCount = 0;
+			foreach (var item in Accordion.Items)
+			{
+				if (item._accordionItemView != null && item._accordionItemView.IsExpanded)
+				{
+					expandedCount++;
+					if (expandedCount > 1)
+					{
+						break;
+					}
+				}
+			}
+
 			return (Accordion.ExpandMode == AccordionExpandMode.Single ||
-					Accordion.ExpandMode == AccordionExpandMode.Multiple) && expandedItems.Count == 1;	
+					Accordion.ExpandMode == AccordionExpandMode.Multiple) && expandedCount == 1;	
         }
 
 		#endregion

--- a/maui/src/Accordion/SfAccordion.cs
+++ b/maui/src/Accordion/SfAccordion.cs
@@ -540,8 +540,22 @@ namespace Syncfusion.Maui.Toolkit.Accordion
 		/// </summary>
 		internal void UpdateSelection()
 		{
-			var selectedItems = Items.ToList().FindAll(x => x._accordionItemView != null && x._accordionItemView.IsSelected);
-			if (selectedItems.Count == 1 && Items[selectedItems[0]._itemIndex] is AccordionItem items && items._accordionItemView is AccordionItemView accordionItem)
+			AccordionItem? selectedItem = null;
+			int selectedCount = 0;
+			foreach (var item in Items)
+			{
+				if (item._accordionItemView != null && item._accordionItemView.IsSelected)
+				{
+					selectedItem ??= item;
+					selectedCount++;
+					if (selectedCount > 1)
+					{
+						break;
+					}
+				}
+			}
+
+			if (selectedCount == 1 && selectedItem != null && Items[selectedItem._itemIndex] is AccordionItem accordionItemEntry && accordionItemEntry._accordionItemView is AccordionItemView accordionItem)
 			{
 				accordionItem.IsSelected = false;
 			}
@@ -560,7 +574,15 @@ namespace Syncfusion.Maui.Toolkit.Accordion
 				return;
 			}
 
-			var expandedItems = Items.ToList().FindAll(x => x._accordionItemView != null && x._accordionItemView.IsExpanded);
+			var expandedItems = new List<AccordionItem>();
+			foreach (var item in Items)
+			{
+				if (item._accordionItemView != null && item._accordionItemView.IsExpanded)
+				{
+					expandedItems.Add(item);
+				}
+			}
+
 			switch (ExpandMode)
 			{
 				case AccordionExpandMode.Single:
@@ -1575,7 +1597,15 @@ namespace Syncfusion.Maui.Toolkit.Accordion
 		/// <param name="e">The <see cref="KeyEventArgs"/> containing the event data for the key that was pressed.</param>
 		void IKeyboardListener.OnKeyDown(KeyEventArgs e)
 		{
-			var selectedItem = Items.ToList().FirstOrDefault(x => x._accordionItemView != null && x._accordionItemView.IsSelected);
+			AccordionItem? selectedItem = null;
+		foreach (var item in Items)
+		{
+			if (item._accordionItemView != null && item._accordionItemView.IsSelected)
+			{
+				selectedItem = item;
+				break;
+			}
+		}
 			if (e.Key == KeyboardKey.Down || (e.Key == KeyboardKey.Tab && !e.IsShiftKeyPressed))
 			{
 				OnDownKeyPressed(selectedItem);

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Layout/SfAccordionUnitTests.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Layout/SfAccordionUnitTests.cs
@@ -1605,7 +1605,61 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 			InvokePrivateMethod(accordion, "UpdateSelection");
 			Assert.False(accordion.Items[0]._accordionItemView?.IsSelected);
 		}
-		
+
+		[Fact]
+		public void UpdateSelection_ShouldNotDeselect_WhenNoItemsAreSelected()
+		{
+			var accordion = new SfAccordion();
+			accordion.Items.Add(new AccordionItem { _itemIndex = 0, _accordionItemView = new AccordionItemView() });
+			accordion.Items.Add(new AccordionItem { _itemIndex = 1, _accordionItemView = new AccordionItemView() });
+			accordion.UpdateSelection();
+			// No exception thrown, items remain unselected
+			Assert.False(accordion.Items[0]._accordionItemView!.IsSelected);
+			Assert.False(accordion.Items[1]._accordionItemView!.IsSelected);
+		}
+
+		[Fact]
+		public void UpdateSelection_ShouldNotThrow_WhenItemsHaveNullAccordionItemView()
+		{
+			var accordion = new SfAccordion();
+			accordion.Items.Add(new AccordionItem { _itemIndex = 0 });
+			accordion.Items.Add(new AccordionItem { _itemIndex = 1 });
+			var exception = Record.Exception(() => accordion.UpdateSelection());
+			Assert.Null(exception);
+		}
+
+		[Fact]
+		public void UpdateAccordionItemsBasedOnExpandModes_SingleMode_CollapsesExtraItems_WhenMultipleExpanded()
+		{
+			var accordion = new SfAccordion
+			{
+				ExpandMode = AccordionExpandMode.Single
+			};
+			var item1 = new AccordionItem { _itemIndex = 0, _accordionItemView = new AccordionItemView { IsExpanded = true } };
+			var item2 = new AccordionItem { _itemIndex = 1, _accordionItemView = new AccordionItemView { IsExpanded = true } };
+			var item3 = new AccordionItem { _itemIndex = 2, _accordionItemView = new AccordionItemView { IsExpanded = true } };
+			accordion.Items.Add(item1);
+			accordion.Items.Add(item2);
+			accordion.Items.Add(item3);
+			accordion.IsViewLoaded = true;
+			accordion.UpdateAccordionItemsBasedOnExpandModes(false);
+			// After collapsing extras, items at indices 0 and 1 should be collapsed (IsExpanded set on AccordionItem)
+			Assert.False(item1.IsExpanded);
+			Assert.False(item2.IsExpanded);
+		}
+
+		[Fact]
+		public void UpdateAccordionItemsBasedOnExpandModes_EmptyItems_ShouldNotThrow()
+		{
+			var accordion = new SfAccordion
+			{
+				ExpandMode = AccordionExpandMode.Single
+			};
+			accordion.IsViewLoaded = true;
+			var exception = Record.Exception(() => accordion.UpdateAccordionItemsBasedOnExpandModes(false));
+			Assert.Null(exception);
+		}
+
 		#endregion
 
 	}


### PR DESCRIPTION
### Root Cause of the Issue

The `SfAccordion` and `AccordionItemView` classes used `Items.ToList().FindAll()` and `Items.ToList().FirstOrDefault()` patterns in multiple methods. Since `Items` is an `ObservableCollection<AccordionItem>`, calling `.ToList()` allocates a full copy of the collection on every invocation — only to immediately filter or search it. This creates unnecessary GC pressure during user interactions (expand/collapse, keyboard navigation).

### Description of Change

Replaced all `Items.ToList().FindAll(predicate)` and `Items.ToList().FirstOrDefault(predicate)` calls with direct `foreach` iteration over the `ObservableCollection`:

| Method | Before | After |
|--------|--------|-------|
| `SfAccordion.UpdateSelection()` | `Items.ToList().FindAll(...)` | `foreach` with counter |
| `SfAccordion.UpdateAccordionItemsBasedOnExpandModes()` | `Items.ToList().FindAll(...)` | `foreach` building filtered list directly |
| `SfAccordion.OnKeyDown()` | `Items.ToList().FirstOrDefault(...)` | `foreach` with early `break` |
| `AccordionItemView.CanCollapseItemOnSingleAndMultipleExpandMode()` | `Accordion.Items.ToList().FindAll(...)` | `foreach` with counter and early exit |

**Impact:** Eliminates 4 unnecessary `List<T>` allocations per operation, reducing GC pressure during accordion interactions.

**Unit tests added:** 4 new tests covering edge cases for the refactored methods.

### Issues Fixed

N/A (performance improvement)

### Screenshots

N/A (no visual changes)