### PR TITLE
Perf: Hoist ToList() out of loops in CartesianChartArea.UpdateSBS and GetTotalWidth

### DIFF
--- a/maui/src/Charts/Area/Partial/CartesianChartArea.cs
+++ b/maui/src/Charts/Area/Partial/CartesianChartArea.cs
@@ -184,7 +184,6 @@ namespace Syncfusion.Maui.Toolkit.Charts
 			{
 				double totalWidth = GetTotalWidth() / SideBySideSeriesPosition.Count;
 				double startPosition = 0, end = 0;
-				var seriesGroups = SideBySideSeriesPosition.Values.ToList();
 
 				var seriesPositionValues = SideBySideSeriesPosition.Values.ToList();
 				for (int i = 0; i < SideBySideSeriesPosition.Count; i++)

--- a/maui/src/Charts/Area/Partial/CartesianChartArea.cs
+++ b/maui/src/Charts/Area/Partial/CartesianChartArea.cs
@@ -182,10 +182,11 @@ namespace Syncfusion.Maui.Toolkit.Charts
 			{
 				double totalWidth = GetTotalWidth() / SideBySideSeriesPosition.Count;
 				double startPosition = 0, end = 0;
+				var seriesGroups = SideBySideSeriesPosition.Values.ToList();
 
-				for (int i = 0; i < SideBySideSeriesPosition.Count; i++)
+				for (int i = 0; i < seriesGroups.Count; i++)
 				{
-					var seriesGroup = SideBySideSeriesPosition.Values.ToList()[i];
+					var seriesGroup = seriesGroups[i];
 					double sbsMaxWidth = GetSBSMaxWidth(seriesGroup);
 
 					foreach (ChartSeries chartSeries in seriesGroup)
@@ -370,10 +371,11 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 			if (SideBySideSeriesPosition != null)
 			{
-				for (int i = 0; i < SideBySideSeriesPosition.Count; i++)
+				var seriesGroups = SideBySideSeriesPosition.Values.ToList();
+				for (int i = 0; i < seriesGroups.Count; i++)
 				{
 					double maxWidth = 0;
-					foreach (ChartSeries sideBySideSeries in SideBySideSeriesPosition.Values.ToList()[i])
+					foreach (ChartSeries sideBySideSeries in seriesGroups[i])
 					{
 						CartesianSeries cartesianSeries = (CartesianSeries)sideBySideSeries;
 						double width = cartesianSeries.GetActualWidth();

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Chart/Features/ChartAreaUnitTest.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Chart/Features/ChartAreaUnitTest.cs
@@ -50,6 +50,33 @@ namespace Syncfusion.Maui.Toolkit.UnitTest.Charts
 
 
 		[Fact]
+		public void UpdateSBS_WithMultipleSeriesGroups_ShouldComputeSbsInfo()
+		{
+			var chart = new SfCartesianChart();
+			var series1 = new ColumnSeries() { Width = 0.8 };
+			var series2 = new ColumnSeries() { Width = 0.8 };
+			var series3 = new ColumnSeries() { Width = 0.6 };
+
+			var area = new CartesianChartArea(chart)
+			{
+				SideBySideSeriesPosition = new Dictionary<object, List<CartesianSeries>>
+				{
+					{ 0, new List<CartesianSeries> { series1, series2 } },
+					{ 1, new List<CartesianSeries> { series3 } }
+				},
+				EnableSideBySideSeriesPlacement = false,
+				SideBySideMinWidth = 1
+			};
+
+			area.UpdateSBS();
+
+			// Verify SbsInfo is set on each series
+			Assert.NotEqual(DoubleRange.Empty, series1.SbsInfo);
+			Assert.NotEqual(DoubleRange.Empty, series2.SbsInfo);
+			Assert.NotEqual(DoubleRange.Empty, series3.SbsInfo);
+		}
+
+		[Fact]
 		public void AddAxes_ShouldSetParentAndArea()
 		{
 			var axisArea = new CartesianChartArea(new SfCartesianChart());


### PR DESCRIPTION
### Root Cause of the Issue

In `CartesianChartArea.cs`, both `UpdateSBS()` and `GetTotalWidth()` called `SideBySideSeriesPosition.Values.ToList()[i]` **inside** a for-loop. This creates a brand new `List<List<CartesianSeries>>` on every iteration just to index into it — resulting in O(n) unnecessary heap allocations where only 1 is needed.

For charts with many series groups, this wastes memory and puts pressure on the garbage collector during layout calculations.

### Description of Change

Hoisted the `.Values.ToList()` call **before** the loop in both methods, materializing the dictionary values once and reusing the cached list for indexed access.

**Before (called N times):**
```csharp
for (int i = 0; i < SideBySideSeriesPosition.Count; i++)
{
    var seriesGroup = SideBySideSeriesPosition.Values.ToList()[i]; // allocates every iteration
}
```

**After (called once):**
```csharp
var seriesGroups = SideBySideSeriesPosition.Values.ToList(); // single allocation
for (int i = 0; i < seriesGroups.Count; i++)
{
    var seriesGroup = seriesGroups[i];
}
```

Also added a unit test `UpdateSBS_WithMultipleSeriesGroups_ShouldComputeSbsInfo` to verify correct behavior with multiple series groups.

### Issues Fixed

Performance improvement — no specific issue.

### Screenshots
N/A — internal performance optimization with no visual change.