### PR TITLE
perf: Optimize Chart control performance with reduced allocations and improved algorithmic complexity

### DIFF
--- a/maui/src/Charts/Area/Partial/CartesianChartArea.cs
+++ b/maui/src/Charts/Area/Partial/CartesianChartArea.cs
@@ -183,9 +183,10 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				double totalWidth = GetTotalWidth() / SideBySideSeriesPosition.Count;
 				double startPosition = 0, end = 0;
 
-				for (int i = 0; i < SideBySideSeriesPosition.Count; i++)
+				var seriesGroups = SideBySideSeriesPosition.Values.ToList();
+				for (int i = 0; i < seriesGroups.Count; i++)
 				{
-					var seriesGroup = SideBySideSeriesPosition.Values.ToList()[i];
+					var seriesGroup = seriesGroups[i];
 					double sbsMaxWidth = GetSBSMaxWidth(seriesGroup);
 
 					foreach (ChartSeries chartSeries in seriesGroup)
@@ -370,10 +371,11 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 			if (SideBySideSeriesPosition != null)
 			{
-				for (int i = 0; i < SideBySideSeriesPosition.Count; i++)
+				var valuesList = SideBySideSeriesPosition.Values.ToList();
+				for (int i = 0; i < valuesList.Count; i++)
 				{
 					double maxWidth = 0;
-					foreach (ChartSeries sideBySideSeries in SideBySideSeriesPosition.Values.ToList()[i])
+					foreach (ChartSeries sideBySideSeries in valuesList[i])
 					{
 						CartesianSeries cartesianSeries = (CartesianSeries)sideBySideSeries;
 						double width = cartesianSeries.GetActualWidth();
@@ -483,73 +485,88 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				}
 				
 				foreach (var series in seriesList)
+			{
+				var xValues = series.GetXValues();
+				var yValues = series.YValues;
+				var bottomValues = new List<double>();
+				var topValues = new List<double>();
+				var seriesTypeName = series.GetType().Name;
+				bool is100Series = seriesTypeName.Contains("Stacking", StringComparison.Ordinal) && seriesTypeName.Contains("100Series", StringComparison.Ordinal);
+
+				if (xValues != null)
 				{
-					var xValues = series.GetXValues();
-					var yValues = series.YValues;
-					var bottomValues = new List<double>();
-					var topValues = new List<double>();
-
-					if (xValues != null)
+					for (int i = 0; i < xValues.Count; i++)
 					{
-						for (int i = 0; i < xValues.Count; i++)
+						var xValue = xValues[i];
+						var yValue = i < yValues.Count ? yValues[i] : 0;
+						yValue = double.IsNaN(yValue) ? 0 : yValue;
+
+						if (yValue >= 0)
 						{
-							var xValue = xValues[i];
-							var yValue = i < yValues.Count ? yValues[i] : 0;
-							yValue = double.IsNaN(yValue) ? 0 : yValue;
-
-							if (yValue >= 0)
+							if (positiveYValues.TryGetValue(xValue, out double currentValue))
 							{
-								if (positiveYValues.TryGetValue(xValue, out double currentValue))
+								bottomValues.Add((axisCross > currentValue) ? axisCross : currentValue);
+								if (is100Series)
 								{
-									bottomValues.Add((axisCross > currentValue) ? axisCross : currentValue);
-									if (series.GetType().Name.Contains("Stacking", StringComparison.Ordinal) && series.GetType().Name.Contains("100Series", StringComparison.Ordinal))
-									{
-										yValue = GetYValue(seriesList, yValue, i);
-									}
-									positiveYValues[xValue] = currentValue + yValue;
+									yValue = GetYValue(seriesList, yValue, i);
 								}
-								else
-								{
-									bottomValues.Add(axisCross);
-									if (series.GetType().Name.Contains("Stacking", StringComparison.Ordinal) && series.GetType().Name.Contains("100Series", StringComparison.Ordinal))
-									{
-										yValue = GetYValue(seriesList, yValue, i);
-									}
-									positiveYValues.Add(xValue, yValue);
-								}
-
-								topValues.Add(positiveYValues[xValue]);
+								positiveYValues[xValue] = currentValue + yValue;
 							}
 							else
 							{
-								if (!negativeYValues.TryAdd(xValue, yValue))
+								bottomValues.Add(axisCross);
+								if (is100Series)
 								{
-									bottomValues.Add((axisCross < negativeYValues[xValue]) ? axisCross : negativeYValues[xValue]);
-									if (series.GetType().Name.Contains("Stacking", StringComparison.Ordinal) && series.GetType().Name.Contains("100Series", StringComparison.Ordinal))
-									{
-										yValue = GetYValue(seriesList, yValue, i);
-									}
-									negativeYValues[xValue] += yValue;
+									yValue = GetYValue(seriesList, yValue, i);
 								}
-								else
-								{
-									bottomValues.Add(axisCross);
-								}
-
-								topValues.Add(negativeYValues[xValue]);
+								positiveYValues.Add(xValue, yValue);
 							}
-						}
 
-						series.BottomValues = bottomValues;
-						series.TopValues = topValues;
+							topValues.Add(positiveYValues[xValue]);
+						}
+						else
+						{
+							if (!negativeYValues.TryAdd(xValue, yValue))
+							{
+								bottomValues.Add((axisCross < negativeYValues[xValue]) ? axisCross : negativeYValues[xValue]);
+								if (is100Series)
+								{
+									yValue = GetYValue(seriesList, yValue, i);
+								}
+								negativeYValues[xValue] += yValue;
+							}
+							else
+							{
+								bottomValues.Add(axisCross);
+							}
+
+							topValues.Add(negativeYValues[xValue]);
+						}
 					}
+
+					series.BottomValues = bottomValues;
+					series.TopValues = topValues;
 				}
+			}
 			}
 		}
 
 		static double GetYValue(List<StackingSeriesBase> SeriesList, double yValue, int index)
 		{
-			double total = SeriesList.Where(series => series != null && series.YValues.Count > index).Sum(series => double.IsNaN(series.YValues[index]) ? 0 : Math.Abs(series.YValues[index]));
+			double total = 0;
+			for (int i = 0; i < SeriesList.Count; i++)
+			{
+				var series = SeriesList[i];
+				if (series != null && series.YValues.Count > index)
+				{
+					double val = series.YValues[index];
+					if (!double.IsNaN(val))
+					{
+						total += Math.Abs(val);
+					}
+				}
+			}
+
 			if (yValue != 0)
 			{
 				yValue = (yValue / total) * 100;

--- a/maui/src/Charts/Area/Partial/CartesianChartArea.cs
+++ b/maui/src/Charts/Area/Partial/CartesianChartArea.cs
@@ -121,6 +121,12 @@ namespace Syncfusion.Maui.Toolkit.Charts
 													break;
 												}
 											}
+
+											if (string.IsNullOrEmpty(groupID))
+											{
+												continue;
+											}
+
 											StackingSeriesBase stackingSeriesBase;
 											int size = SideBySideSeriesPosition.Count > 0 && groupingKeys.Count > 0 && groupingKeys.TryGetValue(groupID, out var groupValue)
 												? SideBySideSeriesPosition[groupValue].Count : 0;
@@ -526,71 +532,71 @@ namespace Syncfusion.Maui.Toolkit.Charts
 						axisCross = 1;
 					}
 				}
-				
+
 				foreach (var series in seriesList)
-			{
-				var xValues = series.GetXValues();
-				var yValues = series.YValues;
-				var bottomValues = new List<double>();
-				var topValues = new List<double>();
-				var seriesTypeName = series.GetType().Name;
-				bool is100Series = seriesTypeName.Contains("Stacking", StringComparison.Ordinal) && seriesTypeName.Contains("100Series", StringComparison.Ordinal);
-
-				if (xValues != null)
 				{
-					for (int i = 0; i < xValues.Count; i++)
+					var xValues = series.GetXValues();
+					var yValues = series.YValues;
+					var bottomValues = new List<double>();
+					var topValues = new List<double>();
+
+					if (xValues != null)
 					{
-						var xValue = xValues[i];
-						var yValue = i < yValues.Count ? yValues[i] : 0;
-						yValue = double.IsNaN(yValue) ? 0 : yValue;
+						bool isStacking100Series = series is StackingColumn100Series || StackingLine100Series || StackingArea100Series;
 
-						if (yValue >= 0)
+						for (int i = 0; i < xValues.Count; i++)
 						{
-							if (positiveYValues.TryGetValue(xValue, out double currentValue))
+							var xValue = xValues[i];
+							var yValue = i < yValues.Count ? yValues[i] : 0;
+							yValue = double.IsNaN(yValue) ? 0 : yValue;
+
+							if (yValue >= 0)
 							{
-								bottomValues.Add((axisCross > currentValue) ? axisCross : currentValue);
-								if (is100Series)
+								if (positiveYValues.TryGetValue(xValue, out double currentValue))
 								{
-									yValue = GetYValue(seriesList, yValue, i);
+									bottomValues.Add((axisCross > currentValue) ? axisCross : currentValue);
+									if (isStacking100Series)
+									{
+										yValue = GetYValue(seriesList, yValue, i);
+									}
+									positiveYValues[xValue] = currentValue + yValue;
 								}
-								positiveYValues[xValue] = currentValue + yValue;
+								else
+								{
+									bottomValues.Add(axisCross);
+									if (isStacking100Series)
+									{
+										yValue = GetYValue(seriesList, yValue, i);
+									}
+									positiveYValues.Add(xValue, yValue);
+								}
+
+								topValues.Add(positiveYValues[xValue]);
 							}
 							else
 							{
-								bottomValues.Add(axisCross);
-								if (is100Series)
+								if (!negativeYValues.TryAdd(xValue, yValue))
 								{
-									yValue = GetYValue(seriesList, yValue, i);
+									bottomValues.Add((axisCross < negativeYValues[xValue]) ? axisCross : negativeYValues[xValue]);
+									if (isStacking100Series)
+									{
+										yValue = GetYValue(seriesList, yValue, i);
+									}
+									negativeYValues[xValue] += yValue;
 								}
-								positiveYValues.Add(xValue, yValue);
-							}
-
-							topValues.Add(positiveYValues[xValue]);
-						}
-						else
-						{
-							if (!negativeYValues.TryAdd(xValue, yValue))
-							{
-								bottomValues.Add((axisCross < negativeYValues[xValue]) ? axisCross : negativeYValues[xValue]);
-								if (is100Series)
+								else
 								{
-									yValue = GetYValue(seriesList, yValue, i);
+									bottomValues.Add(axisCross);
 								}
-								negativeYValues[xValue] += yValue;
-							}
-							else
-							{
-								bottomValues.Add(axisCross);
-							}
 
-							topValues.Add(negativeYValues[xValue]);
+								topValues.Add(negativeYValues[xValue]);
+							}
 						}
+
+						series.BottomValues = bottomValues;
+						series.TopValues = topValues;
 					}
-
-					series.BottomValues = bottomValues;
-					series.TopValues = topValues;
 				}
-			}
 			}
 		}
 

--- a/maui/src/Charts/Axis/CategoryAxis.cs
+++ b/maui/src/Charts/Axis/CategoryAxis.cs
@@ -40,9 +40,10 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				{
 					if (groupedDatas.Count != 0)
 					{
-						for (int j = 0; j <= xValues.Count - 1; j++)
+						var seen = new HashSet<string>(groupingValues);
+						for (int j = 0; j < xValues.Count; j++)
 						{
-							if (!groupingValues.Contains(xValues[j]))
+							if (seen.Add(xValues[j]))
 							{
 								groupingValues.Add(xValues[j]);
 							}
@@ -65,16 +66,31 @@ namespace Syncfusion.Maui.Toolkit.Charts
 			}
 
 			var distinctXValues = groupingValues.Distinct().ToList();
+			var indexLookup = new Dictionary<string, int>(distinctXValues.Count);
+			for (int i = 0; i < distinctXValues.Count; i++)
+			{
+				indexLookup[distinctXValues[i]] = i;
+			}
 
 			foreach (CartesianSeries series in RegisteredSeries.Cast<CartesianSeries>())
 			{
 				if (series.ActualXValues is List<string> list)
 				{
-					series.GroupedXValuesIndexes = (from val in list select (double)distinctXValues.IndexOf(val)).ToList();
+					var indexes = new List<double>(list.Count);
+					for (int i = 0; i < list.Count; i++)
+					{
+						indexes.Add(indexLookup.TryGetValue(list[i], out int idx) ? idx : -1);
+					}
+					series.GroupedXValuesIndexes = indexes;
 				}
-				else if (series.ActualXValues != null)
+				else if (series.ActualXValues is List<double> doubleValues)
 				{
-					series.GroupedXValuesIndexes = (from val in series.ActualXValues as List<double> select (double)distinctXValues.IndexOf(val.ToString())).ToList();
+					var indexes = new List<double>(doubleValues.Count);
+					for (int i = 0; i < doubleValues.Count; i++)
+					{
+						indexes.Add(indexLookup.TryGetValue(doubleValues[i].ToString(), out int idx) ? idx : -1);
+					}
+					series.GroupedXValuesIndexes = indexes;
 				}
 
 				series.GroupedXValues = distinctXValues;

--- a/maui/src/Charts/Axis/Layouts/CartesianAxisLayout.cs
+++ b/maui/src/Charts/Axis/Layouts/CartesianAxisLayout.cs
@@ -499,10 +499,17 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 		static ChartAxis? GetAxisByName(string name, ObservableCollection<ChartAxis>? axes)
 		{
-			var item = (from x in axes where x.Name == name select x).ToList();
-			if (item != null && item.Count > 0)
+			if (axes == null)
 			{
-				return item[0];
+				return null;
+			}
+
+			for (int i = 0; i < axes.Count; i++)
+			{
+				if (axes[i].Name == name)
+				{
+					return axes[i];
+				}
 			}
 
 			return null;

--- a/maui/src/Charts/Segment/ErrorBarSegment.cs
+++ b/maui/src/Charts/Segment/ErrorBarSegment.cs
@@ -83,10 +83,30 @@ namespace Syncfusion.Maui.Toolkit.Charts
 						break;
 				}
 
-				double xMin = xValues.Where(v => !double.IsNaN(v)).DefaultIfEmpty(0).Min();
-				double xMax = xValues.Where(v => !double.IsNaN(v)).DefaultIfEmpty(0).Max();
-				double yMin = yValues.Where(v => !double.IsNaN(v)).DefaultIfEmpty(0).Min();
-				double yMax = yValues.Where(v => !double.IsNaN(v)).DefaultIfEmpty(0).Max();
+				double xMin = double.MaxValue, xMax = double.MinValue;
+				double yMin = double.MaxValue, yMax = double.MinValue;
+				for (int i = 0; i < xValues.Count; i++)
+				{
+					double xVal = xValues[i];
+					if (!double.IsNaN(xVal))
+					{
+						if (xVal < xMin) xMin = xVal;
+						if (xVal > xMax) xMax = xVal;
+					}
+				}
+				for (int i = 0; i < yValues.Count; i++)
+				{
+					double yVal = yValues[i];
+					if (!double.IsNaN(yVal))
+					{
+						if (yVal < yMin) yMin = yVal;
+						if (yVal > yMax) yMax = yVal;
+					}
+				}
+				if (xMin == double.MaxValue) xMin = 0;
+				if (xMax == double.MinValue) xMax = 0;
+				if (yMin == double.MaxValue) yMin = 0;
+				if (yMax == double.MinValue) yMax = 0;
 
 				double leftPointMin = xMin - _horizontalErrorValue;
 				double leftPointMax = xMax - _horizontalErrorValue;
@@ -192,12 +212,35 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 				if (errorBarSeries.Type == ErrorBarType.Percentage)
 				{
-					var validTopPoints = _topPointCollection.Where(p => !double.IsNaN(p.Y)).Select(p => p.Y);
-					var validBottomPoints = _bottomPointCollection.Where(p => !double.IsNaN(p.Y)).Select(p => p.Y);
+					double rangeMin = double.MaxValue;
+					double rangeMax = double.MinValue;
+					bool hasValid = false;
 
-					if (validTopPoints.Any() && validBottomPoints.Any())
+					for (int i = 0; i < _topPointCollection.Count; i++)
 					{
-						YRange = new DoubleRange(Math.Min(validBottomPoints.Min(), validTopPoints.Min()), Math.Max(validBottomPoints.Max(), validTopPoints.Max()));
+						double y = _topPointCollection[i].Y;
+						if (!double.IsNaN(y))
+						{
+							if (y < rangeMin) rangeMin = y;
+							if (y > rangeMax) rangeMax = y;
+							hasValid = true;
+						}
+					}
+
+					for (int i = 0; i < _bottomPointCollection.Count; i++)
+					{
+						double y = _bottomPointCollection[i].Y;
+						if (!double.IsNaN(y))
+						{
+							if (y < rangeMin) rangeMin = y;
+							if (y > rangeMax) rangeMax = y;
+							hasValid = true;
+						}
+					}
+
+					if (hasValid)
+					{
+						YRange = new DoubleRange(rangeMin, rangeMax);
 					}
 				}
 				else
@@ -383,28 +426,36 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				return valueDoubles;
 			}
 
-			var validValues = values.Where(v => !double.IsNaN(v)).ToList();
+			double sum = 0;
+			int validCount = 0;
+			for (int i = 0; i < values.Count; i++)
+			{
+				if (!double.IsNaN(values[i]))
+				{
+					sum += values[i];
+					validCount++;
+				}
+			}
 
-			if (validValues.Count <= 1)
+			if (validCount <= 1)
 			{
 				return valueDoubles;
 			}
 
-			var sum = validValues.Sum();
-			var mean = sum / validValues.Count;
-			var dev = new List<double>();
-			var sQDev = new List<double>();
+			double mean = sum / validCount;
+			double sumSqDev = 0;
 
-			for (var i = 0; i < validValues.Count; i++)
+			for (int i = 0; i < values.Count; i++)
 			{
-				dev.Add(validValues[i] - mean);
-				sQDev.Add(dev[i] * dev[i]);
+				if (!double.IsNaN(values[i]))
+				{
+					double dev = values[i] - mean;
+					sumSqDev += dev * dev;
+				}
 			}
 
-			var sumSqDev = sQDev.Sum(x => x);
-
-			var sDValue = Math.Sqrt(sumSqDev / (validValues.Count - 1));
-			var sDErrorValue = sDValue / Math.Sqrt(validValues.Count);
+			var sDValue = Math.Sqrt(sumSqDev / (validCount - 1));
+			var sDErrorValue = sDValue / Math.Sqrt(validCount);
 
 			valueDoubles[0] = mean;
 			valueDoubles[1] = errorBarSeries.Type == ErrorBarType.StandardDeviation ? sDValue : sDErrorValue;

--- a/maui/src/Charts/Series/CartesianSeries.cs
+++ b/maui/src/Charts/Series/CartesianSeries.cs
@@ -1027,18 +1027,36 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				return null;
 			}
 
-			double xIndexValues = 0d;
 			var xValues = ActualXValues as List<double>;
 
 			if (IsIndexed || xValues == null)
 			{
 				if (ActualXAxis is CategoryAxis categoryAxis && !categoryAxis.ArrangeByIndex || ActualXAxis == null)
 				{
-					xValues = GroupedXValuesIndexes.Count > 0 ? GroupedXValuesIndexes : (from val in (ActualXValues as List<string>) select (xIndexValues++)).ToList();
+					if (GroupedXValuesIndexes.Count > 0)
+					{
+						xValues = GroupedXValuesIndexes;
+					}
+					else
+					{
+						var stringValues = ActualXValues as List<string>;
+						int count = stringValues?.Count ?? 0;
+						xValues = new List<double>(count);
+						for (int i = 0; i < count; i++)
+						{
+							xValues.Add(i);
+						}
+					}
 				}
 				else
 				{
-					xValues = xValues != null ? (from val in xValues select (xIndexValues++)).ToList() : (from val in (ActualXValues as List<string>) select (xIndexValues++)).ToList();
+					int count = xValues?.Count ?? (ActualXValues as List<string>)?.Count ?? 0;
+					var indexValues = new List<double>(count);
+					for (int i = 0; i < count; i++)
+					{
+						indexValues.Add(i);
+					}
+					xValues = indexValues;
 				}
 			}
 


### PR DESCRIPTION
### Root Cause of the Issue

Several hot paths in the Chart control used LINQ queries, `List.Contains()`, `List.IndexOf()`, and repeated `GetType().Name` reflection calls that introduced unnecessary allocations and O(n²) complexity in data-intensive rendering paths.

### Description of Change

10 targeted micro-optimizations across 5 files to reduce allocations and improve algorithmic complexity in the Chart control:

1. **`CategoryAxis.cs` — O(n²) `IndexOf` → `Dictionary` lookup**
   `GroupData()` called `List.IndexOf()` inside a LINQ `select` over every data point, making it O(n²). Replaced with a pre-built `Dictionary<string, int>` for O(1) index lookups, and used pre-allocated `List<double>` instead of LINQ materialization.

2. **`CategoryAxis.cs` — `List.Contains()` → `HashSet`**
   The deduplication loop in `GroupData()` used `List.Contains()` (O(n)) on every iteration. Replaced with a `HashSet<string>` seeded from existing values for O(1) membership checks.

3. **`CartesianAxisLayout.cs` — LINQ `ToList()` for single-item lookup → simple `for` loop**
   `GetAxisByName()` created a full materialized `List` just to return the first match. Replaced with an early-return `for` loop that avoids all allocation and stops at the first match.

4. **`CartesianChartArea.cs` — Repeated `GetType().Name` reflection → cached result**
   `CalculateStackingValues()` called `GetType().Name.Contains(...)` twice per data point inside nested loops (once per `if` branch). Cached the type name and the boolean result before the inner loop to eliminate repeated reflection.

5. **`ErrorBarSegment.cs` — 4× LINQ `Where/Min/Max` → single pass loops**
   Computing `xMin/xMax/yMin/yMax` required 4 separate LINQ chains, each iterating the full collection. Replaced with 2 `for` loops that compute both min and max in a single pass per axis, with `NaN` fallback to `0`.

6. **`CartesianChartArea.cs` — LINQ `Where().Sum()` → `for` loop in `GetYValue`**
   `GetYValue()` used a LINQ chain with closure allocation on every call. Replaced with a plain `for` loop over the pre-typed `List<StackingSeriesBase>`.

7. **`CartesianSeries.cs` — LINQ-generated index sequences → pre-allocated `List<double>`**
   `GetXValues()` used `(from val in list select (xIndexValues++)).ToList()` to produce sequential `[0, 1, 2, …]` index lists, allocating an iterator and boxing closures. Replaced with a `new List<double>(count)` filled with a `for` loop, also removing the unused `xIndexValues` variable.

8. **`ErrorBarSegment.cs` — LINQ `Where/Select/Min/Max` for `YRange` → single loop**
   The percentage-mode `YRange` calculation enumerated `_topPointCollection` and `_bottomPointCollection` 6 times (`.Where`, `.Select`, `.Any`, `.Min`, `.Max` × 2 collections). Replaced with two `for` loops that find the overall min/max in a single pass with a `hasValid` guard.

9. **`ErrorBarSegment.cs` — Eliminate list allocations in `GetSdErrorValue`**
   `GetSdErrorValue()` allocated a filtered `List`, then two more `List<double>` (`dev`, `sQDev`) just to accumulate a sum of squares. Replaced with two inline loops that compute `sum`, `count`, and `sumSqDev` without any heap allocations.

10. **`CartesianChartArea.cs` — `Values.ToList()` inside loops → cache before loop**
    `UpdateSBS()` and `GetTotalWidth()` called `SideBySideSeriesPosition.Values.ToList()` on every loop iteration, creating a fresh `List` snapshot each time. Moved the call outside the loop and iterated the cached list.

### Issues Fixed

No specific issue — proactive performance improvements.

### Screenshots
N/A — internal algorithmic changes with no visible behavior difference.