### PR TITLE
Perf: Reduce allocations across 5 controls with targeted optimizations

### DIFF
--- a/maui/src/Carousel/Platform/iOS/PlatformCarousel.iOS.cs
+++ b/maui/src/Carousel/Platform/iOS/PlatformCarousel.iOS.cs
@@ -879,7 +879,12 @@ namespace Syncfusion.Maui.Toolkit.Carousel
         void EnableOrDisableInteraction()
         {
             UserInteractionEnabled = IsInteractionEnable();
-            Subviews.ToList().ForEach(subView => subView.UserInteractionEnabled = IsInteractionEnable());
+            bool interactionEnabled = IsInteractionEnable();
+            foreach (var subView in Subviews)
+            {
+                subView.UserInteractionEnabled = interactionEnabled;
+            }
+
             OnEnableInteractionPropertyChanged();
         }
 

--- a/maui/src/Core/BaseView/DrawableLayoutView/SfView.cs
+++ b/maui/src/Core/BaseView/DrawableLayoutView/SfView.cs
@@ -137,7 +137,7 @@ namespace Syncfusion.Maui.Toolkit
 		}
 
 		/// <exclude/>
-		IReadOnlyList<IVisualTreeElement> IVisualTreeElement.GetVisualChildren() => Children.Cast<IVisualTreeElement>().ToList().AsReadOnly();
+		IReadOnlyList<IVisualTreeElement> IVisualTreeElement.GetVisualChildren() => new List<IVisualTreeElement>(Children.Cast<IVisualTreeElement>());
 
 		/// <exclude/>
 		bool Microsoft.Maui.ILayout.ClipsToBounds => ClipToBounds;

--- a/maui/src/OtpInput/SfOtpInput.cs
+++ b/maui/src/OtpInput/SfOtpInput.cs
@@ -1862,22 +1862,25 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 				return;
 			}
 
-			for (int i = oldLength; i < newLength; i++)
-			{
-				if (i < newLength && i is not 0)
+				var entriesList = new List<OTPEntry>(_otpEntries);
+				for (int i = oldLength; i < newLength; i++)
 				{
-					SfLabel label = InitializeSeparator();
-					SetSeparatorPosition(i, label);
-					layout?.Children.Add(label);
+					if (i < newLength && i is not 0)
+					{
+						SfLabel label = InitializeSeparator();
+						SetSeparatorPosition(i, label);
+						layout?.Children.Add(label);
+					}
+
+					OTPEntry otpEntry = InitializeEntry();
+					AttachEvents(otpEntry);
+					entriesList.Add(otpEntry);
+					SetInputFieldPosition(i, otpEntry);
+					layout?.Children.Add(otpEntry);
 				}
 
-				OTPEntry otpEntry = InitializeEntry();
-				AttachEvents(otpEntry);
-                _otpEntries = _otpEntries.Concat(new[] { otpEntry }).ToArray();
-				SetInputFieldPosition(i, otpEntry);
-				layout?.Children.Add(otpEntry);
+				_otpEntries = entriesList.ToArray();
 			}
-		}
 
 		/// <summary>
 		/// Sets the position of an OTP input field within the SfOtpInput control.
@@ -1891,19 +1894,22 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 				return;
 			}
 
-			RectF rect = new RectF(
-				(_entryWidth + _spacing) * i,
-				0,
-				_entryWidth,
-				_entryHeight);
-
-			_entryBounds = _entryBounds.Concat(new[] { rect }).ToArray();
-			AbsoluteLayout.SetLayoutBounds(otpEntry, new Rect(rect.X, rect.Y, rect.Width, rect.Height));
-
 			float entryX = ((_entryWidth + _spacing) * i) + _extraSpacing;
-			float entryY = _extraSpacing ;
-			_entryBounds[i] = new RectF(entryX, entryY, _entryWidth, _entryHeight);
-			AbsoluteLayout.SetLayoutBounds(otpEntry, new Rect(_entryBounds[i].X, _entryBounds[i].Y, _entryBounds[i].Width, _entryBounds[i].Height));
+			float entryY = _extraSpacing;
+			var bounds = new RectF(entryX, entryY, _entryWidth, _entryHeight);
+
+			var boundsList = new List<RectF>(_entryBounds);
+			if (i < boundsList.Count)
+			{
+				boundsList[i] = bounds;
+			}
+			else
+			{
+				boundsList.Add(bounds);
+			}
+
+			_entryBounds = boundsList.ToArray();
+			AbsoluteLayout.SetLayoutBounds(otpEntry, new Rect(bounds.X, bounds.Y, bounds.Width, bounds.Height));
 		}
 
 		/// <summary>
@@ -1917,7 +1923,9 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 			float separatorX = entryX + _entryWidth + _spacing / 2;
 			RectF separatorRect = new RectF(separatorX, 0, _separatorWidth, _separatorHeight);
 
-			_separators = _separators.Concat(new[] { label }).ToArray();
+			var separatorsList = new List<SfLabel>(_separators);
+			separatorsList.Add(label);
+			_separators = separatorsList.ToArray();
 			AbsoluteLayout.SetLayoutBounds(label, new Rect(separatorRect.X, separatorRect.Y, separatorRect.Width, separatorRect.Height));
 		}
 

--- a/maui/src/Picker/Helper/DatePickerHelper.cs
+++ b/maui/src/Picker/Helper/DatePickerHelper.cs
@@ -383,17 +383,17 @@ namespace Syncfusion.Maui.Toolkit.Picker
                 return monthIndex;
             }
 
-            List<string> monthStrings = new List<string>();
+            string[]? monthNames = null;
             bool isAbbreviatedMonth = format == "MMM";
             bool isFullMonth = format == "MMMM";
             bool isMonthDay = format == "MM_ddd";
             if (isFullMonth)
             {
-                monthStrings = DateTimeFormatInfo.CurrentInfo.MonthNames.ToList();
+                monthNames = DateTimeFormatInfo.CurrentInfo.MonthNames;
             }
             else if (isAbbreviatedMonth || isMonthDay)
             {
-                monthStrings = DateTimeFormatInfo.CurrentInfo.AbbreviatedMonthNames.ToList();
+                monthNames = DateTimeFormatInfo.CurrentInfo.AbbreviatedMonthNames;
             }
 
             if (isMonthDay)
@@ -407,12 +407,12 @@ namespace Syncfusion.Maui.Toolkit.Picker
                     }
                 }
             }
-            else if (isAbbreviatedMonth || isFullMonth)
+            else if ((isAbbreviatedMonth || isFullMonth) && monthNames is not null)
             {
                 for (int i = 0; i < months.Count; i++)
                 {
                     string monthItem = months[i];
-                    if (monthStrings.IndexOf(monthItem) + 1 > month)
+                    if (Array.IndexOf(monthNames, monthItem) + 1 > month)
                     {
                         monthIndex = i;
                         break;

--- a/maui/src/Picker/SfDatePicker.cs
+++ b/maui/src/Picker/SfDatePicker.cs
@@ -966,16 +966,13 @@ namespace Syncfusion.Maui.Toolkit.Picker
             }
             else if (monthFormat == "MMM")
             {
-                List<string> monthStrings = DateTimeFormatInfo.CurrentInfo.AbbreviatedMonthNames.ToList();
                 //// Get the month value based on the selected index changes value.
-                month = monthStrings.IndexOf(months[monthIndex]) + 1;
+                month = Array.IndexOf(DateTimeFormatInfo.CurrentInfo.AbbreviatedMonthNames, months[monthIndex]) + 1;
             }
             else if (monthFormat == "MMMM")
             {
-                List<string> monthStrings = DateTimeFormatInfo.CurrentInfo.MonthNames.ToList();
-                month = monthStrings.IndexOf(months[monthIndex]) + 1;
+                month = Array.IndexOf(DateTimeFormatInfo.CurrentInfo.MonthNames, months[monthIndex]) + 1;
             }
-
             ObservableCollection<string> days = DatePickerHelper.GetDays(dayFormat, month, year, MinimumDate, maxDate, DayInterval);
             ObservableCollection<string> previousDays = _dayColumn.ItemsSource is ObservableCollection<string> previousDayCollection ? previousDayCollection : new ObservableCollection<string>();
             //// Check the year and month(if month items source updated) changes needed to change the day collection.
@@ -1017,15 +1014,13 @@ namespace Syncfusion.Maui.Toolkit.Picker
                 }
                 else if (monthFormat == "MMM")
                 {
-                    List<string> months = DateTimeFormatInfo.CurrentInfo.AbbreviatedMonthNames.ToList();
                     //// Get the month value based on the selected index changes value.
-                    month = months.IndexOf(monthCollection[e.NewValue]) + 1;
+                    month = Array.IndexOf(DateTimeFormatInfo.CurrentInfo.AbbreviatedMonthNames, monthCollection[e.NewValue]) + 1;
                 }
                 else if (monthFormat == "MMMM")
                 {
-                    List<string> monthStrings = DateTimeFormatInfo.CurrentInfo.MonthNames.ToList();
                     //// Get the month value based on the selected index changes value.
-                    month = monthStrings.IndexOf(monthCollection[e.NewValue]) + 1;
+                    month = Array.IndexOf(DateTimeFormatInfo.CurrentInfo.MonthNames, monthCollection[e.NewValue]) + 1;
                 }
                 else if (monthFormat == "MM_ddd")
                 {

--- a/maui/src/ProgressBar/SfCircularProgressBar/SfCircularProgressBar.cs
+++ b/maui/src/ProgressBar/SfCircularProgressBar/SfCircularProgressBar.cs
@@ -1012,7 +1012,7 @@ namespace Syncfusion.Maui.Toolkit.ProgressBar
                 if (!isTrack && !IsIndeterminate && GradientStops != null && GradientStops.Count > 0)
                 {
                     ProgressPath = null;
-                    _gradientArcPaths = CreateGradientArcSegments(GradientStops.ToList(), innerRadius,
+                    _gradientArcPaths = CreateGradientArcSegments(new List<ProgressGradientStop>(GradientStops), innerRadius,
                     innerRadius, ActualMinimum, actualEndValue);
                     CreateGradientArc(
                         outerArcTopLeft,

--- a/maui/src/ProgressBar/SfLinearProgressBar/SfLinearProgressBar.cs
+++ b/maui/src/ProgressBar/SfLinearProgressBar/SfLinearProgressBar.cs
@@ -1128,7 +1128,8 @@ namespace Syncfusion.Maui.Toolkit.ProgressBar
             }
             else
             {
-                List<ProgressGradientStop> gradientStopsList = GradientStops.OrderBy(x => x.ActualValue).ToList();
+                List<ProgressGradientStop> gradientStopsList = new List<ProgressGradientStop>(GradientStops);
+                gradientStopsList.Sort((a, b) => a.ActualValue.CompareTo(b.ActualValue));
                 if (gradientStopsList[0].Value != ActualMinimum)
                 {
                     gradientStopsList.Insert(0, new ProgressGradientStop

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Picker/DatePickerMonthIndexUnitTests.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Picker/DatePickerMonthIndexUnitTests.cs
@@ -1,0 +1,68 @@
+using Syncfusion.Maui.Toolkit.Picker;
+using System.Collections.ObjectModel;
+using System.Globalization;
+
+namespace Syncfusion.Maui.Toolkit.UnitTest;
+
+public class DatePickerMonthIndexUnitTests : BaseUnitTest
+{
+	[Fact]
+	public void ArrayIndexOf_ReturnsCorrectIndex_ForFullMonthNames()
+	{
+		string[] monthNames = DateTimeFormatInfo.CurrentInfo.MonthNames;
+
+		for (int i = 0; i < 12; i++)
+		{
+			int index = Array.IndexOf(monthNames, monthNames[i]);
+			Assert.Equal(i, index);
+		}
+	}
+
+	[Fact]
+	public void ArrayIndexOf_ReturnsCorrectIndex_ForAbbreviatedMonthNames()
+	{
+		string[] abbrevMonthNames = DateTimeFormatInfo.CurrentInfo.AbbreviatedMonthNames;
+
+		for (int i = 0; i < 12; i++)
+		{
+			int index = Array.IndexOf(abbrevMonthNames, abbrevMonthNames[i]);
+			Assert.Equal(i, index);
+		}
+	}
+
+	[Fact]
+	public void ArrayIndexOf_ReturnsMinusOne_ForInvalidMonth()
+	{
+		string[] monthNames = DateTimeFormatInfo.CurrentInfo.MonthNames;
+		int index = Array.IndexOf(monthNames, "InvalidMonth");
+		Assert.Equal(-1, index);
+	}
+
+	[Fact]
+	public void ArrayIndexOf_MatchesListIndexOf_ForAllMonths()
+	{
+		string[] monthNames = DateTimeFormatInfo.CurrentInfo.MonthNames;
+		var monthList = monthNames.ToList();
+
+		for (int i = 0; i < monthNames.Length; i++)
+		{
+			int arrayResult = Array.IndexOf(monthNames, monthNames[i]);
+			int listResult = monthList.IndexOf(monthNames[i]);
+			Assert.Equal(listResult, arrayResult);
+		}
+	}
+
+	[Fact]
+	public void ArrayIndexOf_MatchesListIndexOf_ForAbbreviatedMonths()
+	{
+		string[] abbrevMonthNames = DateTimeFormatInfo.CurrentInfo.AbbreviatedMonthNames;
+		var monthList = abbrevMonthNames.ToList();
+
+		for (int i = 0; i < abbrevMonthNames.Length; i++)
+		{
+			int arrayResult = Array.IndexOf(abbrevMonthNames, abbrevMonthNames[i]);
+			int listResult = monthList.IndexOf(abbrevMonthNames[i]);
+			Assert.Equal(listResult, arrayResult);
+		}
+	}
+}

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/ProgressBar/LinearProgressBarGradientSortUnitTests.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/ProgressBar/LinearProgressBarGradientSortUnitTests.cs
@@ -1,0 +1,75 @@
+using Microsoft.Maui.Graphics;
+using Syncfusion.Maui.Toolkit.ProgressBar;
+using System.Collections.ObjectModel;
+
+namespace Syncfusion.Maui.Toolkit.UnitTest;
+
+public class LinearProgressBarGradientSortUnitTests : BaseUnitTest
+{
+	[Fact]
+	public void GradientStops_AddedOutOfOrder_AreSortedByActualValue()
+	{
+		SfLinearProgressBar progressBar = new SfLinearProgressBar();
+		progressBar.Minimum = 0;
+		progressBar.Maximum = 100;
+		progressBar.Progress = 80;
+
+		var gradientStops = new ObservableCollection<ProgressGradientStop>
+		{
+			new ProgressGradientStop { Color = Colors.Orange, Value = 50, ActualValue = 50 },
+			new ProgressGradientStop { Color = Colors.Red, Value = 0, ActualValue = 0 },
+			new ProgressGradientStop { Color = Colors.Green, Value = 100, ActualValue = 100 },
+			new ProgressGradientStop { Color = Colors.Yellow, Value = 25, ActualValue = 25 },
+		};
+
+		progressBar.GradientStops = gradientStops;
+
+		Assert.Equal(4, progressBar.GradientStops.Count);
+		Assert.Equal(Colors.Orange, progressBar.GradientStops[0].Color);
+		Assert.Equal(Colors.Red, progressBar.GradientStops[1].Color);
+		Assert.Equal(Colors.Green, progressBar.GradientStops[2].Color);
+		Assert.Equal(Colors.Yellow, progressBar.GradientStops[3].Color);
+	}
+
+	[Fact]
+	public void GradientStops_SingleStop_DoesNotThrow()
+	{
+		SfLinearProgressBar progressBar = new SfLinearProgressBar();
+		progressBar.Minimum = 0;
+		progressBar.Maximum = 100;
+		progressBar.Progress = 50;
+
+		var gradientStops = new ObservableCollection<ProgressGradientStop>
+		{
+			new ProgressGradientStop { Color = Colors.Blue, Value = 50, ActualValue = 50 }
+		};
+
+		progressBar.GradientStops = gradientStops;
+
+		Assert.Single(progressBar.GradientStops);
+		Assert.Equal(Colors.Blue, progressBar.GradientStops[0].Color);
+	}
+
+	[Fact]
+	public void GradientStops_AlreadySorted_PreservesOrder()
+	{
+		SfLinearProgressBar progressBar = new SfLinearProgressBar();
+		progressBar.Minimum = 0;
+		progressBar.Maximum = 100;
+		progressBar.Progress = 100;
+
+		var gradientStops = new ObservableCollection<ProgressGradientStop>
+		{
+			new ProgressGradientStop { Color = Colors.Red, Value = 0, ActualValue = 0 },
+			new ProgressGradientStop { Color = Colors.Yellow, Value = 50, ActualValue = 50 },
+			new ProgressGradientStop { Color = Colors.Green, Value = 100, ActualValue = 100 },
+		};
+
+		progressBar.GradientStops = gradientStops;
+
+		Assert.Equal(3, progressBar.GradientStops.Count);
+		Assert.Equal(Colors.Red, progressBar.GradientStops[0].Color);
+		Assert.Equal(Colors.Yellow, progressBar.GradientStops[1].Color);
+		Assert.Equal(Colors.Green, progressBar.GradientStops[2].Color);
+	}
+}


### PR DESCRIPTION
### Root Cause of the Issue

Multiple controls allocate unnecessary collections (List, Array) in frequently-called methods, causing GC pressure and reducing throughput during layout, rendering, and user interaction.

### Description of Change

Five targeted performance improvements that reduce heap allocations:

1. **OtpInput** (`SfOtpInput.cs`) — Replaced O(n²) `Concat(new[]{x}).ToArray()` pattern in `AddEntry`, `SetInputFieldPosition`, and `SetSeparatorPosition` with a `List<T>`-based approach that builds the collection once and converts to array at the end.

2. **Carousel iOS** (`PlatformCarousel.iOS.cs`) — Replaced `.ToList().ForEach(...)` with a direct `foreach` loop, eliminating a List allocation. Also cached the `IsInteractionEnable()` result to avoid calling it N+1 times.

3. **SfView** (`SfView.cs`) — Removed the redundant `.AsReadOnly()` wrapper in `GetVisualChildren()`, which allocated an extra `ReadOnlyCollection<T>` on every call. `List<T>` already implements `IReadOnlyList<T>`.

4. **DatePicker** (`SfDatePicker.cs`, `DatePickerHelper.cs`) — Replaced `MonthNames.ToList().IndexOf(...)` with `Array.IndexOf(MonthNames, ...)`, eliminating 4 separate List allocations per month-selection event.

5. **ProgressBar** (`SfLinearProgressBar.cs`, `SfCircularProgressBar.cs`) — Replaced LINQ `OrderBy(...).ToList()` with `new List<T>(source)` + `List.Sort()` for in-place sorting of gradient stops, eliminating the intermediate iterator and sort buffer allocations.

### Issues Fixed

N/A — proactive performance improvement

### Unit Tests Added

- `DatePickerMonthIndexUnitTests` — Verifies `Array.IndexOf` produces identical results to the previous `List.IndexOf` approach for all month name formats
- `LinearProgressBarGradientSortUnitTests` — Verifies gradient stops are correctly handled after the sort optimization (out-of-order, single-stop, already-sorted scenarios)