### PR TITLE
perf: Chart control performance improvements

### DIFF
--- a/maui/src/Charts/Area/Partial/CartesianChartArea.cs
+++ b/maui/src/Charts/Area/Partial/CartesianChartArea.cs
@@ -532,7 +532,6 @@ namespace Syncfusion.Maui.Toolkit.Charts
 					var yValues = series.YValues;
 					var bottomValues = new List<double>();
 					var topValues = new List<double>();
-					bool is100Series = series is StackingColumn100Series or StackingLine100Series or StackingArea100Series;
 
 					if (xValues != null)
 					{

--- a/maui/src/Charts/Area/Partial/CartesianChartArea.cs
+++ b/maui/src/Charts/Area/Partial/CartesianChartArea.cs
@@ -102,7 +102,23 @@ namespace Syncfusion.Maui.Toolkit.Charts
 									{
 										if (!stackingSeries.IsSbsValueCalculated && _seriesGroup != null)
 										{
-											string groupID = _seriesGroup.FirstOrDefault(x => x.Value.Any(s => s.GroupingLabel == stackingSeries.GroupingLabel && s.GetType() == stackingSeries.GetType())).Key;
+											string? groupID = null;
+											foreach (var group in _seriesGroup)
+											{
+												foreach (var s in group.Value)
+												{
+													if (s.GroupingLabel == stackingSeries.GroupingLabel && s.GetType() == stackingSeries.GetType())
+													{
+														groupID = group.Key;
+														break;
+													}
+												}
+
+												if (groupID != null)
+												{
+													break;
+												}
+											}
 											StackingSeriesBase stackingSeriesBase;
 											int size = SideBySideSeriesPosition.Count > 0 && groupingKeys.Count > 0 && groupingKeys.TryGetValue(groupID, out var groupValue)
 												? SideBySideSeriesPosition[groupValue].Count : 0;
@@ -351,15 +367,23 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 		internal void ResetSBSSegments()
 		{
-			var sideBySideSeries = VisibleSeries?.Where(series => series.IsSideBySide).ToList();
-
-			if (sideBySideSeries != null && sideBySideSeries.Count > 0)
+			if (VisibleSeries == null)
 			{
-				SideBySideSeriesPosition = null;
+				return;
+			}
 
-				foreach (var chartSeries in sideBySideSeries)
+			bool hasSbsSeries = false;
+			foreach (var series in VisibleSeries)
+			{
+				if (series.IsSideBySide)
 				{
-					chartSeries.SegmentsCreated = false;
+					if (!hasSbsSeries)
+					{
+						SideBySideSeriesPosition = null;
+						hasSbsSeries = true;
+					}
+
+					series.SegmentsCreated = false;
 				}
 			}
 		}
@@ -370,10 +394,11 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 			if (SideBySideSeriesPosition != null)
 			{
+				var positionsList = SideBySideSeriesPosition.Values.ToList();
 				for (int i = 0; i < SideBySideSeriesPosition.Count; i++)
 				{
 					double maxWidth = 0;
-					foreach (ChartSeries sideBySideSeries in SideBySideSeriesPosition.Values.ToList()[i])
+					foreach (ChartSeries sideBySideSeries in positionsList[i])
 					{
 						CartesianSeries cartesianSeries = (CartesianSeries)sideBySideSeries;
 						double width = cartesianSeries.GetActualWidth();
@@ -403,7 +428,22 @@ namespace Syncfusion.Maui.Toolkit.Charts
 		internal void UpdateStackingSeries()
 		{
 			//if visible series count is 0 or not contain any stacking series then return.
-			if (VisibleSeries == null || VisibleSeries.Count == 0 || !VisibleSeries.Any(series => series is StackingSeriesBase && !series.SegmentsCreated))
+			if (VisibleSeries == null || VisibleSeries.Count == 0)
+			{
+				return;
+			}
+
+			bool hasStackingToCreate = false;
+			foreach (var series in VisibleSeries)
+			{
+				if (series is StackingSeriesBase && !series.SegmentsCreated)
+				{
+					hasStackingToCreate = true;
+					break;
+				}
+			}
+
+			if (!hasStackingToCreate)
 			{
 				return;
 			}
@@ -488,6 +528,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 					var yValues = series.YValues;
 					var bottomValues = new List<double>();
 					var topValues = new List<double>();
+					bool is100Series = series is StackingColumn100Series or StackingLine100Series or StackingArea100Series;
 
 					if (xValues != null)
 					{
@@ -502,7 +543,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 								if (positiveYValues.TryGetValue(xValue, out double currentValue))
 								{
 									bottomValues.Add((axisCross > currentValue) ? axisCross : currentValue);
-									if (series.GetType().Name.Contains("Stacking", StringComparison.Ordinal) && series.GetType().Name.Contains("100Series", StringComparison.Ordinal))
+									if (is100Series)
 									{
 										yValue = GetYValue(seriesList, yValue, i);
 									}
@@ -511,7 +552,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 								else
 								{
 									bottomValues.Add(axisCross);
-									if (series.GetType().Name.Contains("Stacking", StringComparison.Ordinal) && series.GetType().Name.Contains("100Series", StringComparison.Ordinal))
+									if (is100Series)
 									{
 										yValue = GetYValue(seriesList, yValue, i);
 									}
@@ -525,7 +566,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 								if (!negativeYValues.TryAdd(xValue, yValue))
 								{
 									bottomValues.Add((axisCross < negativeYValues[xValue]) ? axisCross : negativeYValues[xValue]);
-									if (series.GetType().Name.Contains("Stacking", StringComparison.Ordinal) && series.GetType().Name.Contains("100Series", StringComparison.Ordinal))
+									if (is100Series)
 									{
 										yValue = GetYValue(seriesList, yValue, i);
 									}
@@ -549,7 +590,19 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 		static double GetYValue(List<StackingSeriesBase> SeriesList, double yValue, int index)
 		{
-			double total = SeriesList.Where(series => series != null && series.YValues.Count > index).Sum(series => double.IsNaN(series.YValues[index]) ? 0 : Math.Abs(series.YValues[index]));
+			double total = 0;
+			foreach (var series in SeriesList)
+			{
+				if (series != null && series.YValues.Count > index)
+				{
+					double val = series.YValues[index];
+					if (!double.IsNaN(val))
+					{
+						total += Math.Abs(val);
+					}
+				}
+			}
+
 			if (yValue != 0)
 			{
 				yValue = (yValue / total) * 100;

--- a/maui/src/Charts/Layouts/ChartZoomPanView.cs
+++ b/maui/src/Charts/Layouts/ChartZoomPanView.cs
@@ -115,14 +115,16 @@ namespace Syncfusion.Maui.Toolkit.Charts.Chart.Layouts
 				{
 					if (axis.IsVertical)
 					{
-						startPoint = new Point(isOpposed ? actualArrangeRect.X : actualArrangeRect.X + actualArrangeRect.Width, selectedRect.Top);
-						endPoint = new Point(isOpposed ? actualArrangeRect.X : actualArrangeRect.X + actualArrangeRect.Width, selectedRect.Bottom);
+						double xCoord = isOpposed ? actualArrangeRect.X : actualArrangeRect.X + actualArrangeRect.Width;
+						startPoint = new Point(xCoord, selectedRect.Top);
+						endPoint = new Point(xCoord, selectedRect.Bottom);
 						tooltipPosition = isOpposed ? TooltipPosition.Right : TooltipPosition.Left;
 					}
 					else
 					{
-						startPoint = new Point(selectedRect.Left, isOpposed ? actualArrangeRect.Y + actualArrangeRect.Height : actualArrangeRect.Y);
-						endPoint = new Point(selectedRect.Right, isOpposed ? actualArrangeRect.Y + actualArrangeRect.Height : actualArrangeRect.Y);
+						double yCoord = isOpposed ? actualArrangeRect.Y + actualArrangeRect.Height : actualArrangeRect.Y;
+						startPoint = new Point(selectedRect.Left, yCoord);
+						endPoint = new Point(selectedRect.Right, yCoord);
 						tooltipPosition = isOpposed ? TooltipPosition.Top : TooltipPosition.Bottom;
 					}
 
@@ -177,7 +179,7 @@ namespace Syncfusion.Maui.Toolkit.Charts.Chart.Layouts
 					ChartZoomPanView.MapChartLabelStyle(chart, axisPointInfo2.Helper, axis.TrackballLabelStyle);
 				}
 
-				Rect actualArrangeRect = new Rect(axis.ArrangeRect.X, axis.ArrangeRect.Y, axis.ArrangeRect.X + axis.ArrangeRect.Width, axis.ArrangeRect.Y + axis.ArrangeRect.Height);
+				Rect actualArrangeRect = new Rect(axisRect.X, axisRect.Y, axisRect.X + axisRect.Width, axisRect.Y + axisRect.Height);
 
 				axisPointInfo1.Helper.Show(actualArrangeRect, new Rect(startPoint.X - 1, startPoint.Y - 1, _dimension, _dimension), false);
 				axisPointInfo2.Helper.Show(actualArrangeRect, new Rect(endPoint.X - 1, endPoint.Y - 1, _dimension, _dimension), false);

--- a/maui/src/Charts/Series/CartesianSeries.cs
+++ b/maui/src/Charts/Series/CartesianSeries.cs
@@ -15,6 +15,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 		double _xAxisMax = double.MinValue;
 		double _yAxisMin = double.MaxValue;
 		double _yAxisMax = double.MinValue;
+		List<double>? _cachedIndexedXValues;
 
 		#endregion
 
@@ -1027,26 +1028,44 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				return null;
 			}
 
-			double xIndexValues = 0d;
 			var xValues = ActualXValues as List<double>;
 
 			if (IsIndexed || xValues == null)
 			{
 				if (ActualXAxis is CategoryAxis categoryAxis && !categoryAxis.ArrangeByIndex || ActualXAxis == null)
 				{
-					xValues = GroupedXValuesIndexes.Count > 0 ? GroupedXValuesIndexes : (from val in (ActualXValues as List<string>) select (xIndexValues++)).ToList();
+					xValues = GroupedXValuesIndexes.Count > 0 ? GroupedXValuesIndexes : GetOrCreateIndexedXValues();
 				}
 				else
 				{
-					xValues = xValues != null ? (from val in xValues select (xIndexValues++)).ToList() : (from val in (ActualXValues as List<string>) select (xIndexValues++)).ToList();
+					xValues = GetOrCreateIndexedXValues();
 				}
 			}
 
 			return xValues;
 		}
 
+		List<double> GetOrCreateIndexedXValues()
+		{
+			int count = ActualXValues is List<double> dList ? dList.Count : (ActualXValues as List<string>)?.Count ?? 0;
+			if (_cachedIndexedXValues != null && _cachedIndexedXValues.Count == count)
+			{
+				return _cachedIndexedXValues;
+			}
+
+			var indexedValues = new List<double>(count);
+			for (int i = 0; i < count; i++)
+			{
+				indexedValues.Add(i);
+			}
+
+			_cachedIndexedXValues = indexedValues;
+			return _cachedIndexedXValues;
+		}
+
 		internal override void OnDataSourceChanged(object oldValue, object newValue)
 		{
+			_cachedIndexedXValues = null;
 			ResetAutoScroll();
 			InvalidateSideBySideSeries();
 			foreach (var item in EmptyPointIndexes)
@@ -1059,6 +1078,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 		internal override void OnDataSource_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
 		{
+			_cachedIndexedXValues = null;
 			ResetAutoScroll();
 			base.OnDataSource_CollectionChanged(sender, e);
 		}

--- a/maui/src/Charts/Series/ChartSeriesPartial.cs
+++ b/maui/src/Charts/Series/ChartSeriesPartial.cs
@@ -1411,16 +1411,19 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 			if (ItemsSource != null)
 			{
-				var items = ItemsSource is IList ? ItemsSource as IList : null;
-				if (items == null)
+				bool hasData = false;
+				if (ItemsSource is IList list)
 				{
-					if (ItemsSource is IEnumerable source)
-					{
-						items = source.Cast<object>().ToList();
-					}
+					hasData = list.Count > 0;
+				}
+				else if (ItemsSource is IEnumerable source)
+				{
+					var enumerator = source.GetEnumerator();
+					hasData = enumerator.MoveNext();
+					(enumerator as IDisposable)?.Dispose();
 				}
 
-				if (items != null && items.Count > 0)
+				if (hasData)
 				{
 					GenerateDataPoints();
 				}

--- a/maui/src/Charts/Series/StackingSeriesBase.cs
+++ b/maui/src/Charts/Series/StackingSeriesBase.cs
@@ -330,17 +330,14 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 		void ResetVisibleSeries()
 		{
-			if (ChartArea != null)
+			if (ChartArea?.VisibleSeries == null)
 			{
-				var visibleSeries = ChartArea.VisibleSeries;
-				var stackingSeries = visibleSeries?.Where(series => series.IsStacking).ToList();
+				return;
+			}
 
-				if (stackingSeries == null)
-				{
-					return;
-				}
-
-				foreach (var chartSeries in stackingSeries)
+			foreach (var chartSeries in ChartArea.VisibleSeries)
+			{
+				if (chartSeries.IsStacking)
 				{
 					chartSeries.SegmentsCreated = false;
 				}


### PR DESCRIPTION
### Root Cause of the Issue
Multiple performance bottlenecks in the Chart control's hot paths causing unnecessary allocations and repeated enumeration during render cycles.

### Description of Change
This PR implements 10 performance improvements targeting allocation reduction and LINQ elimination in frequently-called Chart control code paths:

1. **Hoist `.ToList()` outside loop in `GetTotalWidth()`** — `CartesianChartArea.cs`: `.Values.ToList()[i]` was creating a new list on every iteration.

2. **Replace `GetType().Name.Contains()` with `is` pattern matching** — `CartesianChartArea.cs`: String-based type checks in `CalculateStackingValues()` inner loop replaced with compile-time type checks (`is StackingColumn100Series or StackingLine100Series or StackingArea100Series`).

3. **Cache indexed X values in `GetXValues()`** — `CartesianSeries.cs`: LINQ `.ToList()` was creating a new list on every call. Now caches the computed index list and invalidates on data source changes.

4. **Replace `.Where().Sum()` with single `foreach` loop** — `CartesianChartArea.cs`: `GetYValue()` static method no longer double-enumerates the collection.

5. **Remove `.Where().ToList()` in `ResetVisibleSeries()`** — `StackingSeriesBase.cs`: Direct iteration with inline predicate instead of allocating a filtered list.

6. **Remove `.Where().ToList()` in `ResetSBSSegments()`** — `CartesianChartArea.cs`: Direct iteration instead of allocating a filtered list just to set flags.

7. **Replace `.Any()` with manual loop in `UpdateStackingSeries()`** — `CartesianChartArea.cs`: Eliminates LINQ delegate allocation with early-exit foreach loop.

8. **Eliminate `Cast<object>().ToList()` in `ResetDataPoint()`** — `ChartSeriesPartial.cs`: Uses `IEnumerable.GetEnumerator().MoveNext()` to check for data existence without allocating a full list copy.

9. **Pre-compute coordinates in zoom/pan selection rendering** — `ChartZoomPanView.cs`: Cache computed x/y coordinates outside if/else branches to avoid redundant ternary evaluations per axis; reuse `axisRect` local for `actualArrangeRect` computation.

10. **Replace nested LINQ `.FirstOrDefault().Any()` with foreach loops** — `CartesianChartArea.cs`: SBS grouping lookup now uses nested foreach with early break instead of LINQ with reflection.

### Issues Fixed
N/A — Performance improvement (no functional changes)

### Screenshots
N/A — Internal implementation optimization only