### PR TITLE
perf: Reduce allocations and eliminate delegate overhead across 5 controls

### DIFF
--- a/maui/src/Calendar/Views/CalendarView/MonthView/MonthView.cs
+++ b/maui/src/Calendar/Views/CalendarView/MonthView/MonthView.cs
@@ -880,6 +880,24 @@ namespace Syncfusion.Maui.Toolkit.Calendar
 
         #region Private Methods
 
+		/// <summary>
+		/// Finds the special date icon details for a given date using a loop to avoid delegate allocation.
+		/// </summary>
+		/// <param name="dateTime">The date to look up.</param>
+		/// <returns>The matching CalendarIconDetails or null.</returns>
+		CalendarIconDetails? GetSpecialDateIcon(DateTime dateTime)
+		{
+			for (int i = 0; i < _specialDates.Count; i++)
+			{
+				if (CalendarViewHelper.IsSameDate(_calendarViewInfo.View, _specialDates[i].Date, dateTime, _calendarViewInfo.Identifier))
+				{
+					return _specialDates[i];
+				}
+			}
+
+			return null;
+		}
+
         /// <summary>
         /// Method to find the range is present in current view or not.
         /// </summary>
@@ -1635,7 +1653,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
                 // The current date is today date and not a range then need to considered the today text style.
                 bool isTodayDate = todayDate.Date.Equals(dateTime.Date);
                  //// Stores the special dates icon details for drawing.
-                CalendarIconDetails? calendarSpecialDayIconDetails = _specialDates.FirstOrDefault(details => CalendarViewHelper.IsSameDate(_calendarViewInfo.View, details.Date, dateTime, _calendarViewInfo.Identifier));
+                CalendarIconDetails? calendarSpecialDayIconDetails = GetSpecialDateIcon(dateTime);
                 CalendarTextStyle textStyle = GetMonthCellStyle(dateTime, isTodayDate, isLeadingAndTrailingDates, isBlackoutDate, isDisabledDate, _calendarViewInfo.ShowOutOfRangeDates, calendarSpecialDayIconDetails != null, ref fillColor, cellBackground, trailingLeadingDateBackground, weekendsBackground, todayBackground, disabledDatesBackground, specialDatesBackground, cultureCalendar);
                 //// If background color is not transparent then the background color for month cell is applied.
                 if (fillColor != Colors.Transparent)
@@ -3080,7 +3098,7 @@ namespace Syncfusion.Maui.Toolkit.Calendar
 
                 string blackOutDate = CalendarViewHelper.IsDateInDateCollection(dateTime, _disabledDates) ? SfCalendarResources.GetLocalizedString("Blackout Date") : string.Empty;
                 string disabledDate = CalendarViewHelper.IsDisabledDate(dateTime, _calendarViewInfo.View, _calendarViewInfo.EnablePastDates, _calendarViewInfo.MinimumDate, _calendarViewInfo.MaximumDate, _calendarViewInfo.SelectionMode, _calendarViewInfo.RangeSelectionDirection, _selectedRange, _calendarViewInfo.AllowViewNavigation, _calendarViewInfo.Identifier) ? SfCalendarResources.GetLocalizedString("Disabled Date") : string.Empty;
-                CalendarIconDetails? calendarSpecialDayIconDetails = _specialDates.FirstOrDefault(details => CalendarViewHelper.IsSameDate(_calendarViewInfo.View, details.Date, dateTime, _calendarViewInfo.Identifier));
+                CalendarIconDetails? calendarSpecialDayIconDetails = GetSpecialDateIcon(dateTime);
                 string specialDate = calendarSpecialDayIconDetails == null ? string.Empty : SfCalendarResources.GetLocalizedString("Special Date");
                 string dateType = string.IsNullOrEmpty(specialDate) ? !string.IsNullOrEmpty(blackOutDate) ? blackOutDate : disabledDate : specialDate;
                 string dateText = isGregorianCalendar ? dateTime.ToString("dddd, dd/MMMM/yyyy") + dateType : dateTime.ToString("dddd, dd/MMMM/yyyy", cultureInfo) + dateType;

--- a/maui/src/Charts/Axis/Layouts/CartesianAxisLayout.cs
+++ b/maui/src/Charts/Axis/Layouts/CartesianAxisLayout.cs
@@ -499,10 +499,17 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 		static ChartAxis? GetAxisByName(string name, ObservableCollection<ChartAxis>? axes)
 		{
-			var item = (from x in axes where x.Name == name select x).ToList();
-			if (item != null && item.Count > 0)
+			if (axes == null)
 			{
-				return item[0];
+				return null;
+			}
+
+			foreach (var axis in axes)
+			{
+				if (axis.Name == name)
+				{
+					return axis;
+				}
 			}
 
 			return null;

--- a/maui/src/Charts/Segment/PolarAreaSegment.cs
+++ b/maui/src/Charts/Segment/PolarAreaSegment.cs
@@ -212,12 +212,13 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 		List<float> GenerateInteriorPoints(float animationValue)
 		{
-			var fillPoints = new List<float>();
-
 			if (Series is not PolarSeries series)
 			{
-				return fillPoints;
+				return new List<float>();
 			}
+
+			int capacity = (_pointsCount + 2) * 2;
+			var fillPoints = new List<float>(capacity);
 
 			if (series.ActualXAxis != null && series.ActualYAxis != null && _xValues != null && _yValues != null)
 			{
@@ -252,12 +253,13 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 		List<float> GenerateStrokePoints(float animationValue)
 		{
-			var strokePoints = new List<float>();
-
 			if (Series is not PolarSeries series)
 			{
-				return strokePoints;
+				return new List<float>();
 			}
+
+			int capacity = (_pointsCount + 2) * 2;
+			var strokePoints = new List<float>(capacity);
 
 			if (series.ActualXAxis != null && series.ActualYAxis != null && _xValues != null && _yValues != null)
 			{

--- a/maui/src/Charts/Series/ChartSeries.cs
+++ b/maui/src/Charts/Series/ChartSeries.cs
@@ -1582,6 +1582,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 					if (e.PropertyName == nameof(dataLabelSettings.LabelStyle))
 					{
+						dataLabelSettings.LabelStyle.PropertyChanged -= LabelStyle_PropertyChanged;
 						dataLabelSettings.LabelStyle.PropertyChanged += LabelStyle_PropertyChanged;
 						dataLabelSettings.LabelStyle.Parent = Parent;
 					}

--- a/maui/src/Picker/SfTimePicker.cs
+++ b/maui/src/Picker/SfTimePicker.cs
@@ -893,6 +893,23 @@ namespace Syncfusion.Maui.Toolkit.Picker
 
         #region Private Methods
 
+		/// <summary>
+		/// Checks if the collection contains a string that parses to the specified integer value,
+		/// avoiding LINQ Select/Contains allocation overhead.
+		/// </summary>
+		static bool ContainsParsedValue(ObservableCollection<string> collection, int value)
+		{
+			for (int i = 0; i < collection.Count; i++)
+			{
+				if (int.TryParse(collection[i], out int parsed) && parsed == value)
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+
         /// <summary>
         /// Method trigged whenever the base panel selection is changed.
         /// </summary>
@@ -1002,7 +1019,7 @@ namespace Syncfusion.Maui.Toolkit.Picker
             }
 
             int minute = 0;
-            if (_minuteColumn.ItemsSource != null && _minuteColumn.ItemsSource is ObservableCollection<string> minuteCollection && minuteCollection.Select(m => int.Parse(m)).Contains(previousSelectedTime.Value.Minutes))
+            if (_minuteColumn.ItemsSource != null && _minuteColumn.ItemsSource is ObservableCollection<string> minuteCollection && ContainsParsedValue(minuteCollection, previousSelectedTime.Value.Minutes))
             {
                 minute = previousSelectedTime.Value.Minutes;
             }
@@ -1015,7 +1032,7 @@ namespace Syncfusion.Maui.Toolkit.Picker
             }
 
             int second = 0;
-            if (_secondColumn.ItemsSource != null && _secondColumn.ItemsSource is ObservableCollection<string> secondCollection && secondCollection.Select(m => int.Parse(m)).Contains(previousSelectedTime.Value.Seconds))
+            if (_secondColumn.ItemsSource != null && _secondColumn.ItemsSource is ObservableCollection<string> secondCollection && ContainsParsedValue(secondCollection, previousSelectedTime.Value.Seconds))
             {
                 second = previousSelectedTime.Value.Seconds;
             }
@@ -1064,7 +1081,7 @@ namespace Syncfusion.Maui.Toolkit.Picker
             }
 
             int second = 0;
-            if (_secondColumn.ItemsSource != null && _secondColumn.ItemsSource is ObservableCollection<string> secondCollection && secondCollection.Select(m => int.Parse(m)).Contains(previousSelectedTime.Value.Seconds))
+            if (_secondColumn.ItemsSource != null && _secondColumn.ItemsSource is ObservableCollection<string> secondCollection && ContainsParsedValue(secondCollection, previousSelectedTime.Value.Seconds))
             {
                 second = previousSelectedTime.Value.Seconds;
             }

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Chart/PerformanceOptimizationTests.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Chart/PerformanceOptimizationTests.cs
@@ -1,0 +1,161 @@
+using Syncfusion.Maui.Toolkit.Charts;
+
+namespace Syncfusion.Maui.Toolkit.UnitTest.Charts
+{
+	public class PerformanceOptimizationTests
+	{
+		#region CartesianAxisLayout - GetAxisByName
+
+		[Fact]
+		public void CartesianChart_NamedAxes_AssociateCorrectly()
+		{
+			var chart = new SfCartesianChart();
+			var xAxis = new NumericalAxis { Name = "xAxis1" };
+			var yAxis = new NumericalAxis { Name = "yAxis1" };
+
+			chart.XAxes.Add(xAxis);
+			chart.YAxes.Add(yAxis);
+
+			var series = new LineSeries
+			{
+				XAxisName = "xAxis1",
+				YAxisName = "yAxis1"
+			};
+			chart.Series.Add(series);
+
+			Assert.Equal("xAxis1", xAxis.Name);
+			Assert.Equal("yAxis1", yAxis.Name);
+			Assert.Equal("xAxis1", series.XAxisName);
+			Assert.Equal("yAxis1", series.YAxisName);
+		}
+
+		[Fact]
+		public void CartesianChart_MultipleNamedAxes_FindsCorrectAxis()
+		{
+			var chart = new SfCartesianChart();
+			var xAxis1 = new NumericalAxis { Name = "primary" };
+			var xAxis2 = new NumericalAxis { Name = "secondary" };
+			var yAxis1 = new NumericalAxis { Name = "left" };
+			var yAxis2 = new NumericalAxis { Name = "right" };
+
+			chart.XAxes.Add(xAxis1);
+			chart.XAxes.Add(xAxis2);
+			chart.YAxes.Add(yAxis1);
+			chart.YAxes.Add(yAxis2);
+
+			var series1 = new LineSeries
+			{
+				XAxisName = "primary",
+				YAxisName = "left"
+			};
+			var series2 = new LineSeries
+			{
+				XAxisName = "secondary",
+				YAxisName = "right"
+			};
+
+			chart.Series.Add(series1);
+			chart.Series.Add(series2);
+
+			Assert.Equal(2, chart.XAxes.Count);
+			Assert.Equal(2, chart.YAxes.Count);
+			Assert.Equal("secondary", series2.XAxisName);
+			Assert.Equal("right", series2.YAxisName);
+		}
+
+		[Fact]
+		public void CartesianChart_NullAxisName_DoesNotThrow()
+		{
+			var chart = new SfCartesianChart();
+			var xAxis = new NumericalAxis();
+			var yAxis = new NumericalAxis();
+
+			chart.XAxes.Add(xAxis);
+			chart.YAxes.Add(yAxis);
+
+			var series = new LineSeries();
+			chart.Series.Add(series);
+
+			Assert.Null(series.XAxisName);
+			Assert.Null(series.YAxisName);
+		}
+
+		#endregion
+
+		#region DataLabelSettings - LabelStyle PropertyChanged handler
+
+		[Fact]
+		public void DataLabelSettings_LabelStyle_CanBeReassigned()
+		{
+			var settings = new CartesianDataLabelSettings();
+			var labelStyle1 = new ChartDataLabelStyle { TextColor = Colors.Red };
+			var labelStyle2 = new ChartDataLabelStyle { TextColor = Colors.Blue };
+
+			settings.LabelStyle = labelStyle1;
+			Assert.Equal(Colors.Red, settings.LabelStyle.TextColor);
+
+			settings.LabelStyle = labelStyle2;
+			Assert.Equal(Colors.Blue, settings.LabelStyle.TextColor);
+		}
+
+		[Fact]
+		public void DataLabelSettings_LabelStyle_ReassignmentDoesNotThrow()
+		{
+			var series = new ColumnSeries();
+			var settings = new CartesianDataLabelSettings();
+			series.DataLabelSettings = settings;
+
+			var exception = Record.Exception(() =>
+			{
+				for (int i = 0; i < 10; i++)
+				{
+					settings.LabelStyle = new ChartDataLabelStyle
+					{
+						TextColor = Colors.Red,
+						FontSize = 12 + i
+					};
+				}
+			});
+
+			Assert.Null(exception);
+		}
+
+		#endregion
+
+		#region PolarAreaSegment - List capacity optimization
+
+		[Fact]
+		public void PolarAreaSeries_AddedToChart_DoesNotThrow()
+		{
+			var chart = new SfPolarChart();
+			var primaryAxis = new NumericalAxis();
+			var secondaryAxis = new NumericalAxis();
+			chart.PrimaryAxis = primaryAxis;
+			chart.SecondaryAxis = secondaryAxis;
+
+			var series = new PolarAreaSeries();
+			chart.Series.Add(series);
+
+			Assert.Single(chart.Series);
+			Assert.IsType<PolarAreaSeries>(chart.Series[0]);
+		}
+
+		[Fact]
+		public void PolarAreaSeries_WithData_InitializesCorrectly()
+		{
+			var chart = new SfPolarChart();
+			chart.PrimaryAxis = new NumericalAxis();
+			chart.SecondaryAxis = new NumericalAxis();
+
+			var series = new PolarAreaSeries
+			{
+				IsClosed = true
+			};
+			chart.Series.Add(series);
+
+			Assert.True(series.IsClosed);
+		}
+
+		#endregion
+	}
+}

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Picker/TimePickerPerformanceTests.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Picker/TimePickerPerformanceTests.cs
@@ -1,0 +1,87 @@
+using Syncfusion.Maui.Toolkit.Picker;
+
+namespace Syncfusion.Maui.Toolkit.UnitTest
+{
+	public class TimePickerPerformanceTests : PickerBaseUnitTest
+	{
+		[Theory]
+		[InlineData(1)]
+		[InlineData(5)]
+		[InlineData(15)]
+		public void TimePicker_MinuteInterval_SetAndGet(int interval)
+		{
+			var picker = new SfTimePicker
+			{
+				MinuteInterval = interval
+			};
+
+			Assert.Equal(interval, picker.MinuteInterval);
+		}
+
+		[Theory]
+		[InlineData(1)]
+		[InlineData(5)]
+		[InlineData(15)]
+		public void TimePicker_SecondInterval_SetAndGet(int interval)
+		{
+			var picker = new SfTimePicker
+			{
+				SecondInterval = interval
+			};
+
+			Assert.Equal(interval, picker.SecondInterval);
+		}
+
+		[Fact]
+		public void TimePicker_SelectedTimePreserved_WhenIntervalsChange()
+		{
+			var picker = new SfTimePicker
+			{
+				SelectedTime = new TimeSpan(10, 30, 45)
+			};
+
+			Assert.Equal(new TimeSpan(10, 30, 45), picker.SelectedTime);
+
+			picker.MinuteInterval = 5;
+
+			// The selected time should still be accessible
+			Assert.NotNull(picker.SelectedTime);
+		}
+
+		[Theory]
+		[InlineData("10:30:00")]
+		[InlineData("23:59:59")]
+		[InlineData("00:00:00")]
+		public void TimePicker_SelectedTime_SetAndRetrieve(string timeStr)
+		{
+			var expected = TimeSpan.Parse(timeStr);
+			var picker = new SfTimePicker
+			{
+				SelectedTime = expected
+			};
+
+			Assert.Equal(expected, picker.SelectedTime);
+		}
+
+		[Fact]
+		public void TimePicker_MultipleIntervalChanges_DoNotThrow()
+		{
+			var picker = new SfTimePicker
+			{
+				SelectedTime = new TimeSpan(12, 15, 30)
+			};
+
+			var exception = Record.Exception(() =>
+			{
+				picker.MinuteInterval = 5;
+				picker.SecondInterval = 10;
+				picker.MinuteInterval = 15;
+				picker.SecondInterval = 30;
+				picker.MinuteInterval = 1;
+				picker.SecondInterval = 1;
+			});
+
+			Assert.Null(exception);
+		}
+	}
+}


### PR DESCRIPTION
### Root Cause of the Issue

Multiple controls perform unnecessary memory allocations and redundant work in frequently-called paths:
- LINQ queries that allocate intermediate collections just to find a single element
- Capturing lambdas allocated on every iteration of render loops
- Missing event handler unsubscription leading to handler accumulation
- Lists created without capacity hints in per-frame rendering methods
- LINQ Select + Contains chains creating iterator objects for simple lookups

### Description of Change

Five targeted performance improvements across 5 files:

1. **CartesianAxisLayout.cs** — `GetAxisByName()` used a LINQ query expression with `.ToList()` just to get the first matching axis. Replaced with a `foreach` loop that returns on first match, eliminating the list allocation entirely.

2. **Calendar MonthView.cs** — `_specialDates.FirstOrDefault(details => ...)` was called once per calendar cell (28-42 times per render frame), each time allocating a new delegate that captures the changing `dateTime` local. Extracted to a `GetSpecialDateIcon()` method using an indexed `for` loop.

3. **ChartSeries.cs** — `DataLabelSettings_PropertyChanged` subscribed to `LabelStyle.PropertyChanged` without first unsubscribing, causing duplicate handlers to accumulate each time `LabelStyle` was reassigned. Added the missing `-=` before `+=`.

4. **PolarAreaSegment.cs** — `GenerateInteriorPoints()` and `GenerateStrokePoints()` created `new List<float>()` with default capacity (called every render frame). Pre-allocated with calculated capacity `(_pointsCount + 2) * 2` to avoid repeated array resizing.

5. **SfTimePicker.cs** — `.Select(m => int.Parse(m)).Contains(value)` allocates an iterator, a delegate, and evaluates lazily. Replaced with a static `ContainsParsedValue()` helper using a `for` loop with `int.TryParse` — zero allocations.

### Issues Fixed

Performance optimization — no specific issue number.

### Screenshots

N/A — internal allocation/performance changes with no visual impact.