### PR TITLE
Fix: iOS null exception occurs on Toolkit SfButton when text is null

### DIFF
--- a/maui/src/Core/TextMeasurer/TextMeasurer.iOS.cs
+++ b/maui/src/Core/TextMeasurer/TextMeasurer.iOS.cs
@@ -23,6 +23,7 @@ namespace Syncfusion.Maui.Toolkit.Graphics.Internals
 		/// <returns>Measured size</returns>
 		public Size MeasureText(string text, float textSize, FontAttributes attributes = FontAttributes.None, string? fontFamily = null)
 		{
+			text ??= string.Empty;
 			NSString? nsText = new NSString(text);
 
 			UIFont? font = UIFont.SystemFontOfSize(textSize);


### PR DESCRIPTION
### Root Cause of the Issue

This issue occurs when the SfButton text is set to null, causing a null exception during iOS text measurement.
The existing implementation directly creates an NSString using:

`new NSString(text);`

On iOS, NSString does not accept null values, which leads to a null exception at runtime.
This scenario can happen when SfButton or its internal text measurement logic triggers measurement before the text is initialized or when text is explicitly null.

### Description of Change

Added a null-coalescing safeguard:

`text ??= string.Empty;`

Ensures that:

- If text is null, it is replaced with an empty string before creating NSString
- Prevents runtime exceptions from invalid object initialization

This change guarantees:

- Safe text measurement execution on iOS
- No crash when text is missing or not yet initialized
- Improved stability of SfButton rendering lifecycle

