### PR TITLE
Add `SwipeSensitivity` property to `SfTabView` (Android)

### DIFF
--- a/maui/src/TabView/Control/HorizontalContent/SfHorizontalContent.Android.cs
+++ b/maui/src/TabView/Control/HorizontalContent/SfHorizontalContent.Android.cs
@@ -25,7 +25,13 @@ namespace Syncfusion.Maui.Toolkit.TabView
 		double _density = Android.App.Application.Context.Resources.DisplayMetrics.Density;
 #pragma warning restore CS8602
 
-		double _swipeThreshold => 5 * _density;
+		/// <summary>
+		/// Gets the swipe threshold in pixels, derived from the tab view's
+		/// <see cref="SfTabView.SwipeSensitivity"/> and the device display density.
+		/// A higher base value means the user must swipe further before a tab
+		/// switch is triggered (i.e. less sensitive).
+		/// </summary>
+		double _swipeThreshold => (_tabView?.SwipeSensitivity ?? SfTabView.DefaultSwipeSensitivity) * _density;
 
 
 		#endregion

--- a/maui/src/TabView/Control/SfTabView.cs
+++ b/maui/src/TabView/Control/SfTabView.cs
@@ -157,10 +157,10 @@ namespace Syncfusion.Maui.Toolkit.TabView
 		/// </summary>
 		public static readonly BindableProperty TabHeaderAlignmentProperty =
 			BindableProperty.Create(
-				nameof(TabHeaderAlignment), 
-				typeof(TabHeaderAlignment), 
-				typeof(SfTabView), 
-				TabHeaderAlignment.Start, 
+				nameof(TabHeaderAlignment),
+				typeof(TabHeaderAlignment),
+				typeof(SfTabView),
+				TabHeaderAlignment.Start,
 				propertyChanged: OnTabHeaderAlignmentPropertyChanged);
 
 		/// <summary>
@@ -1082,7 +1082,7 @@ namespace Syncfusion.Maui.Toolkit.TabView
 			get => (DataTemplate?)GetValue(HeaderItemTemplateProperty);
 			set => SetValue(HeaderItemTemplateProperty, value);
 		}
-		
+
 		/// <summary>
 		/// Gets or sets the value that defines the spacing between header items.
 		/// </summary>
@@ -1849,7 +1849,7 @@ namespace Syncfusion.Maui.Toolkit.TabView
 			get => (bool)GetValue(IsContentLoopingEnabledProperty);
 			set => SetValue(IsContentLoopingEnabledProperty, value);
 		}
-		
+
 		/// <summary>
 		/// Gets or sets the easing function used for tab transition animations.
 		/// </summary>
@@ -2362,7 +2362,7 @@ namespace Syncfusion.Maui.Toolkit.TabView
 		/// </summary>		
 
 		static void OnTabHeaderAlignmentPropertyChanged(BindableObject bindable, object oldValue, object newValue) => (bindable as SfTabView)?.UpdateTabHeaderAlignment((TabHeaderAlignment)newValue);
-		
+
 		/// <summary>
 		/// Handles changes to the <see cref="AnimationEasing"/> property.
 		/// </summary>
@@ -2720,7 +2720,7 @@ namespace Syncfusion.Maui.Toolkit.TabView
 					if (TabBarHeight >= 0)
 					{
 						_parentGrid.RowDefinitions[tabHeaderContainerIndex].Height = TabBarHeight;
-						
+
 					}
 					_parentGrid.RowDefinitions[tabContentContainerIndex].Height = GridLength.Star;
 				}
@@ -3055,7 +3055,7 @@ namespace Syncfusion.Maui.Toolkit.TabView
 					break;
 			}
 		}
-		
+
 		/// <summary>
 		/// Updates the animation easing for both tab header and content containers.
 		/// </summary>
@@ -3170,5 +3170,80 @@ namespace Syncfusion.Maui.Toolkit.TabView
 			}
 		}
 		#endregion
+
+		#region Swipe Sensitivity
+
+		/// <summary>
+		/// The default base swipe threshold multiplier (density-independent units).
+		/// Matches the original hard-coded value of 5, preserving backward compatibility.
+		/// </summary>
+		internal const double DefaultSwipeSensitivity = 5.0;
+
+		/// <summary>
+		/// Identifies the <see cref="SwipeSensitivity"/> bindable property.
+		/// </summary>
+		/// <remarks>
+		/// The default value is <c>5.0</c>.
+		/// Higher values require a larger horizontal swipe distance before a tab
+		/// switch is triggered (less sensitive). Lower values make the control
+		/// react to shorter swipes (more sensitive).
+		/// </remarks>
+		public static readonly BindableProperty SwipeSensitivityProperty =
+			BindableProperty.Create(
+				nameof(SwipeSensitivity),
+				typeof(double),
+				typeof(SfTabView),
+				DefaultSwipeSensitivity,
+				validateValue: (_, value) => (double)value > 0);
+
+		/// <summary>
+		/// Gets or sets the base swipe threshold (in density-independent units) that
+		/// determines how far the user must swipe horizontally before a tab switch
+		/// is triggered on Android.
+		/// </summary>
+		/// <value>
+		/// A positive <see cref="double"/> value. Defaults to <c>5.0</c>.
+		/// </value>
+		/// <remarks>
+		/// The actual pixel threshold used internally is <c>SwipeSensitivity × DisplayDensity</c>.
+		/// <list type="bullet">
+		///   <item>
+		///     <description>
+		///       Increase this value (e.g. <c>15</c>–<c>20</c>) when users accidentally
+		///       switch tabs while scrolling vertically through list content inside a tab.
+		///     </description>
+		///   </item>
+		///   <item>
+		///     <description>
+		///       Decrease this value (e.g. <c>2</c>–<c>3</c>) if you want the control to
+		///       respond to very short horizontal swipes.
+		///     </description>
+		///   </item>
+		/// </list>
+		/// This property only affects the Android platform; on other platforms the
+		/// swipe gesture is handled natively and is not configurable through this API.
+		/// </remarks>
+		/// <example>
+		/// XAML:
+		/// <code>
+		/// &lt;toolkit:SfTabView SwipeSensitivity="15"&gt;
+		///     &lt;toolkit:SfTabItem Header="Tab 1"&gt;
+		///         &lt;CollectionView ItemsSource="{Binding Items}" /&gt;
+		///     &lt;/toolkit:SfTabItem&gt;
+		/// &lt;/toolkit:SfTabView&gt;
+		/// </code>
+		/// C#:
+		/// <code>
+		/// var tabView = new SfTabView { SwipeSensitivity = 15 };
+		/// </code>
+		/// </example>
+		public double SwipeSensitivity
+		{
+			get => (double)GetValue(SwipeSensitivityProperty);
+			set => SetValue(SwipeSensitivityProperty, value);
+		}
+
+		#endregion
+
 	}
 }

--- a/maui/src/TabView/Control/SfTabView.cs
+++ b/maui/src/TabView/Control/SfTabView.cs
@@ -3194,7 +3194,7 @@ namespace Syncfusion.Maui.Toolkit.TabView
 				typeof(double),
 				typeof(SfTabView),
 				DefaultSwipeSensitivity,
-				validateValue: (_, value) => (double)value > 0);
+				validateValue: (_, value) => value is double d && double.IsFinite(d) && d > 0);
 
 		/// <summary>
 		/// Gets or sets the base swipe threshold (in density-independent units) that

--- a/maui/src/TabView/Control/SfTabView.cs
+++ b/maui/src/TabView/Control/SfTabView.cs
@@ -3174,8 +3174,8 @@ namespace Syncfusion.Maui.Toolkit.TabView
 		#region Swipe Sensitivity
 
 		/// <summary>
-		/// The default base swipe threshold multiplier (density-independent units).
-		/// Matches the original hard-coded value of 5, preserving backward compatibility.
+		/// The default base swipe threshold (in density-independent units).
+		/// Matches the original hard-coded base value of 5, preserving backward compatibility.
 		/// </summary>
 		internal const double DefaultSwipeSensitivity = 5.0;
 


### PR DESCRIPTION
**Closes #393**

---

## Summary

Adds a new `SwipeSensitivity` bindable property to `SfTabView` that lets developers control
how far the user must swipe horizontally before a tab switch is triggered on Android.

The old behaviour (hard-coded threshold of `5 × display density`) is preserved as the default
value, so this is a **non-breaking change**.

---

## Problem

The `_swipeThreshold` in `SfHorizontalContent.Android.cs` was computed from a hard-coded
multiplier of `5`:

```csharp
double _swipeThreshold => 5 * _density;
```

This made the control noticeably more sensitive than the native MAUI `TabbedPage`, causing
users to accidentally switch tabs while scrolling vertically through list content hosted
inside a tab.

---

## Solution

### 1. `Region Swipe Sensitivity` *(new #Region)*

A new `BindableProperty` is added to `SfTabView`:

```csharp
public static readonly BindableProperty SwipeSensitivityProperty =
    BindableProperty.Create(
        nameof(SwipeSensitivity),
        typeof(double),
        typeof(SfTabView),
        defaultValue: 5.0,             // backward-compatible default
        validateValue: (_, v) => (double)v > 0);

public double SwipeSensitivity
{
    get => (double)GetValue(SwipeSensitivityProperty);
    set => SetValue(SwipeSensitivityProperty, value);
}
```

An `internal const double DefaultSwipeSensitivity = 5.0` is also exposed so the Android
file can reference it without hard-coding the number again.

### 2. `SfHorizontalContent.Android.cs` *(modified)*

The hard-coded multiplier is replaced with a read of the new property:

```csharp
// Before
double _swipeThreshold => 5 * _density;

// After
double _swipeThreshold =>
    (_tabView?.SwipeSensitivity ?? SfTabView.DefaultSwipeSensitivity) * _density;
```

---

## Public API Change

| Member | Kind | Default |
|---|---|---|
| `SfTabView.SwipeSensitivityProperty` | `static readonly BindableProperty` | — |
| `SfTabView.SwipeSensitivity` | `double` (read/write) | `5.0` |

### XAML usage

```xml
<!-- Reduce sensitivity: user must swipe ≥15 dp before tab switches -->
<toolkit:SfTabView SwipeSensitivity="15">
    <toolkit:SfTabItem Header="Consulta">
        <views:ConsultaCliente />
    </toolkit:SfTabItem>
    <toolkit:SfTabItem Header="Histórico">
        <views:HistoricoCliente />
    </toolkit:SfTabItem>
</toolkit:SfTabView>
```

### C# usage

```csharp
var tabView = new SfTabView
{
    SwipeSensitivity = 15   // much less likely to trigger accidentally
};
```

---

## Behaviour by value

| `SwipeSensitivity` | Pixel threshold (mdpi=1×) | Effect |
|---|---|---|
| `2` | 2 px | Very sensitive – short swipes switch tabs |
| **`5` (default)** | **5 px** | **Original behaviour – no change for existing apps** |
| `15` | 15 px | Recommended when tabs host vertically scrollable lists |
| `20` | 20 px | Near-native MAUI `TabbedPage` feel |

---

## Platforms affected

Only **Android** (`SfHorizontalContent.Android.cs`). The property is defined on the
cross-platform `SfTabView` class so it is bindable from XAML/C# on all platforms, but
swipe interception on iOS/Windows/macOS is handled by the platform's native gesture
recognisers and is not affected.

---

## Checklist

- [x] No breaking change (default value preserves existing behaviour)
- [x] `BindableProperty` validates that the value is positive
- [x] XML doc comments on the new property and constant
- [x] Consistent naming with existing `Enable*` / numeric properties in the control
- [x] `DefaultSwipeSensitivity` constant used in both files to avoid magic numbers
