### PR TITLE
Update the NumberPad key handling in SfOtpInput Control on Windows

### DIFF
--- a/maui/src/OtpInput/SfOtpInput.cs
+++ b/maui/src/OtpInput/SfOtpInput.cs
@@ -2164,7 +2164,7 @@ namespace Syncfusion.Maui.Toolkit.OtpInput
 
 				default:
                     if ((e.Key >= Windows.System.VirtualKey.A && e.Key <= Windows.System.VirtualKey.Z) ||
-                        (e.Key >= Windows.System.VirtualKey.Number0 && e.Key <= Windows.System.VirtualKey.Number9))
+                        (e.Key >= Windows.System.VirtualKey.Number0 && e.Key <= Windows.System.VirtualKey.Number9) || (e.Key >= Windows.System.VirtualKey.NumberPad0 && e.Key <= Windows.System.VirtualKey.NumberPad9))
                     {
                         string text = e.Key.ToString();
                         HandleKeyPress(text);


### PR DESCRIPTION

### Root Cause of the Issue

On Windows, keyboard input handling differentiates between top-row number keys (VirtualKey.Number0–Number9) and numeric keypad keys (VirtualKey.NumberPad0–NumberPad9).
The existing OnKeyDown logic handled only the top-row number keys and did not include NumberPad keys. As a result, inputs from the numeric keypad were ignored, preventing text updates and the triggering of the TextChanged event.

### Description of Change

Updated the Windows OnKeyDown event handling logic to include numeric keypad inputs by adding a condition for VirtualKey.NumberPad0–NumberPad9.
This ensures both top-row numbers and NumberPad inputs are processed correctly and passed to the input handling logic.
Code change:
`|| (e.Key >= Windows.System.VirtualKey.NumberPad0 &&
    e.Key <= Windows.System.VirtualKey.NumberPad9)
`

### Screenshots

#### Before:
<img width="1422" height="808" alt="image" src="https://github.com/user-attachments/assets/9fc8956e-0d36-4d70-a223-df5c3956bfcd" />


#### After:
<img width="1422" height="808" alt="image" src="https://github.com/user-attachments/assets/816ae322-7115-46c8-9a4f-80898cc994a0" />
