### PR TITLE
Fixed crash in Toolkit SfButton due to VisualStateManager API changes in NET 11

### DIFF
--- a/maui/src/Button/SfButton.Methods.cs
+++ b/maui/src/Button/SfButton.Methods.cs
@@ -900,16 +900,7 @@ namespace Syncfusion.Maui.Toolkit.Buttons
 #else
 			string stateName = IsEnabled ? _isPressed ? "Pressed" : IsCheckable && IsChecked ? "Checked" : "Normal" : IsCheckable && IsChecked ? "Checked" : "Disabled";
 #endif
-			var stateGroup = VisualStateManager.GetVisualStateGroups(this);
-			var findName = "Normal";
-			foreach (VisualStateGroup state in stateGroup)
-			{
-				foreach (var a in state.States)
-				{
-					findName = a.Name == stateName ? stateName : findName;
-				}
-			}
-			VisualStateManager.GoToState(this, findName);
+			VisualStateManager.GoToState(this, stateName);
 			InvalidateDrawable();
 		}
 


### PR DESCRIPTION

### Root Cause of the Issue

Application crash occurs when using SfButton in .NET MAUI during .NET 11 compatibility testing. The crash is triggered by the call to VisualStateManager.GetVisualStateGroups(this);

The issue occurs due to framework changes in .NET 11, where the return type of visual state group retrieval has been modified.
Previously:
`public static IList<VisualStateGroup> GetVisualStateGroups(VisualElement visualElement)`
Now
`public static VisualStateGroupList GetVisualStateGroups(VisualElement visualElement)`
Framework PR: https://github.com/dotnet/maui/pull/33849


### Description of Change
Resolved the issue by removing the GetVisualStateGroups implementations:

`var stateGroup = VisualStateManager.GetVisualStateGroups(this);`

from both SfButton, avoiding the incompatible API usage and preventing the crash.
