### PR TITLE
perf: Chart control performance improvements

### DIFF
--- a/maui/src/Charts/Axis/ChartAxis.cs
+++ b/maui/src/Charts/Axis/ChartAxis.cs
@@ -386,15 +386,18 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 			if (!IsPolarArea)
 			{
-				foreach (CartesianSeries series in visibleSeries.Cast<CartesianSeries>())
+				for (int i = 0; i < visibleSeries.Count; i++)
 				{
-					if (series.ActualXAxis == this)
+					if (visibleSeries[i] is CartesianSeries series)
 					{
-						range += series.VisibleXRange;
-					}
-					else if (series.ActualYAxis == this)
-					{
-						range += series.VisibleYRange;
+						if (series.ActualXAxis == this)
+						{
+							range += series.VisibleXRange;
+						}
+						else if (series.ActualYAxis == this)
+						{
+							range += series.VisibleYRange;
+						}
 					}
 				}
 			}

--- a/maui/src/Charts/Axis/Renderer/CartesianAxisRenderer.cs
+++ b/maui/src/Charts/Axis/Renderer/CartesianAxisRenderer.cs
@@ -153,8 +153,9 @@ namespace Syncfusion.Maui.Toolkit.Charts
 			}
 
 			float currentPosition = 0;
+			int elementCount = elements.Count;
 
-			for (int i = 0; i < elements.Count; i++)
+			for (int i = 0; i < elementCount; i++)
 			{
 				object element = elements[i];
 

--- a/maui/src/Charts/ChartBase.cs
+++ b/maui/src/Charts/ChartBase.cs
@@ -597,8 +597,9 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				return null;
 			}
 
-			foreach (var chartSeries in visibleSeries.Reverse())
+			for (int i = visibleSeries.Count - 1; i >= 0; i--)
 			{
+				var chartSeries = visibleSeries[i];
 				if (!chartSeries.EnableTooltip || chartSeries.PointsCount <= 0)
 				{
 					continue;

--- a/maui/src/Charts/Series/CartesianSeries.cs
+++ b/maui/src/Charts/Series/CartesianSeries.cs
@@ -1153,13 +1153,16 @@ namespace Syncfusion.Maui.Toolkit.Charts
 		{
 			if (ChartArea != null)
 			{
-				var sideBySideSeries = ChartArea.VisibleSeries?.Where(series => series.IsSideBySide).ToList();
+				var visibleSeries = ChartArea.VisibleSeries;
 
-				if (sideBySideSeries != null && sideBySideSeries.Count > 0)
+				if (visibleSeries != null)
 				{
-					foreach (var chartSeries in sideBySideSeries)
+					foreach (var chartSeries in visibleSeries)
 					{
-						chartSeries.SegmentsCreated = false;
+						if (chartSeries.IsSideBySide)
+						{
+							chartSeries.SegmentsCreated = false;
+						}
 					}
 				}
 
@@ -1414,9 +1417,9 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 			if (legend != null && legend.IsVisible && legendItems != null)
 			{
-				foreach (LegendItem legendItem in legendItems.Cast<LegendItem>())
+				for (int i = 0; i < legendItems.Count; i++)
 				{
-					if (legendItem != null && legendItem.Item == this)
+					if (legendItems[i] is LegendItem legendItem && legendItem.Item == this)
 					{
 						legendItem.IconBrush = GetFillColor(legendItem, legendItem.Index) ?? new SolidColorBrush(Colors.Transparent);
 						break;
@@ -1432,9 +1435,9 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 			if (legend != null && legend.IsVisible && legendItems != null)
 			{
-				foreach (LegendItem legendItem in legendItems.Cast<LegendItem>())
+				for (int i = 0; i < legendItems.Count; i++)
 				{
-					if (legendItem != null && legendItem.Item == this)
+					if (legendItems[i] is LegendItem legendItem && legendItem.Item == this)
 					{
 						legendItem.IsToggled = !IsVisible;
 						break;
@@ -2114,9 +2117,9 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 				if (legendItems != null)
 				{
-					foreach (LegendItem legendItem in legendItems.Cast<LegendItem>())
+					for (int i = 0; i < legendItems.Count; i++)
 					{
-						if (legendItem != null && legendItem.Item == chartSeries)
+						if (legendItems[i] is LegendItem legendItem && legendItem.Item == chartSeries)
 						{
 							legendItem.Text = chartSeries.Label;
 							break;

--- a/maui/src/Charts/Series/ChartSeries.cs
+++ b/maui/src/Charts/Series/ChartSeries.cs
@@ -1628,7 +1628,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 			if (LabelContext == LabelContext.Percentage)
 			{
 				var percentage = Math.Floor((value / sumOfValue * 100) * 100) / 100;
-				labelContent = percentage.ToString() + "%";
+				labelContent = $"{percentage}%";
 			}
 			else
 			{

--- a/maui/src/Charts/Series/ChartSeriesPartial.cs
+++ b/maui/src/Charts/Series/ChartSeriesPartial.cs
@@ -21,6 +21,8 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 		bool _isComplexYProperty;
 
+		bool _isComplexXProperty;
+
 		ChartValueType _xValueType;
 
 		bool _isRepeatPoint;
@@ -234,10 +236,13 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 					if (categoryAxis.RegisteredSeries.Count > 0)
 					{
-						foreach (CartesianSeries chartSeries in categoryAxis.RegisteredSeries.Cast<CartesianSeries>())
+						for (int i = 0; i < categoryAxis.RegisteredSeries.Count; i++)
 						{
-							chartSeries.SegmentsCreated = false;
-							chartSeries.ChartArea?.UpdateVisibleSeries();
+							if (categoryAxis.RegisteredSeries[i] is CartesianSeries chartSeries)
+							{
+								chartSeries.SegmentsCreated = false;
+								chartSeries.ChartArea?.UpdateVisibleSeries();
+							}
 						}
 					}
 				}
@@ -672,6 +677,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 			IList<double>[]? yLists = null;
 			_isComplexYProperty = false;
+			_isComplexXProperty = XBindingPath.Contains('.', StringComparison.Ordinal);
 			bool isArrayProperty = false;
 			YComplexPaths = new string[yPaths.Length][];
 
@@ -709,7 +715,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 					{
 						GenerateComplexPropertyPoints(yPaths, yLists, GetArrayPropertyValue);
 					}
-					else if (XBindingPath.Contains('.', StringComparison.Ordinal) || _isComplexYProperty)
+					else if (_isComplexXProperty || _isComplexYProperty)
 					{
 						GenerateComplexPropertyPoints(yPaths, yLists, GetPropertyValue);
 					}
@@ -1279,8 +1285,10 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				var path = paths[i];
 				if (path.Contains('[', StringComparison.Ordinal))
 				{
-					int index = Convert.ToInt32(path.Substring(path.IndexOf('[', StringComparison.Ordinal) + 1, path.IndexOf(']', StringComparison.Ordinal) - path.IndexOf('[', StringComparison.Ordinal) - 1));
-					string actualPath = path.Replace(path[path.IndexOf('[', StringComparison.Ordinal)..], string.Empty, StringComparison.Ordinal);
+					int bracketOpen = path.IndexOf('[', StringComparison.Ordinal);
+					int bracketClose = path.IndexOf(']', StringComparison.Ordinal);
+					int index = Convert.ToInt32(path.Substring(bracketOpen + 1, bracketClose - bracketOpen - 1));
+					string actualPath = path.Replace(path[bracketOpen..], string.Empty, StringComparison.Ordinal);
 					parentObj = ReflectedObject(parentObj, actualPath);
 
 					if (parentObj == null)
@@ -1338,7 +1346,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 					{
 						if (listenToPropertyChange)
 						{
-							if (_isComplexYProperty || XBindingPath.Contains('.', StringComparison.Ordinal))
+							if (_isComplexYProperty || _isComplexXProperty)
 							{
 								HookComplexProperty(enumerator.Current, XComplexPaths!);
 
@@ -1470,7 +1478,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 				return;
 			}
 
-			if (_isComplexYProperty || XBindingPath.Contains('.', StringComparison.Ordinal))
+			if (_isComplexYProperty || _isComplexXProperty)
 			{
 				ComplexPropertyChanged(sender, e);
 			}


### PR DESCRIPTION
### Root Cause of the Issue
The Chart control source code uses several LINQ patterns (.Reverse(), .Cast<>(), .Where().ToList()) and repeated string operations that cause unnecessary heap allocations and repeated work on every frame/update cycle.

### Description of Change
This PR implements 10 targeted performance improvements in the Chart control source code:

1. **Replace `.Reverse()` with reverse index loop** in `ChartBase.cs` — avoids allocating a reversed collection during tooltip hit-testing
2. **Remove `.Where().ToList()` allocation** in `CartesianSeries.cs` — replaces filtered list with direct iteration
3. **Replace `.Cast<CartesianSeries>()` with pattern matching** in `ChartAxis.cs` — eliminates LINQ enumerator overhead
4. **Cache IndexOf calls** in `ChartSeriesPartial.cs` — avoids scanning the same string multiple times
5. **Replace string concatenation with interpolation** in `ChartSeries.cs` — minor allocation improvement
6. **Replace `.Cast<CartesianSeries>()` in group update** in `ChartSeriesPartial.cs` — pattern matching loop
7. **Simplify ItemsSource IList check** — already optimized in current code (no change needed)
8. **Cache `.Count` in loop conditions** in `CartesianAxisRenderer.cs` — avoids repeated property access
9. **Cache complex property path check** in `ChartSeriesPartial.cs` — introduces `_isComplexXProperty` field to avoid repeated `String.Contains` calls
10. **Replace remaining `.Cast<>()` usages** in `CartesianSeries.cs` legend item loops — pattern matching with indexed access

### Issues Fixed
N/A — Performance improvement

### Screenshots
N/A — No visual changes