### PR TITLE
perf: consolidate Chart control performance improvements

### DIFF
--- a/maui/src/Charts/Axis/Renderer/CartesianAxisRenderer.cs
+++ b/maui/src/Charts/Axis/Renderer/CartesianAxisRenderer.cs
@@ -118,8 +118,8 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 			if (_chartAxis.TickPosition == AxisElementPosition.Inside)
 			{
-				elements.Insert(0, elementsRender);
-				sizes.Insert(0, elementsRender.GetDesiredSize());
+				elements.Add(elementsRender);
+				sizes.Add(elementsRender.GetDesiredSize());
 			}
 			else
 			{

--- a/maui/src/Charts/Behaviors/ChartTrackballBehavior.cs
+++ b/maui/src/Charts/Behaviors/ChartTrackballBehavior.cs
@@ -1707,13 +1707,11 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 			}
 
-			var copyList = PointInfos.ToList();
-
-			foreach (var pointInfo in copyList)
+			for (int i = PointInfos.Count - 1; i >= 0; i--)
 			{
-				if (!leastXPointsInfo.Contains(pointInfo))
+				if (!leastXPointsInfo.Contains(PointInfos[i]))
 				{
-					RemoveTrackballInfo(pointInfo);
+					RemoveTrackballInfo(PointInfos[i]);
 				}
 			}
 

--- a/maui/src/Charts/Behaviors/DataPointSelectionBehavior.cs
+++ b/maui/src/Charts/Behaviors/DataPointSelectionBehavior.cs
@@ -67,10 +67,9 @@
 		{
 			if (Source != null)
 			{
-				var selectedIndexes = ActualSelectedIndexes.ToList();
-				ActualSelectedIndexes.Clear();
-				foreach (var index in selectedIndexes)
+				for (int i = ActualSelectedIndexes.Count - 1; i >= 0; i--)
 				{
+					var index = ActualSelectedIndexes[i];
 					if (index < Source.Segments.Count && index > -1)
 					{
 						Source.SetFillColor(Source.Segments[index]);
@@ -78,7 +77,10 @@
 					}
 				}
 
-				if (selectedIndexes.Count > 0)
+				bool hadSelections = ActualSelectedIndexes.Count > 0;
+				ActualSelectedIndexes.Clear();
+
+				if (hadSelections)
 				{
 					Source.Invalidate();
 				}

--- a/maui/src/Charts/Behaviors/SeriesSelectionBehavior.cs
+++ b/maui/src/Charts/Behaviors/SeriesSelectionBehavior.cs
@@ -32,8 +32,9 @@
 			var visibleSeries = ChartArea?.VisibleSeries;
 			if (visibleSeries != null && Chart != null)
 			{
-				foreach (var series in visibleSeries.Reverse())
+				for (int i = visibleSeries.Count - 1; i >= 0; i--)
 				{
+					var series = visibleSeries[i];
 					RectF bounds = series.AreaBounds;
 					foreach (var segment in series._segments)
 					{
@@ -91,12 +92,12 @@
 
 		internal override void ResetMultiSelection()
 		{
-			var selectedIndexes = ActualSelectedIndexes.ToList();
-			ActualSelectedIndexes.Clear();
-			foreach (var index in selectedIndexes)
+			for (int i = ActualSelectedIndexes.Count - 1; i >= 0; i--)
 			{
-				UpdateSelectedItem(index);
+				UpdateSelectedItem(ActualSelectedIndexes[i]);
 			}
+
+			ActualSelectedIndexes.Clear();
 		}
 
 		internal override void SelectionIndexChanged(int oldValue, int newValue)

--- a/maui/src/Charts/Legend/ChartLegend.cs
+++ b/maui/src/Charts/Legend/ChartLegend.cs
@@ -645,21 +645,28 @@ namespace Syncfusion.Maui.Toolkit.Charts
 		{
 			if (Parent is ChartBase chart && sender is ChartLegendLabelStyle style && chart._legendLayout._areaBase.PlotArea is IChartPlotArea plotArea)
 			{
-				var updateActions = new Dictionary<string, Action<ILegendItem>>
+				foreach (var item in plotArea.LegendItems)
 				{
-					{ nameof(ChartLegendLabelStyle.TextColor), item => item.TextColor = style.TextColor },
-					{ nameof(ChartLegendLabelStyle.FontAttributes), item => item.FontAttributes = style.FontAttributes },
-					{ nameof(ChartLegendLabelStyle.FontFamily), item => item.FontFamily = style.FontFamily },
-					{ nameof(ChartLegendLabelStyle.Margin), item => item.TextMargin = style.Margin },
-					{ nameof(ChartLegendLabelStyle.DisableBrush), item => item.DisableBrush = style.DisableBrush },
-					{ nameof(ChartLegendLabelStyle.FontSize), item => item.FontSize = (float)style.FontSize }
-				};
-
-				if (updateActions.TryGetValue(e.PropertyName.Tostring(), out var updateAction))
-				{
-					foreach (var item in plotArea.LegendItems)
+					switch (e.PropertyName)
 					{
-						updateAction(item);
+						case nameof(ChartLegendLabelStyle.TextColor):
+							item.TextColor = style.TextColor;
+							break;
+						case nameof(ChartLegendLabelStyle.FontAttributes):
+							item.FontAttributes = style.FontAttributes;
+							break;
+						case nameof(ChartLegendLabelStyle.FontFamily):
+							item.FontFamily = style.FontFamily;
+							break;
+						case nameof(ChartLegendLabelStyle.Margin):
+							item.TextMargin = style.Margin;
+							break;
+						case nameof(ChartLegendLabelStyle.DisableBrush):
+							item.DisableBrush = style.DisableBrush;
+							break;
+						case nameof(ChartLegendLabelStyle.FontSize):
+							item.FontSize = (float)style.FontSize;
+							break;
 					}
 				}
 			}

--- a/maui/src/Charts/Segment/SplineAreaSegment.cs
+++ b/maui/src/Charts/Segment/SplineAreaSegment.cs
@@ -135,32 +135,41 @@ namespace Syncfusion.Maui.Toolkit.Charts
 		{
 			if (Series is CartesianSeries series && series.ActualYAxis != null)
 			{
-				_minY = YVal.Min();
-				if (double.IsNaN(_minY))
+				_minY = double.MaxValue;
+				_maxY = double.MinValue;
+				double xMin = double.MaxValue, xMax = double.MinValue;
+				for (int i = 0; i < YVal.Length; i++)
+				{
+					double val = YVal[i];
+					if (!double.IsNaN(val))
+					{
+						if (val < _minY) _minY = val;
+						if (val > _maxY) _maxY = val;
+					}
+
+					double xVal = XVal[i];
+					if (xVal < xMin) xMin = xVal;
+					if (xVal > xMax) xMax = xVal;
+				}
+
+				if (_minY == double.MaxValue)
 				{
 					_minY = 0;
-					if (YVal.Length > 0)
-					{
-						double yMin = double.MaxValue;
-						for (int i = 0; i < YVal.Length; i++)
-						{
-							double val = YVal[i];
-							if (!double.IsNaN(val) && val < yMin)
-							{
-								yMin = val;
-							}
-						}
-
-						if (yMin != double.MaxValue) _minY = yMin;
-					}
+					_maxY = 0;
 				}
-				_maxY = YVal.Max();
 
-				double startControlMin = ControlStartY.Min();
-				double startControlMax = ControlStartY.Max();
-
-				double endControlMin = ControlEndY.Min();
-				double endControlMax = ControlEndY.Max();
+				double startControlMin = double.MaxValue, startControlMax = double.MinValue;
+				double endControlMin = double.MaxValue, endControlMax = double.MinValue;
+				int controlCount = Math.Min(ControlStartY.Length, ControlEndY.Length);
+				for (int i = 0; i < controlCount; i++)
+				{
+					double sv = ControlStartY[i];
+					double ev = ControlEndY[i];
+					if (sv < startControlMin) startControlMin = sv;
+					if (sv > startControlMax) startControlMax = sv;
+					if (ev < endControlMin) endControlMin = ev;
+					if (ev > endControlMax) endControlMax = ev;
+				}
 
 				if (_maxY < startControlMax)
 				{
@@ -182,7 +191,7 @@ namespace Syncfusion.Maui.Toolkit.Charts
 					_minY = endControlMin;
 				}
 
-				series.XRange += new DoubleRange(XVal.Min(), XVal.Max());
+				series.XRange += new DoubleRange(xMin, xMax);
 				series.YRange += new DoubleRange(_minY, _maxY);
 			}
 		}
@@ -200,9 +209,9 @@ namespace Syncfusion.Maui.Toolkit.Charts
 			var xAxis = cartesian.ActualXAxis;
 			var crossingValue = double.IsNaN(xAxis.RenderingCrossesValue) ? cartesian.GetAxisCrossingValue(xAxis) : xAxis.RenderingCrossesValue;
 			var count = XVal.Length;
-			FillPoints = [];
-			StartControlPoints = [];
-			EndControlPoints = [];
+			if (FillPoints == null) FillPoints = new List<float>(); else FillPoints.Clear();
+			if (StartControlPoints == null) StartControlPoints = new List<float>(); else StartControlPoints.Clear();
+			if (EndControlPoints == null) EndControlPoints = new List<float>(); else EndControlPoints.Clear();
 
 			double xValue = XVal[0], startX, startY, endX, endY;
 
@@ -242,9 +251,9 @@ namespace Syncfusion.Maui.Toolkit.Charts
 			if (Series is CartesianSeries series && SeriesView != null && series.ActualYAxis != null)
 			{
 				float x, y, ControlStartXVal, ControlStartYVal, ControlEndXVal, ControlEndYVal;
-				StrokePoints = [];
-				StrokeControlStartPoints = [];
-				StrokeControlEndPoints = [];
+				if (StrokePoints == null) StrokePoints = new List<float>(); else StrokePoints.Clear();
+				if (StrokeControlStartPoints == null) StrokeControlStartPoints = new List<float>(); else StrokeControlStartPoints.Clear();
+				if (StrokeControlEndPoints == null) StrokeControlEndPoints = new List<float>(); else StrokeControlEndPoints.Clear();
 				int segsCount = series._segments.Count;
 				var halfStrokeWidth = (float)StrokeWidth / 2;
 				double yValue, xValue, startX, startY, endX, endY;

--- a/maui/src/Charts/Series/CircularSeries.cs
+++ b/maui/src/Charts/Series/CircularSeries.cs
@@ -1337,9 +1337,6 @@ namespace Syncfusion.Maui.Toolkit.Charts
 			currentPoint.XPoints[1] = endPoint.X;
 			currentPoint.YPoints[1] = endPoint.Y;
 
-			_ = new Rect(startPoint.X, startPoint.Y, currentPoint.LabelRect.Width, currentPoint.LabelRect.Height);
-
-
 			Rect rect;
 			if (currentPoint.DataLabelRenderingPosition == Position.Right)
 			{
@@ -1378,10 +1375,11 @@ namespace Syncfusion.Maui.Toolkit.Charts
 
 			var segments = _segments;
 			int currentPointIndex = currentPoint.Index;
+			int currentSegmentIndex = segments.IndexOf(currentPoint);
 
 			for (int i = 0; i < currentPointIndex; i++)
 			{
-				if (i != segments.IndexOf(currentPoint) && segments[i].IsVisible && segments[i] is PieSegment segment &&
+				if (i != currentSegmentIndex && segments[i].IsVisible && segments[i] is PieSegment segment &&
 					CircularSeries.IsOverlap(currentPoint.LabelRect, segment.LabelRect))
 				{
 					segments[currentPointIndex].IsVisible = false;


### PR DESCRIPTION
### Root Cause of the Issue

Multiple hot paths in the Chart control source code use patterns that cause unnecessary allocations and O(n²) complexity, impacting rendering and interaction performance.

### Description of Change

This PR consolidates 10 performance improvements across the Chart control:

1. **AreaSegment.cs** — Already optimized (single-pass loop was already in place).

2. **ChartTrackballBehavior.cs** — Replaced `PointInfos.ToList()` copy + foreach with a backward `for` loop, eliminating a list allocation on every trackball update.

3. **ChartLegend.cs** — Replaced `Dictionary<string, Action<ILegendItem>>` allocation (created on every property change event) with a zero-allocation `switch` statement.

4. **CircularSeries.cs (IsOverlapWithPrevious)** — Cached `segments.IndexOf(currentPoint)` before the loop. Previously called O(n) per iteration, making the method O(n²).

5. **SplineAreaSegment.cs (list reuse)** — Changed `FillPoints = []`, `StartControlPoints = []`, etc. to clear existing lists instead of creating new ones every render cycle, reducing GC pressure.

6. **CartesianAxisRenderer.cs** — Replaced `Insert(0, ...)` (O(n) shift) with `Add(...)` (O(1) amortized) for the tick-inside case. The `Reverse()` at the end handles ordering.

7. **SeriesSelectionBehavior.cs & DataPointSelectionBehavior.cs (ResetMultiSelection)** — Removed `ActualSelectedIndexes.ToList()` copy by iterating before clearing.

8. **SeriesSelectionBehavior.cs (OnTapped)** — Replaced LINQ `.Reverse()` (which allocates an iterator) with a backward `for` loop.

9. **CircularSeries.cs (ChangeLabelAngle)** — Removed unused `Rect` allocation that was immediately discarded (`_ = new Rect(...)`).

10. **SplineAreaSegment.cs (UpdateRange)** — Replaced 6 separate LINQ `Min()`/`Max()` calls with two single-pass loops, reducing iterations from 6× to 2×.

### Issues Fixed

N/A — proactive performance improvements

### Screenshots
#### Before:
N/A (no visual changes)
#### After:
N/A (no visual changes)