### PR TITLE
perf(SparkCharts): reduce allocations in data processing and trackball rendering

### DIFF
--- a/maui/src/SparkCharts/Behaviors/SparkChartTrackballBehavior.cs
+++ b/maui/src/SparkCharts/Behaviors/SparkChartTrackballBehavior.cs
@@ -22,6 +22,14 @@ namespace Syncfusion.Maui.Toolkit.SparkCharts
 		private SfTooltip? _templateView;
 		private SparkChartTrackballInfo? _previousTrackballInfo;
 
+		// Cached tooltip position list to avoid repeated allocations on every draw call
+		static readonly List<TooltipPosition> s_tooltipFallbackPositions =
+		[
+			TooltipPosition.Left,
+			TooltipPosition.Top,
+			TooltipPosition.Bottom
+		];
+
 		#endregion
 
 		#region Bindable Properties
@@ -975,12 +983,7 @@ namespace Syncfusion.Maui.Toolkit.SparkCharts
 			
 			// Set preferred position to right (similar to ChartTrackballBehavior)
 			TooltipHelper.PriorityPosition = TooltipPosition.Right;
-			TooltipHelper.PriorityPositionList = new List<TooltipPosition>
-			{
-				TooltipPosition.Left,
-				TooltipPosition.Top,
-				TooltipPosition.Bottom
-			};
+			TooltipHelper.PriorityPositionList = s_tooltipFallbackPositions;
 
 			// Create target rect around the marker point (small rect for nose to point to)
 			float markerWidth = MarkerSettings != null ? (float)MarkerSettings.Width : 8f;
@@ -1058,12 +1061,7 @@ namespace Syncfusion.Maui.Toolkit.SparkCharts
 		private static void SetTemplatePosition(SfTooltip templateView)
 		{
 			templateView.Helper.PriorityPosition = TooltipPosition.Right;
-			templateView.Helper.PriorityPositionList = new List<TooltipPosition>
-			{
-				TooltipPosition.Left,
-				TooltipPosition.Top,
-				TooltipPosition.Bottom
-			};
+			templateView.Helper.PriorityPositionList = s_tooltipFallbackPositions;
 		}
 
 		/// <summary>

--- a/maui/src/SparkCharts/SfSparkChart.cs
+++ b/maui/src/SparkCharts/SfSparkChart.cs
@@ -911,7 +911,8 @@ namespace Syncfusion.Maui.Toolkit.SparkCharts
 						}
 					}
 
-					foreach (var value in pairs.OrderBy(value => value.x))
+					pairs.Sort((a, b) => a.x.CompareTo(b.x));
+					foreach (var value in pairs)
 					{
 						xValues.Add(value.x);
 						yValues.Add(value.y);
@@ -931,7 +932,8 @@ namespace Syncfusion.Maui.Toolkit.SparkCharts
 						}
 					}
 
-					foreach (var value in pairs.OrderBy(value => value.x))
+					pairs.Sort((a, b) => a.x.CompareTo(b.x));
+					foreach (var value in pairs)
 					{
 						xValues.Add(value.x);
 						yValues.Add(value.y);
@@ -1185,16 +1187,34 @@ namespace Syncfusion.Maui.Toolkit.SparkCharts
 				return;
 			}
 
-			var validYValues = yValues.Where(y => !double.IsNaN(y)).ToList();
+			// Single-pass min/max calculation avoids LINQ allocation and multiple enumerations
+			double yMin = double.MaxValue;
+			double yMax = double.MinValue;
+			for (int i = 0; i < yValues.Count; i++)
+			{
+				double y = yValues[i];
+				if (!double.IsNaN(y))
+				{
+					if (y < yMin)
+					{
+						yMin = y;
+					}
 
-			if (validYValues.Count == 0)
+					if (y > yMax)
+					{
+						yMax = y;
+					}
+				}
+			}
+
+			if (yMin == double.MaxValue)
 			{
 				minYValue = maxYValue = 0;
 			}
 			else
 			{
-				minYValue = validYValues.Min();
-				maxYValue = validYValues.Max();
+				minYValue = yMin;
+				maxYValue = yMax;
 			}
 
 			if (!double.IsNaN(MinimumYValue))
@@ -1216,8 +1236,25 @@ namespace Syncfusion.Maui.Toolkit.SparkCharts
 
 			if (xValues.Count > 0)
 			{
-				minXValue = xValues.Min();
-				maxXValue = xValues.Max();
+				// Single-pass min/max avoids two separate enumerations
+				double xMin = xValues[0];
+				double xMax = xValues[0];
+				for (int i = 1; i < xValues.Count; i++)
+				{
+					double x = xValues[i];
+					if (x < xMin)
+					{
+						xMin = x;
+					}
+
+					if (x > xMax)
+					{
+						xMax = x;
+					}
+				}
+
+				minXValue = xMin;
+				maxXValue = xMax;
 			}
 			else
 			{

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/SparkChart/SfSparkChartUnitTest.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/SparkChart/SfSparkChartUnitTest.cs
@@ -341,5 +341,118 @@ namespace Syncfusion.Maui.Toolkit.UnitTest.SparkCharts
         }
 
         #endregion
+
+        #region Performance Optimization Tests
+
+        [Fact]
+        public void UpdateMinMaxValues_AllNaNValues_ReturnsZeroMinMax()
+        {
+            // Arrange
+            var chart = new TestSparkChart();
+
+            // Act
+            chart.ItemsSource = new List<double> { double.NaN, double.NaN, double.NaN };
+
+            // Assert
+            Assert.Equal(0, chart.MinY);
+            Assert.Equal(0, chart.MaxY);
+        }
+
+        [Fact]
+        public void UpdateMinMaxValues_MixedNaNAndValidValues_IgnoresNaN()
+        {
+            // Arrange - use EmptyPointMode.None so NaN values remain as-is
+            var chart = new TestSparkChart();
+            chart.EmptyPointMode = SparkChartEmptyPointMode.None;
+
+            // Act
+            chart.ItemsSource = new List<double> { double.NaN, 5, double.NaN, 15, double.NaN, 10 };
+
+            // Assert - NaN values should be ignored in min/max calculation
+            Assert.Equal(5, chart.MinY);
+            Assert.Equal(15, chart.MaxY);
+        }
+
+        [Fact]
+        public void UpdateMinMaxValues_SingleValidValue_MinEqualsMax()
+        {
+            // Arrange
+            var chart = new TestSparkChart();
+
+            // Act
+            chart.ItemsSource = new List<double> { 42 };
+
+            // Assert
+            Assert.Equal(42, chart.MinY);
+            Assert.Equal(42, chart.MaxY);
+            Assert.Equal(0, chart.MinX);
+            Assert.Equal(0, chart.MaxX);
+        }
+
+        [Fact]
+        public void UpdateMinMaxValues_EmptySource_ReturnsZeroes()
+        {
+            // Arrange
+            var chart = new TestSparkChart();
+
+            // Act
+            chart.ItemsSource = new List<double>();
+
+            // Assert
+            Assert.Equal(0, chart.MinY);
+            Assert.Equal(0, chart.MaxY);
+            Assert.Equal(0, chart.MinX);
+            Assert.Equal(0, chart.MaxX);
+        }
+
+        [Fact]
+        public void UpdateMinMaxValues_NegativeValues_CalculatesCorrectly()
+        {
+            // Arrange
+            var chart = new TestSparkChart();
+
+            // Act
+            chart.ItemsSource = new List<double> { -50, -10, -30, -20 };
+
+            // Assert
+            Assert.Equal(-50, chart.MinY);
+            Assert.Equal(-10, chart.MaxY);
+        }
+
+        [Fact]
+        public void NumericAxis_SortsDataByXValue()
+        {
+            // Arrange - verifies in-place sort produces correct ordering
+            var chart = new SfSparkLineChart();
+            var data = new List<NumericAxisData>
+            {
+                new() { X = 30, Y = 100 },
+                new() { X = 10, Y = 200 },
+                new() { X = 20, Y = 150 },
+            };
+
+            // Act
+            chart.XBindingPath = "X";
+            chart.YBindingPath = "Y";
+            chart.AxisType = SparkChartAxisType.Numeric;
+            chart.ItemsSource = data;
+
+            // Assert - data should be sorted by X
+            Assert.Equal(3, chart.DataCount);
+            Assert.Equal(10, chart.xValues[0]);
+            Assert.Equal(20, chart.xValues[1]);
+            Assert.Equal(30, chart.xValues[2]);
+            Assert.Equal(200, chart.yValues[0]);
+            Assert.Equal(150, chart.yValues[1]);
+            Assert.Equal(100, chart.yValues[2]);
+        }
+
+        private class NumericAxisData
+        {
+            public double X { get; set; }
+            public double Y { get; set; }
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
## Summary

This PR reduces unnecessary heap allocations in the SparkCharts component, improving performance during data processing and trackball rendering.

## Changes

### `SfSparkChart.UpdateMinMaxValues()`
- **Before**: Used `yValues.Where(y => !double.IsNaN(y)).ToList()` followed by `.Min()` and `.Max()` — 3 passes over data + intermediate list allocation.
- **After**: Single-pass loop computing min/max while skipping NaN values — zero allocations.

- **Before**: Used `xValues.Min()` and `xValues.Max()` — 2 separate enumerations.
- **After**: Single-pass loop — 1 enumeration.

### `SfSparkChart.GenerateDataPoints()`
- **Before**: `pairs.OrderBy(value => value.x)` allocates an OrderedEnumerable iterator.
- **After**: `pairs.Sort((a, b) => a.x.CompareTo(b.x))` sorts in-place with no extra allocation.

### `SparkChartTrackballBehavior`
- **Before**: `new List<TooltipPosition> { ... }` allocated on every draw/template call.
- **After**: Static cached `s_tooltipFallbackPositions` list reused across all calls.

## Testing

- All 65 existing SparkChart unit tests pass.
- Added 6 new unit tests covering edge cases: all-NaN values, mixed NaN values, single value, empty source, negative values, and numeric axis sorting.