### PR TITLE
Honor FontAutoScalingEnabled for TextInputLayout labels and align Windows text measuring with drawing

### DIFF
--- a/maui/src/Core/TextMeasurer/TextMeasurer.Windows.cs
+++ b/maui/src/Core/TextMeasurer/TextMeasurer.Windows.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Maui.Platform;
 using Microsoft.UI.Xaml.Controls;
-using Windows.UI.ViewManagement;
 
 namespace Syncfusion.Maui.Toolkit.Graphics.Internals
 {
@@ -31,6 +30,7 @@ namespace Syncfusion.Maui.Toolkit.Graphics.Internals
 
 			_textBlock.Text = text;
 			double fontSize = textSize > 0 ? textSize : 12;
+			_textBlock.IsTextScaleFactorEnabled = true;
 			_textBlock.FontSize = fontSize;
 			_textBlock.Measure(new Windows.Foundation.Size(double.PositiveInfinity, double.PositiveInfinity));
 			return new Size((float)_textBlock.DesiredSize.Width, (float)_textBlock.DesiredSize.Height);
@@ -104,17 +104,9 @@ namespace Syncfusion.Maui.Toolkit.Graphics.Internals
 
 		private void UpdateFontSize(ITextElement textElement)
 		{
-			var uiSettings = new UISettings();
-			float fontScale = (float)uiSettings.TextScaleFactor;
 			double fontSize = textElement.FontSize > 0 ? textElement.FontSize : 12;
-			if (textElement.FontAutoScalingEnabled)
-			{
-				_textBlock!.FontSize = fontSize * fontScale;
-			}
-			else
-			{
-				_textBlock!.FontSize = fontSize;
-			}
+			_textBlock!.IsTextScaleFactorEnabled = textElement.FontAutoScalingEnabled;
+			_textBlock!.FontSize = fontSize;
 		}
 	}
 }

--- a/maui/src/TextInputLayout/SfTextInputLayout.Methods.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.Methods.cs
@@ -479,6 +479,11 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 			{
 				internalLabelStyle.FontFamily = labelStyle.FontFamily;
 			}
+
+			if (propertyName == nameof(LabelStyle.FontAutoScalingEnabled))
+			{
+				internalLabelStyle.FontAutoScalingEnabled = labelStyle.FontAutoScalingEnabled;
+			}
 		}
 
 		/// <summary>

--- a/maui/src/TextInputLayout/SfTextInputLayout.Properties.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.Properties.cs
@@ -2283,6 +2283,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 					inputLayout._internalHintLabelStyle.TextColor = newLabelStyle.TextColor;
 					inputLayout._internalHintLabelStyle.FontFamily = newLabelStyle.FontFamily;
 					inputLayout._internalHintLabelStyle.FontAttributes = newLabelStyle.FontAttributes;
+					inputLayout._internalHintLabelStyle.FontAutoScalingEnabled = newLabelStyle.FontAutoScalingEnabled;
 					inputLayout.HintFontSize = (float)(newLabelStyle.FontSize < 12d ? inputLayout.FloatedHintFontSize : newLabelStyle.FontSize);
 					newLabelStyle.PropertyChanged += inputLayout.OnHintLabelStylePropertyChanged;
 					if (inputLayout._initialLoaded)
@@ -2310,6 +2311,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 					inputLayout._internalHelperLabelStyle.TextColor = newLabelStyle.TextColor;
 					inputLayout._internalHelperLabelStyle.FontFamily = newLabelStyle.FontFamily;
 					inputLayout._internalHelperLabelStyle.FontAttributes = newLabelStyle.FontAttributes;
+					inputLayout._internalHelperLabelStyle.FontAutoScalingEnabled = newLabelStyle.FontAutoScalingEnabled;
 					inputLayout._internalHelperLabelStyle.FontSize = newLabelStyle.FontSize;
 					newLabelStyle.PropertyChanged += inputLayout.OnHelperLabelStylePropertyChanged;
 					if (inputLayout._initialLoaded)
@@ -2337,6 +2339,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 					inputLayout._internalErrorLabelStyle.TextColor = newLabelStyle.TextColor;
 					inputLayout._internalErrorLabelStyle.FontFamily = newLabelStyle.FontFamily;
 					inputLayout._internalErrorLabelStyle.FontAttributes = newLabelStyle.FontAttributes;
+					inputLayout._internalErrorLabelStyle.FontAutoScalingEnabled = newLabelStyle.FontAutoScalingEnabled;
 					inputLayout._internalErrorLabelStyle.FontSize = newLabelStyle.FontSize;
 					newLabelStyle.PropertyChanged += inputLayout.OnErrorLabelStylePropertyChanged;
 					if (inputLayout._initialLoaded)
@@ -2360,6 +2363,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 					inputLayout._internalCounterLabelStyle.TextColor = newLabelStyle.TextColor;
 					inputLayout._internalCounterLabelStyle.FontFamily = newLabelStyle.FontFamily;
 					inputLayout._internalCounterLabelStyle.FontAttributes = newLabelStyle.FontAttributes;
+					inputLayout._internalCounterLabelStyle.FontAutoScalingEnabled = newLabelStyle.FontAutoScalingEnabled;
 					inputLayout._internalCounterLabelStyle.FontSize = newLabelStyle.FontSize;
 					newLabelStyle.PropertyChanged += inputLayout.OnCounterLabelStylePropertyChanged;
 					if (inputLayout._initialLoaded)

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Layout/SfTextInputLayoutUnitTests.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Layout/SfTextInputLayoutUnitTests.cs
@@ -555,6 +555,52 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 		}
 
 		[Fact]
+		public void TestHintLabelStyleFontAutoScalingEnabledAppliedOnAssign()
+		{
+			var inputLayout = new SfTextInputLayout()
+			{
+				Hint = "Enter text here",
+				HintLabelStyle = new LabelStyle { FontAutoScalingEnabled = true },
+			};
+
+			Assert.True(GetInternalLabelStyle(inputLayout, "_internalHintLabelStyle").FontAutoScalingEnabled);
+		}
+
+		[Fact]
+		public void TestHintLabelStyleFontAutoScalingEnabledAppliedOnChange()
+		{
+			var inputLayout = new SfTextInputLayout()
+			{
+				Hint = "Enter text here",
+				HintLabelStyle = new LabelStyle(),
+			};
+
+			inputLayout.HintLabelStyle.FontAutoScalingEnabled = true;
+
+			Assert.True(GetInternalLabelStyle(inputLayout, "_internalHintLabelStyle").FontAutoScalingEnabled);
+		}
+
+		[Fact]
+		public void TestErrorLabelStyleFontAutoScalingEnabledAppliedOnAssign()
+		{
+			var inputLayout = new SfTextInputLayout()
+			{
+				ErrorText = "Error text",
+				ErrorLabelStyle = new LabelStyle { FontAutoScalingEnabled = true },
+			};
+
+			Assert.True(GetInternalLabelStyle(inputLayout, "_internalErrorLabelStyle").FontAutoScalingEnabled);
+		}
+
+		static LabelStyle GetInternalLabelStyle(SfTextInputLayout inputLayout, string fieldName)
+		{
+			var field = typeof(SfTextInputLayout).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+			Assert.NotNull(field);
+
+			return (LabelStyle)field!.GetValue(inputLayout)!;
+		}
+
+		[Fact]
 		public void TestHelperLabelFontSize()
 		{
 			var inputLayout = new SfTextInputLayout()


### PR DESCRIPTION
### Root Cause of the Issue

`LabelStyle.FontAutoScalingEnabled` was never copied into the internal label styles that draw and measure the hint, helper, error and counter text. `MatchLabelStyleProperty` and the four `On*LableStylePropertyChanged` handlers copied `FontAttributes`, `TextColor`, `FontSize` and `FontFamily` only, so the public property, including the usage shown in its own documentation example, had no effect.

On Windows there was a second problem. `TextMeasurer` measured with a `TextBlock` whose `IsTextScaleFactorEnabled` was left at its default (`true`), so measuring always included the system text scale, while `CanvasExtensions.DrawText` applied the scale only when `FontAutoScalingEnabled` was `true`. Measuring and drawing therefore disagreed whenever the flag was `false` (the default), which is what made the cut-out in the outlined border roughly twice as wide as the hint text and the size was scaled twice when the flag was `true`, once by the manual `TextScaleFactor` multiplication and once by the `TextBlock`.

### Description of Change

- `SfTextInputLayout.Properties.cs`: the hint, helper, error and counter handlers now copy `FontAutoScalingEnabled` into the internal style, next to the properties they already copy.
- `SfTextInputLayout.Methods.cs`: `MatchLabelStyleProperty` handles `FontAutoScalingEnabled`, so changing it on a live `LabelStyle` is picked up too.
- `TextMeasurer.Windows.cs`: `UpdateFontSize` now drives `TextBlock.IsTextScaleFactorEnabled` from `FontAutoScalingEnabled` and lets WinUI apply the scale, instead of multiplying by `UISettings.TextScaleFactor` on top of the scaling the `TextBlock` already does. This mirrors what MAUI does in `TextBlockExtensions` for its own text controls, and makes measuring agree with drawing in both states of the flag. The `MeasureText` overload that takes a plain font size now sets `IsTextScaleFactorEnabled` explicitly, because the `TextBlock` instance is reused across calls and would otherwise inherit the previous call's setting.

With this, `FontAutoScalingEnabled="True"` on `HintLabelStyle` makes the hint follow the Windows text size, and the border cut-out matches the text in both states.

Three unit tests in `SfTextInputLayoutUnitTests` cover the propagation, both when a style is assigned and when the property changes on an already assigned style. They fail without the change and pass with it.

### Issues Fixed

Fixes #405 

### Screenshots

#### Before:
<img width="523" height="293" alt="Zrzut ekranu 2026-08-3 o 09 19 52" src="https://github.com/user-attachments/assets/ea89c9ed-1a21-4696-bbea-3cbbeb72f376" />

#### After:
<img width="504" height="314" alt="Zrzut ekranu 2026-08-3 o 09 18 58" src="https://github.com/user-attachments/assets/d3c1b1a0-9705-4889-988a-3117f9320be9" />
