### PR TITLE
Task(1036479) - Add swiping sensitivity support for NET MAUI SfTabView

### DIFF
--- a/maui/src/TabView/Control/HorizontalContent/SfHorizontalContent.Android.cs
+++ b/maui/src/TabView/Control/HorizontalContent/SfHorizontalContent.Android.cs
@@ -25,7 +25,7 @@ namespace Syncfusion.Maui.Toolkit.TabView
 		double _density = Android.App.Application.Context.Resources.DisplayMetrics.Density;
 #pragma warning restore CS8602
 
-		double _swipeThreshold => 5 * _density;
+		double _swipeThreshold => _tabView!.SwipingSensitivity * _density;
 
 
 		#endregion

--- a/maui/src/TabView/Control/HorizontalContent/SfHorizontalContent.cs
+++ b/maui/src/TabView/Control/HorizontalContent/SfHorizontalContent.cs
@@ -833,7 +833,12 @@ namespace Syncfusion.Maui.Toolkit.TabView
 					case PointerActions.Moved:
 						if (_isPressed)
 						{
-							HandleTouchMovement(point);
+							var moveDistanceX = Math.Abs(point.X - _startPoint.X);
+							var moveDistanceY = Math.Abs(point.Y - _startPoint.Y);
+							if (moveDistanceX >= this._tabView.SwipingSensitivity && moveDistanceX >= moveDistanceY)
+							{								
+								HandleTouchMovement(point);
+							}
 						}
 						break;
 

--- a/maui/src/TabView/Control/SfTabView.cs
+++ b/maui/src/TabView/Control/SfTabView.cs
@@ -510,6 +510,14 @@ namespace Syncfusion.Maui.Toolkit.TabView
 				true,
 				propertyChanged: OnEnableRippleAnimationChanged);
 
+		/// <summary>
+		/// Identifies the <see cref="SwipingSensitivity"/> bindable property.
+		/// </summary>
+		/// <value>
+		/// The identifier for <see cref="SwipingSensitivity"/> bindable property.
+		/// </value>
+		public static readonly BindableProperty SwipingSensitivityProperty = BindableProperty.Create(nameof(SwipingSensitivity), typeof(double), typeof(SfTabView), 5d, BindingMode.Default, null);
+
 		#endregion
 
 		#region Properties
@@ -1938,6 +1946,21 @@ namespace Syncfusion.Maui.Toolkit.TabView
 		{
 			get => (bool)GetValue(EnableRippleAnimationProperty);
 			set => SetValue(EnableRippleAnimationProperty, value);
+		}
+
+		/// <summary>
+		/// Gets or sets the swipe sensitivity for navigating between tabs in the Tab View content area.
+		/// </summary>
+		/// <remarks>
+		/// A higher value requires a larger swipe gesture to trigger tab navigation, while a lower value makes swipe navigation more responsive.
+		/// </remarks>
+		/// <value>
+		/// It accepts double values and the default value is 5.
+		/// </value>
+		public double SwipingSensitivity
+		{
+			get { return (double)this.GetValue(SwipingSensitivityProperty); }
+			set { this.SetValue(SwipingSensitivityProperty, value); }
 		}
 
 		#endregion

--- a/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Navigation/SfTabViewUnitTests.cs
+++ b/maui/tests/Syncfusion.Maui.Toolkit.UnitTest/Navigation/SfTabViewUnitTests.cs
@@ -9486,6 +9486,335 @@ namespace Syncfusion.Maui.Toolkit.UnitTest
 
 		#endregion
 
+		#region Helpers
+
+		private TabItemCollection BuildTabItems(int count)
+		{
+			var items = new TabItemCollection();
+			for (int i = 0; i < count; i++)
+			{
+				items.Add(new SfTabItem
+				{
+					Header = $"Tab {i}",
+					Content = new Label { Text = $"Content {i}" }
+				});
+			}
+			return items;
+		}
+
+		private SfTabView CreateTabView(int itemCount = 3, double? swipeSensitive = null)
+		{
+			var tabView = new SfTabView
+			{
+				EnableSwiping = true,
+				Items = BuildTabItems(itemCount)
+			};
+
+			if (swipeSensitive.HasValue)
+			{
+				tabView.SwipingSensitivity = swipeSensitive.Value;
+			}
+
+			return tabView;
+		}
+
+		private SfHorizontalContent GetHorizontalContent(SfTabView tabView)
+		{
+			var horizontalContent = GetPrivateField<SfTabView>(tabView, "_tabContentContainer") as SfHorizontalContent;
+			Assert.NotNull(horizontalContent);
+			return horizontalContent!;
+		}
+
+		#endregion
+
+		#region Default Value
+
+		[Fact]
+		public void SwipingSensitivity_DefaultValue_IsFive()
+		{
+			// The documented/intended default value for the SwipingSensitivity
+			// property on SfTabView is 5d.
+			var tabView = new SfTabView();
+
+			Assert.Equal(5d, tabView.SwipingSensitivity);
+		}
+
+		#endregion
+
+		#region Property Round-Trip
+
+		[Theory]
+		[InlineData(0d)]
+		[InlineData(1d)]
+		[InlineData(5d)]
+		[InlineData(10d)]
+		[InlineData(50d)]
+		[InlineData(100d)]
+		public void SwipingSensitivity_SetAndGet_ReturnsExpectedValue(double expected)
+		{
+			var tabView = new SfTabView
+			{
+				SwipingSensitivity = expected
+			};
+
+			Assert.Equal(expected, tabView.SwipingSensitivity);
+		}
+
+		[Fact]
+		public void SwipingSensitivity_SetAfterConstruction_IsObservable()
+		{
+			// Changing SwipingSensitivity on the parent SfTabView must remain
+			// observable after the underlying SfHorizontalContent has been
+			// constructed, because it is the consumer of this value during
+			// OnHandleTouchInteraction.
+			var tabView = CreateTabView(itemCount: 3);
+			var horizontalContent = GetHorizontalContent(tabView);
+
+			tabView.SwipingSensitivity = 25d;
+
+			Assert.Equal(25d, tabView.SwipingSensitivity);
+			Assert.NotNull(horizontalContent);
+		}
+
+		#endregion
+
+		#region Pressed - Initialization
+
+		[Fact]
+		public void Pressed_AfterPointerDown_SetsIsPressed()
+		{
+			var tabView = CreateTabView();
+			var horizontalContent = GetHorizontalContent(tabView);
+
+			horizontalContent.OnHandleTouchInteraction(PointerActions.Pressed, new Point(0, 0));
+
+			Assert.True((bool)GetPrivateField(horizontalContent, "_isPressed")!);
+			Assert.False((bool)GetPrivateField(horizontalContent, "_isMoved")!);
+		}
+
+		[Fact]
+		public void Pressed_StoresStartPointAsOldPoint()
+		{
+			var tabView = CreateTabView();
+			var horizontalContent = GetHorizontalContent(tabView);
+
+			horizontalContent.OnHandleTouchInteraction(PointerActions.Pressed, new Point(50, 80));
+
+			var startPoint = (Point)GetPrivateField(horizontalContent, "_startPoint")!;
+			var oldPoint = (Point)GetPrivateField(horizontalContent, "_oldPoint")!;
+
+			Assert.Equal(50d, startPoint.X);
+			Assert.Equal(80d, startPoint.Y);
+			Assert.Equal(startPoint, oldPoint);
+		}
+
+		#endregion
+
+		#region Released - Cleanup
+
+		[Fact]
+		public void Released_AfterPressed_ResetsIsPressedAndIsMoved()
+		{
+			var tabView = CreateTabView();
+			var horizontalContent = GetHorizontalContent(tabView);
+
+			horizontalContent.OnHandleTouchInteraction(PointerActions.Pressed, new Point(0, 0));
+			horizontalContent.OnHandleTouchInteraction(PointerActions.Released, new Point(0, 0));
+
+			Assert.False((bool)GetPrivateField(horizontalContent, "_isPressed")!);
+			Assert.False((bool)GetPrivateField(horizontalContent, "_isMoved")!);
+		}
+
+		#endregion
+
+		#region EnableSwiping Gate
+
+		[Fact]
+		public void OnHandleTouchInteraction_EnableSwipingFalse_DoesNothing()
+		{
+			// When EnableSwiping is false the dispatcher should not change
+			// any touch state, regardless of pointer events.
+			var tabView = new SfTabView
+			{
+				EnableSwiping = false,
+				Items = BuildTabItems(3)
+			};
+			var horizontalContent = GetHorizontalContent(tabView);
+
+			horizontalContent.OnHandleTouchInteraction(PointerActions.Pressed, new Point(0, 0));
+			horizontalContent.OnHandleTouchInteraction(PointerActions.Moved, new Point(200, 0));
+
+			Assert.False((bool)GetPrivateField(horizontalContent, "_isPressed")!);
+			Assert.False((bool)GetPrivateField(horizontalContent, "_isMoved")!);
+		}
+
+		#endregion
+
+		#region SwipingSensitivity Gate
+
+		[Fact]
+		public void Moved_DistanceBelowThreshold_DoesNotSetIsMoved()
+		{
+			// With default SwipingSensitivity = 5, a 2px move must not pass the
+			// gate and therefore must not mark the gesture as moved.
+			var tabView = CreateTabView(swipeSensitive: 5d);
+			var horizontalContent = GetHorizontalContent(tabView);
+
+			horizontalContent.OnHandleTouchInteraction(PointerActions.Pressed, new Point(100, 100));
+			horizontalContent.OnHandleTouchInteraction(PointerActions.Moved, new Point(102, 100));
+
+			Assert.True((bool)GetPrivateField(horizontalContent, "_isPressed")!);
+			Assert.False((bool)GetPrivateField(horizontalContent, "_isMoved")!);
+		}
+
+		[Fact]
+		public void Moved_DistanceAtThreshold_SetsIsMoved()
+		{
+			// Exactly at the threshold the gate must allow the move through.
+			var tabView = CreateTabView(swipeSensitive: 5d);
+			var horizontalContent = GetHorizontalContent(tabView);
+
+			horizontalContent.OnHandleTouchInteraction(PointerActions.Pressed, new Point(100, 100));
+			horizontalContent.OnHandleTouchInteraction(PointerActions.Moved, new Point(105, 100));
+
+			Assert.True((bool)GetPrivateField(horizontalContent, "_isMoved")!);
+		}
+
+		[Fact]
+		public void Moved_DistanceAboveThreshold_SetsIsMoved()
+		{
+			// A clearly above-threshold horizontal move must pass the gate.
+			var tabView = CreateTabView(swipeSensitive: 5d);
+			var horizontalContent = GetHorizontalContent(tabView);
+
+			horizontalContent.OnHandleTouchInteraction(PointerActions.Pressed, new Point(100, 100));
+			horizontalContent.OnHandleTouchInteraction(PointerActions.Moved, new Point(140, 100));
+
+			Assert.True((bool)GetPrivateField(horizontalContent, "_isMoved")!);
+		}
+
+		[Fact]
+		public void Moved_VerticalDominantMove_DoesNotSetIsMoved()
+		{
+			// The gate requires horizontal distance >= vertical distance.
+			// A vertical-only move must not be treated as a swipe.
+			var tabView = CreateTabView(swipeSensitive: 5d);
+			var horizontalContent = GetHorizontalContent(tabView);
+
+			horizontalContent.OnHandleTouchInteraction(PointerActions.Pressed, new Point(100, 100));
+			horizontalContent.OnHandleTouchInteraction(PointerActions.Moved, new Point(101, 200));
+
+			Assert.False((bool)GetPrivateField(horizontalContent, "_isMoved")!);
+		}
+
+		[Theory]
+		[InlineData(5d, 3, false)]   // below threshold
+		[InlineData(5d, 5, true)]    // at threshold
+		[InlineData(5d, 10, true)]   // above threshold
+		[InlineData(20d, 19, false)] // just below a higher threshold
+		[InlineData(20d, 20, true)]  // at a higher threshold
+		[InlineData(20d, 50, true)]  // well above a higher threshold
+		[InlineData(100d, 99, false)]
+		[InlineData(100d, 100, true)]
+		public void Moved_HorizontalDistance_VsSwipingSensitivity_GatesCorrectly(
+			double swipeSensitive, int horizontalDelta, bool shouldBeMoved)
+		{
+			var tabView = CreateTabView(swipeSensitive: swipeSensitive);
+			var horizontalContent = GetHorizontalContent(tabView);
+
+			horizontalContent.OnHandleTouchInteraction(PointerActions.Pressed, new Point(0, 0));
+			horizontalContent.OnHandleTouchInteraction(
+				PointerActions.Moved,
+				new Point(horizontalDelta, 0));
+
+			Assert.Equal(shouldBeMoved, (bool)GetPrivateField(horizontalContent, "_isMoved")!);
+		}
+
+		[Theory]
+		[InlineData(5d, -3, false)]  // below threshold, negative direction
+		[InlineData(5d, -5, true)]   // at threshold, negative direction
+		[InlineData(5d, -25, true)]  // above threshold, negative direction
+		public void Moved_NegativeHorizontalDistance_StillGatesByMagnitude(
+			double swipeSensitive, int horizontalDelta, bool shouldBeMoved)
+		{
+			var tabView = CreateTabView(swipeSensitive: swipeSensitive);
+			var horizontalContent = GetHorizontalContent(tabView);
+
+			horizontalContent.OnHandleTouchInteraction(PointerActions.Pressed, new Point(200, 200));
+			horizontalContent.OnHandleTouchInteraction(
+				PointerActions.Moved,
+				new Point(200 + horizontalDelta, 200));
+
+			Assert.Equal(shouldBeMoved, (bool)GetPrivateField(horizontalContent, "_isMoved")!);
+		}
+
+		[Fact]
+		public void Moved_BelowThreshold_DoesNotUpdateOldPoint()
+		{
+			// If the gate rejects the move, HandleTouchMovement must not run,
+			// therefore _oldPoint must remain equal to _startPoint.
+			var tabView = CreateTabView(swipeSensitive: 50d);
+			var horizontalContent = GetHorizontalContent(tabView);
+
+			horizontalContent.OnHandleTouchInteraction(PointerActions.Pressed, new Point(100, 100));
+			horizontalContent.OnHandleTouchInteraction(PointerActions.Moved, new Point(110, 100));
+
+			var startPoint = (Point)GetPrivateField(horizontalContent, "_startPoint")!;
+			var oldPoint = (Point)GetPrivateField(horizontalContent, "_oldPoint")!;
+
+			Assert.Equal(startPoint, oldPoint);
+		}
+
+		[Fact]
+		public void Moved_AboveThreshold_UpdatesOldPoint()
+		{
+			// Once the gate allows the move, _oldPoint must be advanced.
+			var tabView = CreateTabView(swipeSensitive: 5d);
+			var horizontalContent = GetHorizontalContent(tabView);
+
+			horizontalContent.OnHandleTouchInteraction(PointerActions.Pressed, new Point(100, 100));
+			horizontalContent.OnHandleTouchInteraction(PointerActions.Moved, new Point(140, 100));
+
+			var oldPoint = (Point)GetPrivateField(horizontalContent, "_oldPoint")!;
+			Assert.Equal(140d, oldPoint.X);
+			Assert.Equal(100d, oldPoint.Y);
+		}
+
+		#endregion
+
+		#region Multi-Step Swipe
+
+		[Fact]
+		public void MultiStepSwipe_OnlyStepsAboveThresholdAdvanceState()
+		{
+			// Simulate a real gesture: many small moves that are all below the
+			// threshold should not move state. The first move that crosses the
+			// threshold should commit and subsequent moves should follow.
+			var tabView = CreateTabView(swipeSensitive: 10d);
+			var horizontalContent = GetHorizontalContent(tabView);
+
+			horizontalContent.OnHandleTouchInteraction(PointerActions.Pressed, new Point(0, 0));
+
+			// Step 1: below threshold (3px)
+			horizontalContent.OnHandleTouchInteraction(PointerActions.Moved, new Point(3, 0));
+			Assert.False((bool)GetPrivateField(horizontalContent, "_isMoved")!);
+			var oldPointAfter1 = (Point)GetPrivateField(horizontalContent, "_oldPoint")!;
+			Assert.Equal(0d, oldPointAfter1.X);
+
+			// Step 2: crosses threshold from origin (12px)
+			horizontalContent.OnHandleTouchInteraction(PointerActions.Moved, new Point(12, 0));
+			Assert.True((bool)GetPrivateField(horizontalContent, "_isMoved")!);
+			var oldPointAfter2 = (Point)GetPrivateField(horizontalContent, "_oldPoint")!;
+			Assert.Equal(12d, oldPointAfter2.X);
+
+			// Step 3: continues from the new old point (15px total, 3px delta)
+			horizontalContent.OnHandleTouchInteraction(PointerActions.Moved, new Point(15, 0));
+			var oldPointAfter3 = (Point)GetPrivateField(horizontalContent, "_oldPoint")!;
+			Assert.Equal(15d, oldPointAfter3.X);
+		}
+
+		#endregion
+
 	}
 
 	public class Model : INotifyPropertyChanged


### PR DESCRIPTION
### Root Cause of the Issue ###
 
1. Enhance the Syncfusion .NET MAUI SfTabView control by introducing Swiping Sensitivity support, allowing developers to define how far a user must swipe before the gesture is recognized as a valid tab switch.
 
### Description of change ###
 
Added a new configurable property, SwipeSensitive, to SfTabView.
`public double SwipeSensitive { get; set; }`

- This property is used to define the minimum horizontal movement required before the Tab View starts handling the swipe gesture.
- Updated the touch movement logic to calculate the swipe distance from the initial touch point.

### API Summary ###
API Name: CollapseOnOverlayTap
Namespace: Syncfusion.Maui.Toolkit.TabView
Input type: double
Access specifier: public

### Issues Fixed

https://github.com/syncfusion/maui-toolkit/issues/393

