### PR TITLE
Resolved the Windows FontAutoScalingEnabled issue in TextInputLayout

### DIFF
--- a/maui/src/Core/TextMeasurer/TextMeasurer.Windows.cs
+++ b/maui/src/Core/TextMeasurer/TextMeasurer.Windows.cs
@@ -108,9 +108,7 @@ namespace Syncfusion.Maui.Toolkit.Graphics.Internals
 			float fontScale = (float)uiSettings.TextScaleFactor;
 			double fontSize = textElement.FontSize > 0 ? textElement.FontSize : 12;
 
-			// Disable the TextBlock's built-in text scale factor so we can apply it
-			// explicitly and only when FontAutoScalingEnabled is true, preventing
-			// double-scaling (once by us and once by the TextBlock itself).
+			// Disable TextBlock auto-scaling to avoid applying the scale factor twice.
 			_textBlock!.IsTextScaleFactorEnabled = false;
 
 			if (textElement.FontAutoScalingEnabled)

--- a/maui/src/Core/TextMeasurer/TextMeasurer.Windows.cs
+++ b/maui/src/Core/TextMeasurer/TextMeasurer.Windows.cs
@@ -107,9 +107,15 @@ namespace Syncfusion.Maui.Toolkit.Graphics.Internals
 			var uiSettings = new UISettings();
 			float fontScale = (float)uiSettings.TextScaleFactor;
 			double fontSize = textElement.FontSize > 0 ? textElement.FontSize : 12;
+
+			// Disable the TextBlock's built-in text scale factor so we can apply it
+			// explicitly and only when FontAutoScalingEnabled is true, preventing
+			// double-scaling (once by us and once by the TextBlock itself).
+			_textBlock!.IsTextScaleFactorEnabled = false;
+
 			if (textElement.FontAutoScalingEnabled)
 			{
-				_textBlock!.FontSize = fontSize * fontScale;
+				_textBlock.FontSize = fontSize * fontScale;
 			}
 			else
 			{

--- a/maui/src/TextInputLayout/SfTextInputLayout.Methods.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.Methods.cs
@@ -485,6 +485,11 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 			{
 				internalLabelStyle.FontFamily = labelStyle.FontFamily;
 			}
+
+			if (propertyName == nameof(LabelStyle.FontAutoScalingEnabled))
+			{
+				internalLabelStyle.FontAutoScalingEnabled = labelStyle.FontAutoScalingEnabled;
+			}
 		}
 
 		/// <summary>

--- a/maui/src/TextInputLayout/SfTextInputLayout.Properties.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.Properties.cs
@@ -2283,6 +2283,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 					inputLayout._internalHintLabelStyle.TextColor = newLabelStyle.TextColor;
 					inputLayout._internalHintLabelStyle.FontFamily = newLabelStyle.FontFamily;
 					inputLayout._internalHintLabelStyle.FontAttributes = newLabelStyle.FontAttributes;
+					inputLayout._internalHintLabelStyle.FontAutoScalingEnabled = newLabelStyle.FontAutoScalingEnabled;
 					inputLayout.HintFontSize = (float)(newLabelStyle.FontSize < 12d ? inputLayout.FloatedHintFontSize : newLabelStyle.FontSize);
 					newLabelStyle.PropertyChanged += inputLayout.OnHintLabelStylePropertyChanged;
 					if (inputLayout._initialLoaded)
@@ -2310,6 +2311,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 					inputLayout._internalHelperLabelStyle.TextColor = newLabelStyle.TextColor;
 					inputLayout._internalHelperLabelStyle.FontFamily = newLabelStyle.FontFamily;
 					inputLayout._internalHelperLabelStyle.FontAttributes = newLabelStyle.FontAttributes;
+					inputLayout._internalHelperLabelStyle.FontAutoScalingEnabled = newLabelStyle.FontAutoScalingEnabled;
 					inputLayout._internalHelperLabelStyle.FontSize = newLabelStyle.FontSize;
 					newLabelStyle.PropertyChanged += inputLayout.OnHelperLabelStylePropertyChanged;
 					if (inputLayout._initialLoaded)
@@ -2338,6 +2340,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 					inputLayout._internalErrorLabelStyle.FontFamily = newLabelStyle.FontFamily;
 					inputLayout._internalErrorLabelStyle.FontAttributes = newLabelStyle.FontAttributes;
 					inputLayout._internalErrorLabelStyle.FontSize = newLabelStyle.FontSize;
+					inputLayout._internalErrorLabelStyle.FontAutoScalingEnabled = newLabelStyle.FontAutoScalingEnabled;
 					newLabelStyle.PropertyChanged += inputLayout.OnErrorLabelStylePropertyChanged;
 					if (inputLayout._initialLoaded)
 					{
@@ -2360,6 +2363,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 					inputLayout._internalCounterLabelStyle.TextColor = newLabelStyle.TextColor;
 					inputLayout._internalCounterLabelStyle.FontFamily = newLabelStyle.FontFamily;
 					inputLayout._internalCounterLabelStyle.FontAttributes = newLabelStyle.FontAttributes;
+					inputLayout._internalCounterLabelStyle.FontAutoScalingEnabled = newLabelStyle.FontAutoScalingEnabled;
 					inputLayout._internalCounterLabelStyle.FontSize = newLabelStyle.FontSize;
 					newLabelStyle.PropertyChanged += inputLayout.OnCounterLabelStylePropertyChanged;
 					if (inputLayout._initialLoaded)


### PR DESCRIPTION
### Root Cause of the Issue

`LabelStyle.FontAutoScalingEnabled` was never copied into the internal label styles that draw and measure the hint, helper, error and counter text. `MatchLabelStyleProperty` and the four `On*LableStylePropertyChanged` handlers copied `FontAttributes`, `TextColor`, `FontSize` and `FontFamily` only, so the public property, including the usage shown in its own documentation example, had no effect.

On Windows there was a second problem. `TextMeasurer` measured with a `TextBlock` whose `IsTextScaleFactorEnabled` was left at its default (`true`), so measuring always included the system text scale, while `CanvasExtensions.DrawText` applied the scale only when `FontAutoScalingEnabled` was `true`. Measuring and drawing therefore disagreed whenever the flag was `false` (the default), which is what made the cut-out in the outlined border roughly twice as wide as the hint text and the size was scaled twice when the flag was `true`, once by the manual `TextScaleFactor` multiplication and once by the `TextBlock`.

### Description of Change

- `SfTextInputLayout.Properties.cs`: the hint, helper, error and counter handlers now copy `FontAutoScalingEnabled` into the internal style, next to the properties they already copy.
- `SfTextInputLayout.Methods.cs`: `MatchLabelStyleProperty` handles `FontAutoScalingEnabled`, so changing it on a live `LabelStyle` is picked up too.
- `TextMeasurer.Windows.cs`: In the UpdateFontSize(ITextElement textElement) method, we added logic to disable the TextBlock's built-in text auto-scaling before applying the custom font scaling calculations. This prevents the text scale factor from being applied twice and ensures that text measurement and rendering remain consistent when FontAutoScalingEnabled is enabled.

With this, `FontAutoScalingEnabled="True"` on `HintLabelStyle` makes the hint follow the Windows text size, and the border cut-out matches the text in both states.

### Issues Fixed

Fixes #405 

### Screenshots

#### Before:
<img width="523" height="293" alt="Zrzut ekranu 2026-08-3 o 09 19 52" src="https://github.com/user-attachments/assets/ea89c9ed-1a21-4696-bbea-3cbbeb72f376" />

#### After:
<img width="504" height="314" alt="Zrzut ekranu 2026-08-3 o 09 18 58" src="https://github.com/user-attachments/assets/d3c1b1a0-9705-4889-988a-3117f9320be9" />