### PR TITLE
Provide RTL Arabic culture support for NET MAUI SfTextInputLayout

### DIFF
--- a/maui/src/TextInputLayout/SfTextInputLayout.Methods.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.Methods.cs
@@ -2109,7 +2109,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 		}
 
 #if ANDROID
-        bool IsArabic(string text)
+        static bool IsArabic(string text)
         {
             if (string.IsNullOrEmpty(text))
                 return false;

--- a/maui/src/TextInputLayout/SfTextInputLayout.Methods.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.Methods.cs
@@ -2077,7 +2077,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 
 				_internalHintLabelStyle.FontSize = _isAnimating ? (float)_animatingFontSize : IsHintFloated ? FloatedHintFontSize : HintLabelStyle.FontSize;
 
-				HorizontalAlignment horizontalAlignment = IsRTL ? HorizontalAlignment.Right : HorizontalAlignment.Left;
+				HorizontalAlignment horizontalAlignment = GetAlignment(Hint);
 #if IOS || MACCATALYST
 				VerticalAlignment verticalAlignment = VerticalAlignment.Top;
 #else
@@ -2102,10 +2102,51 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 				UpdateCounterTextPosition();
 				UpdateCounterTextColor();
 
-				canvas.DrawText(_counterText, _counterTextRect, IsRTL ? HorizontalAlignment.Right : HorizontalAlignment.Left, VerticalAlignment.Top, _internalCounterLabelStyle);
+				canvas.DrawText(_counterText, _counterTextRect, GetAlignment(_counterText) , VerticalAlignment.Top, _internalCounterLabelStyle);
 
 				canvas.CanvasRestoreState();
 			}
+		}
+
+#if ANDROID
+        private static bool IsArabic(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+                return false;
+
+            foreach (char c in text)
+            {
+                if((c >= '\u0590' && c <= '\u05FF') || // Hebrew
+                   (c >= '\u0600' && c <= '\u06FF') || // Arabic
+                   (c >= '\u0750' && c <= '\u077F') || // Arabic Supplement
+                   (c >= '\u08A0' && c <= '\u08FF') || // Arabic Extended-A
+                   (c >= '\uFB1D' && c <= '\uFB4F') || // Hebrew Presentation Forms
+                   (c >= '\uFB50' && c <= '\uFDFF') || // Arabic Presentation Forms-A
+                   (c >= '\uFE70' && c <= '\uFEFF')) // Arabic Presentation Forms-B
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+#endif
+
+		private HorizontalAlignment GetAlignment(string text)
+		{
+			HorizontalAlignment horizontalAlignment;
+#if ANDROID
+            if (IsArabic(text))
+            {
+                horizontalAlignment = IsRTL ? HorizontalAlignment.Left : HorizontalAlignment.Right;
+            }
+            else
+            {
+                horizontalAlignment = IsRTL ? HorizontalAlignment.Right : HorizontalAlignment.Left;
+            }
+#else
+			horizontalAlignment = IsRTL ? HorizontalAlignment.Right : HorizontalAlignment.Left;
+#endif
+			return horizontalAlignment;
 		}
 
 		/// <summary>

--- a/maui/src/TextInputLayout/SfTextInputLayout.Methods.cs
+++ b/maui/src/TextInputLayout/SfTextInputLayout.Methods.cs
@@ -2109,7 +2109,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
 		}
 
 #if ANDROID
-        private static bool IsArabic(string text)
+        bool IsArabic(string text)
         {
             if (string.IsNullOrEmpty(text))
                 return false;
@@ -2131,7 +2131,7 @@ namespace Syncfusion.Maui.Toolkit.TextInputLayout
         }
 #endif
 
-		private HorizontalAlignment GetAlignment(string text)
+		HorizontalAlignment GetAlignment(string text)
 		{
 			HorizontalAlignment horizontalAlignment;
 #if ANDROID


### PR DESCRIPTION
### Feature description ###

Ensure SfTextInputLayout correctly supports right-to-left (RTL) layouts (Arabic and other RTL cultures). Mirror layout ordering, alignment, and text flow for labels, hint, entry, leading/trailing views and error text; support runtime FlowDirection and culture changes. Without RTL handling, the control misaligns and reads unnatural for Arabic users, harming usability and accessibility.

**Purpose/benefits of the feature**

**Use cases**

- As an Arabic-speaking user, I want the input, label and hint to read right-to-left so forms are natural and usable.
- As a developer, I want SfTextInputLayout to automatically mirror layout for RTL cultures but still respect any explicit FlowDirection set in XAML/code.
- As an accessibility engineer, I want the control to expose correct AutomationProperties and not duplicate announcements in RTL.

### Description of Change

Implemented Arabic RTL support enhancements across SfTextInputLayout by:

- Find out the SfTextInputLayout's Hint, Helper Text, Error Text are Arabic text or other type text.
- Updating  SfTextInputLayout's Hint, Helper Text, Error Text's horizontal text alignment based on the arabic text and RTL texts
- Ensuring leading and trailing views are positioned correctly in RTL layouts.
- Supporting runtime `FlowDirection` changes.
- Supporting runtime culture changes that affect layout direction.
- Preserving existing behavior when explicit flow direction settings are provided by developers.

### Issues Fixed

Fixes  - https://github.com/syncfusion/maui-toolkit/issues/394