### PR TITLE
SfCarousel handler and platform view remain in memory after closing the page (iOSMac)

### DIFF
--- a/maui/src/Carousel/Platform/PlatformCarousel.cs
+++ b/maui/src/Carousel/Platform/PlatformCarousel.cs
@@ -22,6 +22,31 @@
 		/// </summary>
 		internal void Disconnect()
 		{
+#if MACCATALYST || IOS
+            if (_handler != null)
+            {
+                if (GestureRecognizer != null)
+                {
+                    RemoveGestureRecognizer(GestureRecognizer);
+                }
+
+                foreach (var view in Subviews)
+                {
+                    if (view is PlatformCarouselItem item)
+                    {
+                        item.InternalCarousel = null;
+                    }
+                }
+
+                _handler = null;
+            }
+#elif ANDROID
+            if (carouselHandler != null)
+            {
+                carouselHandler = null;
+            }
+#endif
+
 			_virtualView = null;
 		}
 


### PR DESCRIPTION
### Root Cause of the Issue

The SfCarousel control’s handler and its associated platform view are not getting released from memory after the page containing the control is closed. This leads to memory retention and potential memory leaks when navigating repeatedly between pages.

The issue is reproducible in a sample application where instance counting is used to track whether objects are properly disposed.

Handler not set null when disconnect. The native PlatformCarousel retained strong references through internal native object relationships, preventing timely garbage collection after page disposal.


### Description of Change

Need to set null for handler in Disconnect when the app closing. Updated the PlatformCarousel cleanup logic during disconnection to explicitly release native references and break the retention chains.

The fix includes:

Removing the registered gesture recognizer from the carousel during disconnect.
Clearing InternalCarousel references from all PlatformCarouselItem instances.
Releasing handler references after native cleanup is completed.
Ensuring native carousel items no longer hold references to the parent carousel once the page is closed.

This cleanup allows the PlatformCarousel instance to become eligible for garbage collection after navigation, preventing memory accumulation during repeated page open/close operations on iOS and Mac Catalyst.